### PR TITLE
small fixes to `hello.c3` and function generation

### DIFF
--- a/bindgen.c3l/implementation/writers/func.c3
+++ b/bindgen.c3l/implementation/writers/func.c3
@@ -16,7 +16,7 @@ fn usz! writeFunc(
 {
   usz acc;
 
-  acc += io::fprintfn(out, "fn %s %s(", return_type, translated_name)!;
+  acc += io::fprintfn(out, "extern fn %s %s(", return_type, translated_name)!;
   foreach (i, p : params) 
   {
     acc += io::fprintf(out, "  %s %s", p.type, p.name)!;

--- a/examples/hello.c3
+++ b/examples/hello.c3
@@ -38,8 +38,10 @@ fn String translateType(String str)
     case "long long": return "CLongLong";
     case "short": return "CShort";
     case "char": return "CChar";
+    case "unsigned char": return "CUChar";
     case "double": return "double";
     case "float": return "float";
+    case "void": return "void";
   }
 
   return capitalizeFirst(str);


### PR DESCRIPTION
add more type cases to the example and add `extern` when generating function definitions (this is required for external functions).

the only thing missing now to fully translate `dummy.h` is some sort of literal translation to translate things like `0ULL`, which is invalid, to `0UL`

this is a really cool project, thank you for putting the time and effort into making it :).