### PR TITLE
Expand vulkan example

### DIFF
--- a/bindgen.c3l/bindgen.c3i
+++ b/bindgen.c3l/bindgen.c3i
@@ -39,6 +39,7 @@ extern fn void? translate_header(
  out_name     : "Output file name into which a translation will be written. Default: result is written to stdout"
  out_file     : "Output file descriptor. If it's set, overrides out_name. Default: out_name is used as output file"
  module_name  : "Resulting module name, prepended at the top .c3i file. Default: no module name is written on top of .c3i"
+ imports      : "imports to append"
  include_file : "By default, bindgen ignore `#include` directives as C stdlib headers are usually not needed to be translated." 
                 "This option is a function which returns true if we want to '#include' file passed to 'name' parameter." 
                 "Note that 'name' is either relative or absolute path to a file"
@@ -50,6 +51,7 @@ struct BGOptions
   String    out_name;
   File      out_file;
   String    module_name;
+  String[]  imports;
   BGCheckFn include_file;
 
   bitstruct : char

--- a/bindgen.c3l/src/bg.c3
+++ b/bindgen.c3l/src/bg.c3
@@ -115,6 +115,10 @@ fn void? translateHeader(
   // Write module name
   if (opts.module_name != "") wter::moduleHead(&out, &visit_data.write_state, opts.module_name);
 
+  foreach (imp : opts.imports) {
+	wter::importModule(&out, &visit_data.write_state, imp);
+  }
+
   CXCursor cursor = clang::getTranslationUnitCursor(tu);
   clang::visitChildren(cursor, &vtor::global, (CXClientData) &visit_data);
 

--- a/bindgen.c3l/src/data.c3
+++ b/bindgen.c3l/src/data.c3
@@ -77,8 +77,8 @@ enum WriteKind
 *>
 enum WriteAttrKind : char (String str, bool has_arg)
 {
-  PRIVATE = { "@private", false },
-  IF      = { "@if",      true },
+  PRIVATE { "@private", false },
+  IF      { "@if",      true },
 }
 
 

--- a/examples/vulkan.c3
+++ b/examples/vulkan.c3
@@ -2,38 +2,127 @@
 import bindgen;
 import std::ascii, std::io;
 
+String[] defines = {
+	"-DVK_ENABLE_BETA_EXTENSIONS",
+	"-DVK_USE_PLATFORM_WIN32_KHR",
+	"-DVK_USE_PLATFORM_WAYLAND_KHR",
+	"-DVK_USE_PLATFORM_XCB_KHR",
+	"-DVK_USE_PLATFORM_XLIB_KHR",
+	"-DVK_USE_PLATFORM_METAL_EXT",
+	"-DVK_USE_PLATFORM_MACOS_MVK", 
+};
+
 fn void main(String[] args)
-{
-  String out = args.len > 1 ? args[1] : "";
-  
-  BGOptions opts = {
-    .clang_args = { "-DVK_ENABLE_BETA_EXTENSIONS" },
-    .module_name = "vulkan::vk",
-    .out_name = out,
-    .include_file = &includeFile,
-    .skip_errors = true,
-    .no_verbose = false,
-  }; 
+{  
+	String out = args.len > 1 ? args[1] : "";
 
-  BGTransCallbacks trans_cbs = {
-    // Strip 'vk' from functions
-    .func = fn String(String str, Allocator alloc) =>
-      str.strip("vk").camel_to_snake(alloc),
-    // There is a small conflict with variable called 'module'
-    .variable = fn String(String str, Allocator alloc) =>
-      str == "module" ? "mod" : str.camel_to_snake(alloc),
-    // Strip 'VK_' from constans
-    .constant = fn String(String str, Allocator alloc) =>
-      str.strip("VK_").snake_to_screaming(alloc),
+  	BGOptions opts_core = {
+		.clang_args = defines,
+		.module_name = "vulkan::vk",
+		.imports = { "std::os::win32" },
+		.out_name = out,
+		.include_file = &includeFile,
+		.skip_errors = true,
+		.no_verbose = false,
+  	}; 
 
-    .func_macro = &transFuncMacro,
-  };
+  	BGTransCallbacks trans_cbs = {
+		// Strip 'vk' from functions
+		.func = fn String(String str, Allocator alloc) =>
+			str.strip("vk").camel_to_snake(alloc),
+		.type = &valType,
+		// There is a small conflict with variable called 'module'
+		.variable = fn String(String str, Allocator alloc) =>
+			str == "module" ? "mod" : str.camel_to_snake(alloc),
+		// Strip 'VK_' from constans
+		.constant = &trans_const,
+		.func_macro = &transFuncMacro,
+  	};
 
-  BGGenCallbacks gen_cbs = {
-    .func_macro = &valFuncMacro,
-  };
+	BGGenCallbacks gen_cbs = {
+		.func_macro = &valFuncMacro,
+		.constant = &val_const,
+	};
 
-  bg::translate_header("./examples/headers/vulkan-part.h", opts, trans_cbs, gen_cbs)!!;
+  	bg::translate_header("./examples/headers/vulkan/vulkan.h", opts_core, trans_cbs, gen_cbs)!!;
+}
+
+fn String trans_const(String name, Allocator alloc) {
+	if (name == "VKAPI_CALL") return "";
+	if (name == "VKAPI_PTR") return "";
+	return name.strip("VK_").snake_to_screaming(alloc);
+}
+
+fn String val_const(String name, Allocator alloc) {
+	if (name.contains("NULL_HANDLE"))
+	{
+		return "null".copy(alloc);
+	}
+	
+	return "";
+}
+
+fn String valType(String name, Allocator alloc) {
+
+	if (name.ends_with("_T"))
+	{
+		return "void".copy(alloc);
+	}
+
+	switch (name) {
+		case "__IOSurface":
+			return "void".copy(alloc);
+
+		case "VkBuffer_T":
+		case "VkImage_T":
+		case "VkInstance_T":
+		case "VkPhysicalDevice_T":
+		case "VkDevice_T":
+		case "VkQueue_T":
+		case "VkSemaphore_T":
+		case "VkFence_T":
+		case "VkDeviceMemory_T":
+		case "VkQueryPool_T":
+		case "VkBufferView_T":
+		case "VkImageView_T":
+		case "VkShaderModule_T":
+		case "VkPipelineCache_T":
+		case "VkPipelineLayout_T":
+		case "VkPipeline_T":
+		case "VkRenderPass_T":
+		case "VkDescriptorSetLayout_T":
+		case "VkSampler_T":
+		case "VkDescriptorSet_T":
+		case "VkDescriptorPool_T":
+		case "VkFramebuffer_T":
+		case "VkCommandPool_T":
+		case "VkCommandBuffer_T":
+		case "VkEvent_T":
+			return "void".copy(alloc);
+
+		case "wl_display":
+			return "void".copy(alloc);
+		case "wl_surface":
+			return "void".copy(alloc);
+
+		case "HMONITOR":
+			return "Win32_HMONITOR".copy(alloc);
+		case "HINSTANCE":
+			return "Win32_HINSTANCE".copy(alloc);
+		case "HWND":
+			return "Win32_HWND".copy(alloc);
+		case "HANDLE":
+			return "Win32_HANDLE".copy(alloc);
+		case "LPCWSTR":
+			return "Win32_LPCWSTR".copy(alloc);
+		case "LPCWSTR":
+			return "Win32_LPCWSTR".copy(alloc);
+		case "SECURITY_ATTRIBUTES":
+			return "Win32_SECURITY_ATTRIBUTES".copy(alloc);
+		case "DWORD":
+			return "Win32_DWORD".copy(alloc);
+		default: return name.copy(alloc);
+	}
 }
 
 fn String valFuncMacro(String name, Allocator alloc) {
@@ -52,6 +141,9 @@ fn String valFuncMacro(String name, Allocator alloc) {
 
     case "VK_API_VERSION_PATCH":
       return "return (uint)(#version) & 0xFFFU;".copy(alloc);
+
+	case "VK_MAKE_VIDEO_STD_VERSION":
+		return "return (((uint)(#major)) << 22) | (((uint)(#minor)) << 12) | ((uint)(#patch));";
   }
 
   return name.copy(alloc);
@@ -74,7 +166,7 @@ fn String transFuncMacro(String name, Allocator alloc) {
 
 // #include a file only in case it's full path contains 'vulkan/'
 fn bool includeFile(String name) {
-  return name.contains("vulkan/");
+  return name.contains("vulkan");
 }
 
 


### PR DESCRIPTION
Hello, i updated the vulkan example to include all of the surface implementations (win32, wayland and so on).

I also added a array of strings to the `BGOptions` so it can import `std::os::win32`.

when parsing it gives a bunch of errors but those doesnt matter its just vulkan.h trying to include the os specific thingys.
It compiles for me, so should be fine ig xD

No need to accept the PR i just wanted to generate Vulkan for myself so i thought i'd share it incase it would fit as an example :)