### PR TITLE
update to c3 version 0.7.2 with breaking changes

### DIFF
--- a/bindgen.c3l/implementation/api/str.c3
+++ b/bindgen.c3l/implementation/api/str.c3
@@ -84,7 +84,7 @@ fn String strSnakeToCamel(String str, Allocator alloc) @inline => @pool()
   usz last = 0;
   foreach (i, t : tokens)
   {
-    res[last:t.len] = t;
+    res[last:t.len] = t[..];
 
     if (i != (has_underscore ? 1 : 0))
     {
@@ -116,7 +116,7 @@ fn String strSnakeToPascal(String str, Allocator alloc) @inline => @pool()
   usz last = 0;
   foreach (i, t : tokens)
   {
-    res[last:t.len] = t;
+    res[last:t.len] = t[..];
     res[last] = res[last].to_upper();
     last += t.len;
   }
@@ -155,7 +155,7 @@ fn String strScreamingToCamel(String str, Allocator alloc) @inline => @pool()
   usz last = 0;
   foreach (i, t : tokens)
   {
-    res[last:t.len] = t;
+    res[last:t.len] = t[..];
     
     usz offset = 1;
     if (i == (has_underscore ? 1 : 0)) offset = 0;
@@ -186,7 +186,7 @@ fn String strScreamingToPascal(String str, Allocator alloc) @inline => @pool()
   usz last = 0;
   foreach (i, t : tokens)
   {
-    res[last:t.len] = t;
+    res[last:t.len] = t[..];
     
     for (usz j = last + 1; j < last + t.len; ++j)
     {
@@ -234,7 +234,7 @@ fn String strCamelToSnake(String str, Allocator alloc) @inline => @pool()
   foreach (i, t : tokens)
   {
     bool is_underscore = t[0] == '_';
-    res[last:t.len] = t;
+    res[last:t.len] = t[..];
 
     foreach (&c : res[last:t.len])
     {

--- a/bindgen.c3l/implementation/data.c3
+++ b/bindgen.c3l/implementation/data.c3
@@ -70,7 +70,7 @@ macro void CFields.init(&self, Allocator alloc)
 *>
 macro CFields.@foreach(&self; @body(FieldKind* kind, usz index))
 {
-  usz[FieldKind.elements] counters;
+  usz[FieldKind.values.len] counters;
 
   foreach (i, &k : self.kinds)
   {
@@ -130,7 +130,7 @@ macro void C3Fields.init(&self, Allocator alloc)
 *>
 macro C3Fields.@foreach(&self; @body(FieldKind* kind, usz index))
 {
-  usz[FieldKind.elements] counters;
+  usz[FieldKind.values.len] counters;
 
   foreach (i, &k : self.kinds)
   {

--- a/bindgen.c3l/implementation/trans.c3
+++ b/bindgen.c3l/implementation/trans.c3
@@ -29,8 +29,8 @@ fn String? apply(String s, BGTransFn fun, Allocator alloc = allocator::heap()) @
  table. String itself is always allocated on the
  heap and should NOT be freed as it would cause
  dangerous dead nodes in table.
- @param s "String to translate"
- @param key "String to be used as a key in the 'table'. By default, equals to 's'"
+ @param s : "String to translate"
+ @param key : "String to be used as a key in the 'table'. By default, equals to 's'"
 *>
 fn String? capply(String s, BGTransFn fun, TransTable* table, String key = "")
 {

--- a/bindgen.c3l/implementation/user.c3
+++ b/bindgen.c3l/implementation/user.c3
@@ -5,7 +5,7 @@ import std::os::process, std::io;
 import std::collections::list;
 
 <*
- @param extra_opts "Additional options for clang compiler"
+ @param extra_opts : "Additional options for clang compiler"
  @return "List{ZString}, which and each element of which should be then freed via allocator"
 *>
 fn List{ZString}? getParseCommandArgs(Allocator allocator, String[] extra_opts) => @pool() 


### PR DESCRIPTION
Might be able to avoid some of these breaking changes with compiler flags such as `--use-old-slice-copy`. 

From the [c3 dev blog](https://c3.handmade.network/blog/p/9021-c3_0.7.1_-_operator_overloading%252C_here_we_come%2521#30473): 

> Deprecated old inference with slice copy. Copying must now ensure a slicing operator at the end of the right hand side: foo[1..2] = bar[..] rather than the old foo[1..2] = bar. The old behaviour can be mostly retained with --use-old-slice-copy).