### PR TITLE
update to c3 0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 
+.vscode/
+
 build/
 .direnv/
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Join and contact me in [C3 discord channel](https://discord.com/channels/6503459
 
 ## TODO
 
-- Comment support
+- Comments: convert attributes
 - Fix multiple definitions for macros
 - Inline definition of records and enums inside of function parameters
 - Allow user to write any attributes on an entity based on WriteAttrs

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ For better user experience there is additional API for string transformations, w
 
 There are several examples located in `examples` directory. To check them out, run the following command in root directory of the repository:
 
+- LibClang bindings: `c3c run clang -- ./build/clang.c3i`
 - Sandbox to try out library: `c3c run sandbox` - it will write to stdout
 - My dummy: `c3c run dummy -- ./build/dummy.c3i` or `c3c run dummy` - it will print output to stdout
 - Vulkan: `c3c run vulkan -- ./build/vulkan.c3i`
@@ -98,6 +99,7 @@ Join and contact me in [C3 discord channel](https://discord.com/channels/6503459
 
 ## TODO
 
+- Comment support
 - Fix multiple definitions for macros
 - Inline definition of records and enums inside of function parameters
 - Allow user to write any attributes on an entity based on WriteAttrs

--- a/bindgen.c3l/bindgen.c3i
+++ b/bindgen.c3l/bindgen.c3i
@@ -33,223 +33,225 @@ extern fn void? translate_header(
 
 
 <*
- Optional settings for translation.
+	Optional settings for translation.
 
- clang_args   : "Command-line args passed to clang when parsing each header. Default: no args are passed"
- out_name     : "Output file name into which a translation will be written. Default: result is written to stdout"
- out_file     : "Output file descriptor. If it's set, overrides out_name. Default: out_name is used as output file"
- module_name  : "Resulting module name, prepended at the top .c3i file. Default: no module name is written on top of .c3i"
- imports      : "imports to append"
- include_file : "By default, bindgen ignore `#include` directives as C stdlib headers are usually not needed to be translated." 
-                "This option is a function which returns true if we want to '#include' file passed to 'name' parameter." 
-                "Note that 'name' is either relative or absolute path to a file"
- skip_errors  : "Whether to skip clang's parse errors. Note, that '<...> file not found' errors are skipped always and not controlled with this flag"
+	clang_args   : "Command-line args passed to clang when parsing each header. Default: no args are passed"
+	out_name     : "Output file name into which a translation will be written. Default: result is written to stdout"
+	out_file     : "Output file descriptor. If it's set, overrides out_name. Default: out_name is used as output file"
+	module_name  : "Resulting module name, prepended at the top .c3i file. Default: no module name is written on top of .c3i"
+	imports      : "imports to append"
+	include_file : "By default, bindgen ignore `#include` directives as C stdlib headers are usually not needed to be translated." 
+					"This option is a function which returns true if we want to '#include' file passed to 'name' parameter." 
+					"Note that 'name' is either relative or absolute path to a file"
+	skip_errors  : "Whether to skip clang's parse errors. Note, that '<...> file not found' errors are skipped always and not controlled with this flag"
+	generate_docs  : "Whether to retrive docs and translate to C3 docs"
 *>
 struct BGOptions
 {
-  String[]  clang_args;
-  String    out_name;
-  File      out_file;
-  String    module_name;
-  String[]  imports;
-  BGCheckFn include_file;
+	String[]  clang_args;
+	String    out_name;
+	File      out_file;
+	String    module_name;
+	String[]  imports;
+	BGCheckFn include_file;
 
-  bitstruct : char
-  {
-    bool skip_errors;
-    bool no_verbose;
-  }
+	bitstruct : char
+	{
+		bool skip_errors;
+		bool no_verbose;
+		bool generate_docs;
+	}
 }
 
 
 <*
- Translation callbacks is the set of functions, each of 
- which will be called when translating the corresponding 
- C entity. For instance, 'func' is invoked when we translate functions.
+	Translation callbacks is the set of functions, each of 
+	which will be called when translating the corresponding 
+	C entity. For instance, 'func' is invoked when we translate functions.
 
- func       : "Function"
- type       : "Type"
- variable   : "Function parameter or global variable"
- constant   : "Global constant"
- func_maro  : "Functional macro. Note: you should not prepend '@' before macro name as it will be performed automatically"
+	func       : "Function"
+	type       : "Type"
+	variable   : "Function parameter or global variable"
+	constant   : "Global constant"
+	func_maro  : "Functional macro. Note: you should not prepend '@' before macro name as it will be performed automatically"
 *>
 struct BGTransCallbacks
 {
-  BGTransFn func;
-  BGTransFn type;
-  BGTransFn variable;
-  BGTransFn enum_field;
-  BGTransFn constant;
-  BGTransFn func_macro;
+	BGTransFn func;
+	BGTransFn type;
+	BGTransFn variable;
+	BGTransFn enum_field;
+	BGTransFn constant;
+	BGTransFn func_macro;
 }
 
 
 <*
- Generation callbacks is a set of functions which will be invoked, for instance, 
- for generating problematic bodies or values for function-like 
- macros and global constants respectively. 
+	Generation callbacks is a set of functions which will be invoked, for instance, 
+	for generating problematic bodies or values for function-like 
+	macros and global constants respectively. 
 
- For instance, you have something like this:
+	For instance, you have something like this:
 
- ```c
- #define COLOR (uint32_t) 0xFFFFFF
- ```
+	```c
+	#define COLOR (uint32_t) 0xFFFFFF
+	```
 
- In this case, there is no way for c3c to translate this constant because of '(uint32_t)' before literal.
- One thing you can do is set BGGenCallbacks.constant to the:
+	In this case, there is no way for c3c to translate this constant because of '(uint32_t)' before literal.
+	One thing you can do is set BGGenCallbacks.constant to the:
 
- ```c3
- BGGenCallbacks gens = {
-   .constant = fn String(String name, Allocator alloc) => 
-     name == "COLOR" ? "(uint) 0xFFFFFF" : "";
- };
- ```
+	```c3
+	BGGenCallbacks gens = {
+	.constant = fn String(String name, Allocator alloc) => 
+		name == "COLOR" ? "(uint) 0xFFFFFF" : "";
+	};
+	```
 
- So now the output will be:
+	So now the output will be:
 
- ```c3
- const COLOR = (uint) 0xFFFFFF;
- ```
- 
- Another example might be when you want to conditionally include several
- declarations:
+	```c3
+	const COLOR = (uint) 0xFFFFFF;
+	```
+	
+	Another example might be when you want to conditionally include several
+	declarations:
 
- ```c
- struct SomeStruct {
-   int a;
-   #ifdef PLATFORM_1
-   int b;
-   #endif
- };
+	```c
+	struct SomeStruct {
+	int a;
+	#ifdef PLATFORM_1
+	int b;
+	#endif
+	};
 
- #ifdef PLATFORM_2
- some_type f2();
- #endif
- ```
+	#ifdef PLATFORM_2
+	some_type f2();
+	#endif
+	```
 
- In this case, 'if_condition' or 'module_wrap' might help you. 
- The first one applies `@if` attribute to a declaration, while
- the second one wraps top-level declaration into separate module
- section.
+	In this case, 'if_condition' or 'module_wrap' might help you. 
+	The first one applies `@if` attribute to a declaration, while
+	the second one wraps top-level declaration into separate module
+	section.
 
- ```c3
- BGGenCallbacks gens = {
-   .if_condition = fn String(String name, Allocator alloc) => 
-     name == "b" ? "PLATFORM_1" : "";
-   .module_wrap = fn BGModuleWrap(String name, Allocator alloc) =>
-     name == "f2" ? {
-       .if_condition = "PLATFORM_2" 
-     } : {};
- };
- ```
+	```c3
+	BGGenCallbacks gens = {
+	.if_condition = fn String(String name, Allocator alloc) => 
+		name == "b" ? "PLATFORM_1" : "";
+	.module_wrap = fn BGModuleWrap(String name, Allocator alloc) =>
+		name == "f2" ? {
+		.if_condition = "PLATFORM_2" 
+		} : {};
+	};
+	```
 
- One problem may occur here - it's missing 'some_type', which might be
- defined somewhere in the specific header file for PLATFORM_2.
- Solution for that is the section import, which you can apply to the whole
- module section. Let's modify gens:
+	One problem may occur here - it's missing 'some_type', which might be
+	defined somewhere in the specific header file for PLATFORM_2.
+	Solution for that is the section import, which you can apply to the whole
+	module section. Let's modify gens:
 
- ```c3
- BGGenCallbacks gens = {
-   .if_condition = fn String(String name, Allocator alloc) => 
-     name == "b" ? "PLATFORM_1" : "";
-   .module_wrap = fn BGModuleWrap(String name, Allocator alloc) =>
-     name == "f2" ? {
-       .if_condition = "PLATFORM_2",
-       .imports = "platform_interface",
-     } : {};
- };
- ```
+	```c3
+	BGGenCallbacks gens = {
+	.if_condition = fn String(String name, Allocator alloc) => 
+		name == "b" ? "PLATFORM_1" : "";
+	.module_wrap = fn BGModuleWrap(String name, Allocator alloc) =>
+		name == "f2" ? {
+		.if_condition = "PLATFORM_2",
+		.imports = "platform_interface",
+		} : {};
+	};
+	```
 
- Also, don't forget to define PLATFORM_1 and PLATFORM_2,
- using `BGOptions.clang_args = { "-DPLATFORM_1", "-DPLATFORM_2" }`.
- So the generated code will be:
- 
- ```c3
- module yourlib;
+	Also, don't forget to define PLATFORM_1 and PLATFORM_2,
+	using `BGOptions.clang_args = { "-DPLATFORM_1", "-DPLATFORM_2" }`.
+	So the generated code will be:
+	
+	```c3
+	module yourlib;
 
- struct SomeStruct {
-   int a;
-   int b @if(PLATFORM_1);
- };
+	struct SomeStruct {
+	int a;
+	int b @if(PLATFORM_1);
+	};
 
- module yourlib @if(PLATFORM_2);
- import platform_interface;
+	module yourlib @if(PLATFORM_2);
+	import platform_interface;
 
- some_type f2();
- ```
+	some_type f2();
+	```
 
- func_macro   : "Functional macro body. Called for each function-like macro."
-                "Note that all functional macro parameters are translated via BGTransCallbacks.variable and prepended with '#',"
-                "so you should consider this when generating macro body"
- variable     : "Global non-const variable rhs value. Called for global variables"
- constant     : "Global const rhs value. Called for global constants"
- if_condition : "Generates the first argument for @if conditional compilation attribute. Called for each entity"
- module_wrap  : "Pretty similar to the 'if_condition' function on top-level declarations like functions, structures, etc." 
-                "It wraps the name into a separate module section with it's attributes (including @if conditional compilation attribute),"
-                "imports and other functions. Note that using 'module_wrap' on f.e. structure fields or function parameters is"
-                "impossible - in that case use 'if_condition'. Called for each top-level declaration"
+	func_macro   : "Functional macro body. Called for each function-like macro."
+					"Note that all functional macro parameters are translated via BGTransCallbacks.variable and prepended with '#',"
+					"so you should consider this when generating macro body"
+	variable     : "Global non-const variable rhs value. Called for global variables"
+	constant     : "Global const rhs value. Called for global constants"
+	if_condition : "Generates the first argument for @if conditional compilation attribute. Called for each entity"
+	module_wrap  : "Pretty similar to the 'if_condition' function on top-level declarations like functions, structures, etc." 
+					"It wraps the name into a separate module section with it's attributes (including @if conditional compilation attribute),"
+					"imports and other functions. Note that using 'module_wrap' on f.e. structure fields or function parameters is"
+					"impossible - in that case use 'if_condition'. Called for each top-level declaration"
 *>
 struct BGGenCallbacks
 {
-  BGGenFn         func_macro;
-  BGGenFn         variable;
-  BGGenFn         constant;
-  BGGenFn         if_condition;
-  BGModuleWrapFn  module_wrap;
+	BGGenFn         func_macro;
+	BGGenFn         variable;
+	BGGenFn         constant;
+	BGGenFn         if_condition;
+	BGModuleWrapFn  module_wrap;
 }
 
 
 <*
- name   : "Original string from C source. Should NOT be changed"
- alloc  : "Allocator for the new returned string. Each allocation should be performed with that specific allocator"
- @return  "Translated string, allocated via 'allocator', or empty string to skip the translation of a name (ignore it)"
+	name   : "Original string from C source. Should NOT be changed"
+	alloc  : "Allocator for the new returned string. Each allocation should be performed with that specific allocator"
+	@return  "Translated string, allocated via 'allocator', or empty string to skip the translation of a name (ignore it)"
 *>
 alias BGTransFn = fn String(String name, Allocator alloc);
 
 
 <*
- name   : "Original string from C source. Should NOT be changed"
- @return  "Boolean connected with the passed name"
+	name   : "Original string from C source. Should NOT be changed"
+	@return  "Boolean connected with the passed name"
 *>
 alias BGCheckFn = fn bool(String name);
 
 
 <*
- name   : "Original string from C source. Should NOT be changed"
- alloc  : "Allocator for the new returned string. Each allocation should be performed with that specific allocator"
- @return  "Generated value according to the name string, allocated via 'alloc', or empty string to make no changes"
+	name   : "Original string from C source. Should NOT be changed"
+	alloc  : "Allocator for the new returned string. Each allocation should be performed with that specific allocator"
+	@return  "Generated value according to the name string, allocated via 'alloc', or empty string to make no changes"
 *>
 alias BGGenFn = fn String(String name, Allocator alloc);
 
 
 <*
- name   : "Original string from C source. Should NOT be changed"
- alloc  : "Allocator for BGModuleWrap strings. Each allocation should be performed with that specific allocator"
- @return  "Module properties, with all strings of which allocated via 'alloc'"
+	name   : "Original string from C source. Should NOT be changed"
+	alloc  : "Allocator for BGModuleWrap strings. Each allocation should be performed with that specific allocator"
+	@return  "Module properties, with all strings of which allocated via 'alloc'"
 *>
 alias BGModuleWrapFn = fn BGModuleWrap(String name, Allocator alloc);
 
 
 <*
- For example `(BGModuleWrap){ .if_condition = "env::GLFW_INCLUDE_VULKAN", .imports = "vulkan; opengl" } }`
- will emit the following:
+	For example `(BGModuleWrap){ .if_condition = "env::GLFW_INCLUDE_VULKAN", .imports = "vulkan; opengl" } }`
+	will emit the following:
 
- ```c3
- module mname @if(env::GLFW_INCLUDE_VULKAN);
- import vulkan;
- import opengl;
- ```
+	```c3
+	module mname @if(env::GLFW_INCLUDE_VULKAN);
+	import vulkan;
+	import opengl;
+	```
 
- If all fields are empty, does not emit anything, meaning that the new section is not created.
+	If all fields are empty, does not emit anything, meaning that the new section is not created.
 
- if_condition : "Content of @if attribute of a generated module"
- imports      : "A set of imports of a generated module, separated by ';'" 
-                "Note that all whitespaces after ';' till the beginning of a word are trimmed"
+	if_condition : "Content of @if attribute of a generated module"
+	imports      : "A set of imports of a generated module, separated by ';'" 
+					"Note that all whitespaces after ';' till the beginning of a word are trimmed"
 *>
 struct BGModuleWrap
 {
-  String if_condition;
-  String imports;
+	String if_condition;
+	String imports;
 }
 
 

--- a/bindgen.c3l/bindgen.c3i
+++ b/bindgen.c3l/bindgen.c3i
@@ -29,7 +29,7 @@ extern fn void? translate_header(
   BGOptions         opts = {},
   BGTransCallbacks  trans_callbacks = {},
   BGGenCallbacks    gen_callbacks = {})
-@extern("bg_translate_header");
+@cname("bg_translate_header");
 
 
 <*
@@ -77,7 +77,8 @@ struct BGTransCallbacks
 {
   BGTransFn func;
   BGTransFn type;
-  BGTransFn variable; 
+  BGTransFn variable;
+  BGTransFn enum_field;
   BGTransFn constant;
   BGTransFn func_macro;
 }
@@ -260,28 +261,28 @@ struct BGModuleWrap
 *>
 module bindgen::bgstr;
 
-fn bool is_between(String name, String bound_1, String bound_2) @extern("bgstr_is_between");
+fn bool is_between(String name, String bound_1, String bound_2) @cname("bgstr_is_between");
 
-fn String snake_to_camel(String str, Allocator alloc) @extern("bgstr_snake_to_camel");
-fn String snake_to_pascal(String str, Allocator alloc) @extern("bgstr_snake_to_pascal");
-fn String snake_to_screaming(String str, Allocator alloc) @extern("bgstr_snake_to_screaming");
+fn String snake_to_camel(String str, Allocator alloc) @cname("bgstr_snake_to_camel");
+fn String snake_to_pascal(String str, Allocator alloc) @cname("bgstr_snake_to_pascal");
+fn String snake_to_screaming(String str, Allocator alloc) @cname("bgstr_snake_to_screaming");
 
-fn String pascal_to_screaming(String str, Allocator alloc) @extern("bgstr_pascal_to_screaming");
-fn String pascal_to_snake(String str, Allocator alloc) @extern("bgstr_pascal_to_snake");
-fn String pascal_to_camel(String str, Allocator alloc) @extern("bgstr_pascal_to_camel");
+fn String pascal_to_screaming(String str, Allocator alloc) @cname("bgstr_pascal_to_screaming");
+fn String pascal_to_snake(String str, Allocator alloc) @cname("bgstr_pascal_to_snake");
+fn String pascal_to_camel(String str, Allocator alloc) @cname("bgstr_pascal_to_camel");
 
-fn String camel_to_screaming(String str, Allocator alloc) @extern("bgstr_camel_to_screaming");
-fn String camel_to_snake(String str, Allocator alloc) @extern("bgstr_camel_to_snake");
-fn String camel_to_pascal(String str, Allocator alloc) @extern("bgstr_camel_to_pascal");
+fn String camel_to_screaming(String str, Allocator alloc) @cname("bgstr_camel_to_screaming");
+fn String camel_to_snake(String str, Allocator alloc) @cname("bgstr_camel_to_snake");
+fn String camel_to_pascal(String str, Allocator alloc) @cname("bgstr_camel_to_pascal");
 
-fn String screaming_to_snake(String str, Allocator alloc) @extern("bgstr_screaming_to_snake");
-fn String screaming_to_camel(String str, Allocator alloc) @extern("bgstr_screaming_to_camel");
-fn String screaming_to_pascal(String str, Allocator alloc) @extern("bgstr_screaming_to_pascal");
+fn String screaming_to_snake(String str, Allocator alloc) @cname("bgstr_screaming_to_snake");
+fn String screaming_to_camel(String str, Allocator alloc) @cname("bgstr_screaming_to_camel");
+fn String screaming_to_pascal(String str, Allocator alloc) @cname("bgstr_screaming_to_pascal");
 
-fn String mixed_to_camel(String str, Allocator alloc) @extern("bgstr_mixed_to_camel");
-fn String mixed_to_screaming(String str, Allocator alloc) @extern("bgstr_mixed_to_screaming");
-fn String mixed_to_snake(String str, Allocator alloc) @extern("bgstr_mixed_to_snake");
-fn String mixed_to_pascal(String str, Allocator alloc) @extern("bgstr_mixed_to_pascal");
+fn String mixed_to_camel(String str, Allocator alloc) @cname("bgstr_mixed_to_camel");
+fn String mixed_to_screaming(String str, Allocator alloc) @cname("bgstr_mixed_to_screaming");
+fn String mixed_to_snake(String str, Allocator alloc) @cname("bgstr_mixed_to_snake");
+fn String mixed_to_pascal(String str, Allocator alloc) @cname("bgstr_mixed_to_pascal");
 
 macro bool String.is_between(String str, String a, String b) => is_between(str, a, b);
 

--- a/bindgen.c3l/src/bg.c3
+++ b/bindgen.c3l/src/bg.c3
@@ -61,7 +61,7 @@ fn void? translateHeader(
     out = file::open(opts.out_name, "w")!;
   };
 
-  defer (void) out.close();
+  defer (void)out.close();
 
   // Check callbacks
   if (trans_callbacks.func == null) err::warn(opts.no_verbose, "Function translation will not be performed as function pointer is null");
@@ -88,12 +88,12 @@ fn void? translateHeader(
   }
 
   CXTranslationUnit tu;
-  CXErrorCode code = clang::parseTranslationUnit2(index, (ZString) header_name, cargs.ptr, cargs.len, null, 0, bgimpl::TRANSLATION_UNIT_PARSE_FLAGS, &tu);
+  CXErrorCode code = clang::parseTranslationUnit2(index, (ZString)header_name, cargs.ptr, cargs.len, null, 0, (uint)bgimpl::TRANSLATION_UNIT_PARSE_FLAGS, &tu);
   checkCode(code)!;
   defer clang::disposeTranslationUnit(tu);
 
   // Print diagnostics
-  usz severe_count = runDiagnostics(tu, header_name, clang::DIAGNOSTIC_ERROR);
+  usz severe_count = runDiagnostics(tu, header_name, DIAGNOSTIC_ERROR);
   if (severe_count > 0 && !opts.skip_errors) return bg::CLANG_PARSE_ERROR~;
 
   GlobalVisitData visit_data = {
@@ -181,23 +181,23 @@ fn void? checkCode(
   CXErrorCode code)
 {
   switch (code) {
-    case clang::ERROR_SUCCESS: 
+    case ERROR_SUCCESS: 
       break;
-    case clang::ERROR_FAILURE:
-    case clang::ERROR_AST_READ_ERROR:
+    case ERROR_FAILURE:
+    case ERROR_AST_READ_ERROR:
       return bg::CLANG_PARSE_ERROR~;
-    case clang::ERROR_CRASHED:
+    case ERROR_CRASHED:
       return bg::CLANG_CRASH~;
-    case clang::ERROR_INVALID_ARGUMENTS:
+    case ERROR_INVALID_ARGUMENTS:
       return bg::INVALID_ARGUMENTS~;
   }
 }
 
 
-const TRANSLATION_UNIT_PARSE_FLAGS =
-    clang::TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD
-  | clang::TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES
-  | clang::TRANSLATION_UNIT_SKIP_FUNCTION_BODIES
-  | clang::TRANSLATION_UNIT_KEEP_GOING;
+const CXTranslationUnit_Flags TRANSLATION_UNIT_PARSE_FLAGS =
+    CXTranslationUnit_Flags.TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD
+  | CXTranslationUnit_Flags.TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES
+  | CXTranslationUnit_Flags.TRANSLATION_UNIT_SKIP_FUNCTION_BODIES
+  | CXTranslationUnit_Flags.TRANSLATION_UNIT_KEEP_GOING;
 
 

--- a/bindgen.c3l/src/bg.c3
+++ b/bindgen.c3l/src/bg.c3
@@ -39,22 +39,15 @@ fn void? translateHeader(
 	if (opts.out_name != "") @pool() {
 		err::warn(opts.no_verbose, "BGOptions.out_name is deprecated in favour of BGOptions.out_file");
 
-		Path out_path = { 
-		.path_string = opts.out_name,
-		.env = path::DEFAULT_ENV,
-		};
+		Path out_path = path::tnew(opts.out_name)!;
 
 		if (path::is_dir(out_path)) {
-		err::erro("The output name you've provided is an existing directory. Please provide a name of a file I should write to");
-		return bg::INVALID_ARGUMENTS~;
+			err::erro("The output name you've provided is an existing directory. Please provide a name of a file I should write to");
+			return bg::INVALID_ARGUMENTS~;
 		}
 
 		// If there is no parent, we are in root
-		Path out_parent = out_path.parent() ?? {
-		.path_string = "/",
-		.env = path::DEFAULT_ENV,
-		};
-
+		Path out_parent = out_path.parent() ?? path::tnew(string::tformat("%s", path::PREFERRED_SEPARATOR))!;
 		// Create missing directories on the path
 		path::mkdir(out_parent, recursive: true)!!;
 
@@ -93,7 +86,7 @@ fn void? translateHeader(
 	defer clang::disposeTranslationUnit(tu);
 
 	// Print diagnostics
-	usz severe_count = runDiagnostics(tu, header_name, DIAGNOSTIC_ERROR);
+	sz severe_count = runDiagnostics(tu, header_name, DIAGNOSTIC_ERROR);
 	if (severe_count > 0 && !opts.skip_errors) return bg::CLANG_PARSE_ERROR~;
 
 	GlobalVisitData visit_data = {
@@ -141,7 +134,7 @@ fn void? translateHeader(
 	@param ignore_file_not_found : "Whether to ignore file not found error in diagnostics"
 	@return                        "Number of severe diagnostics"
 *>
-fn usz runDiagnostics(
+fn sz runDiagnostics(
 	CXTranslationUnit tu,
 	String header_name,
 	CXDiagnosticSeverity min_severity,
@@ -149,7 +142,7 @@ fn usz runDiagnostics(
 	@inline
 {
 	CUInt diagnostics_count = clang::getNumDiagnostics(tu);
-	usz severe_count;
+	sz severe_count;
 	for (CUInt i; i < diagnostics_count; ++i) {
 		CXDiagnostic diag = clang::getDiagnostic(tu, i); 
 		defer clang::disposeDiagnostic(diag);

--- a/bindgen.c3l/src/bg.c3
+++ b/bindgen.c3l/src/bg.c3
@@ -7,169 +7,170 @@ import clang,
        std::os::process;
 
 <*
- Implementation of bg::translate_header
+	Implementation of bg::translate_header
 *>
 fn void? translateHeader(
-  String header_name, 
-  BGOptions opts = {},
-  BGTransCallbacks trans_callbacks = {},
-  BGGenCallbacks gen_callbacks = {})
-  @export("bg_translate_header")
+	String header_name, 
+	BGOptions opts = {},
+	BGTransCallbacks trans_callbacks = {},
+	BGGenCallbacks gen_callbacks = {})
+	@export("bg_translate_header")
 {
-  err::info(opts.no_verbose, "Translating %s", header_name);
-  
-  // Set the output name
-  String out_name;
+	err::info(opts.no_verbose, "Translating %s", header_name);
+	
+	// Set the output name
+	String out_name;
 
-  switch {
-    case (bool)opts.out_file.file:
-      out_name = "file descriptor";
-    case (bool)opts.out_name:
-      out_name = opts.out_name;
-    default:
-      out_name = "standard output";
-  }
+	switch {
+		case (bool)opts.out_file.file:
+		out_name = "file descriptor";
+		case (bool)opts.out_name:
+		out_name = opts.out_name;
+		default:
+		out_name = "standard output";
+	}
 
-  err::info(opts.no_verbose, "Writing to %s", out_name);
- 
-  // Open file
-  File out = opts.out_file.file ? opts.out_file : *io::stdout();
+	err::info(opts.no_verbose, "Writing to %s", out_name);
+	
+	// Open file
+	File out = opts.out_file.file ? opts.out_file : *io::stdout();
 
-  // FIX: make BGOptions.out_file override BGOptions.out_name
-  if (opts.out_name != "") @pool() {
-    err::warn(opts.no_verbose, "BGOptions.out_name is deprecated in favour of BGOptions.out_file");
+	// FIX: make BGOptions.out_file override BGOptions.out_name
+	if (opts.out_name != "") @pool() {
+		err::warn(opts.no_verbose, "BGOptions.out_name is deprecated in favour of BGOptions.out_file");
 
-    Path out_path = { 
-      .path_string = opts.out_name,
-      .env = path::DEFAULT_ENV,
-    };
+		Path out_path = { 
+		.path_string = opts.out_name,
+		.env = path::DEFAULT_ENV,
+		};
 
-    if (path::is_dir(out_path)) {
-      err::erro("The output name you've provided is an existing directory. Please provide a name of a file I should write to");
-      return bg::INVALID_ARGUMENTS~;
-    }
+		if (path::is_dir(out_path)) {
+		err::erro("The output name you've provided is an existing directory. Please provide a name of a file I should write to");
+		return bg::INVALID_ARGUMENTS~;
+		}
 
-    // If there is no parent, we are in root
-    Path out_parent = out_path.parent() ?? {
-      .path_string = "/",
-      .env = path::DEFAULT_ENV,
-    };
+		// If there is no parent, we are in root
+		Path out_parent = out_path.parent() ?? {
+		.path_string = "/",
+		.env = path::DEFAULT_ENV,
+		};
 
-    // Create missing directories on the path
-    path::mkdir(out_parent, recursive: true)!!;
+		// Create missing directories on the path
+		path::mkdir(out_parent, recursive: true)!!;
 
-    out = file::open(opts.out_name, "w")!;
-  };
+		out = file::open(opts.out_name, "w")!;
+	};
 
-  defer (void)out.close();
+	defer (void)out.close();
 
-  // Check callbacks
-  if (trans_callbacks.func == null) err::warn(opts.no_verbose, "Function translation will not be performed as function pointer is null");
-  if (trans_callbacks.variable == null) err::warn(opts.no_verbose, "Variable translation will not be performed as function pointer is null");
-  if (trans_callbacks.type == null) err::warn(opts.no_verbose, "Type translation will not be performed as function pointer is null");
-  if (trans_callbacks.constant == null) err::warn(opts.no_verbose, "Constant translation will not be performed as function pointer is null");
-  if (trans_callbacks.func_macro == null) err::warn(opts.no_verbose, "Functional macros translation will not be performed as function pointer is null");
+	// Check callbacks
+	if (trans_callbacks.func == null) err::warn(opts.no_verbose, "Function translation will not be performed as function pointer is null");
+	if (trans_callbacks.variable == null) err::warn(opts.no_verbose, "Variable translation will not be performed as function pointer is null");
+	if (trans_callbacks.type == null) err::warn(opts.no_verbose, "Type translation will not be performed as function pointer is null");
+	if (trans_callbacks.constant == null) err::warn(opts.no_verbose, "Constant translation will not be performed as function pointer is null");
+	if (trans_callbacks.func_macro == null) err::warn(opts.no_verbose, "Functional macros translation will not be performed as function pointer is null");
 
-  // Get command args for clang
-  ZString[]? cargs = user::getParseCommandArgs(tmem, opts.clang_args);
-  if (catch exc = cargs) {
-    if (exc == process::FAILED_TO_START_PROCESS) {
-      err::erro("Could not run 'clang' in order to find libc headers. Please, install clang");
-    }
-    return exc~;
-  }
+	// Get command args for clang
+	ZString[]? cargs = user::getParseCommandArgs(tmem, opts.clang_args);
+	if (catch exc = cargs) {
+		if (exc == process::FAILED_TO_START_PROCESS) {
+		err::erro("Could not run 'clang' in order to find libc headers. Please, install clang");
+		}
+		return exc~;
+	}
 
-  CXIndex index = clang::createIndex(0, 0);
-  defer clang::disposeIndex(index);
+	CXIndex index = clang::createIndex(0, 0);
+	defer clang::disposeIndex(index);
 
-  if (!file::exists(header_name)) {
-    err::erro("Could not find input header file '%s'. Please, check your current directory", header_name);
-    return bg::INVALID_ARGUMENTS~;
-  }
+	if (!file::exists(header_name)) {
+		err::erro("Could not find input header file '%s'. Please, check your current directory", header_name);
+		return bg::INVALID_ARGUMENTS~;
+	}
 
-  CXTranslationUnit tu;
-  CXErrorCode code = clang::parseTranslationUnit2(index, (ZString)header_name, cargs.ptr, cargs.len, null, 0, (uint)bgimpl::TRANSLATION_UNIT_PARSE_FLAGS, &tu);
-  checkCode(code)!;
-  defer clang::disposeTranslationUnit(tu);
+	CXTranslationUnit tu;
+	CXErrorCode code = clang::parseTranslationUnit2(index, (ZString)header_name, cargs.ptr, cargs.len, null, 0, (uint)bgimpl::TRANSLATION_UNIT_PARSE_FLAGS, &tu);
+	checkCode(code)!;
+	defer clang::disposeTranslationUnit(tu);
 
-  // Print diagnostics
-  usz severe_count = runDiagnostics(tu, header_name, DIAGNOSTIC_ERROR);
-  if (severe_count > 0 && !opts.skip_errors) return bg::CLANG_PARSE_ERROR~;
+	// Print diagnostics
+	usz severe_count = runDiagnostics(tu, header_name, DIAGNOSTIC_ERROR);
+	if (severe_count > 0 && !opts.skip_errors) return bg::CLANG_PARSE_ERROR~;
 
-  GlobalVisitData visit_data = {
-    .trans_fns = trans_callbacks,
-    .gen_fns = gen_callbacks,
-    .include_file = opts.include_file,
-    .module_name = opts.module_name,
+	GlobalVisitData visit_data = {
+		.trans_fns = trans_callbacks,
+		.gen_fns = gen_callbacks,
+		.include_file = opts.include_file,
+		.module_name = opts.module_name,
 
-    .out = &out,
-    .cxfile = clang::getFile(tu, (ZString)header_name),
+		.out = &out,
+		.cxfile = clang::getFile(tu, (ZString)header_name),
 
-    .no_verbose = opts.no_verbose,
-  };
-  
-  // TODO: also free Strings under types_table
-  visit_data.types_table.init(mem);
-  defer visit_data.types_table.free();
+		.no_verbose = opts.no_verbose,
+		.use_docs = opts.generate_docs
+	};
+	
+	// TODO: also free Strings under types_table
+	visit_data.types_table.init(mem);
+	defer visit_data.types_table.free();
 
-  // Write module name
-  if (opts.module_name != "") wter::moduleHead(&out, &visit_data.write_state, opts.module_name);
+	// Write module name
+	if (opts.module_name != "") wter::moduleHead(&out, &visit_data.write_state, opts.module_name);
 
-  foreach (imp : opts.imports) {
-	wter::importModule(&out, &visit_data.write_state, imp);
-  }
+	foreach (imp : opts.imports) {
+		wter::importModule(&out, &visit_data.write_state, imp);
+	}
 
-  CXCursor cursor = clang::getTranslationUnitCursor(tu);
-  clang::visitChildren(cursor, &vtor::global, (CXClientData) &visit_data);
+	CXCursor cursor = clang::getTranslationUnitCursor(tu);
+	clang::visitChildren(cursor, &vtor::global, (CXClientData) &visit_data);
 
-  // TODO: make freeing of command args
-  // foreach (zstr : cargs)
-  // {
-  //   allocator::free(tmem, zstr);
-  // }
+	// TODO: make freeing of command args
+	// foreach (zstr : cargs)
+	// {
+	//   allocator::free(tmem, zstr);
+	// }
 }
 
 
 <*
- Run diagnostics on translation unit.
- Prints each diangostic if it is more or
- equal to the min_severity. By default, ignores 
- the file not found error, but you can override
- it by unsetting ignore_file_not_found.
- @param min_severity          : "Minimal severity for a diagnostic to be counted"
- @param ignore_file_not_found : "Whether to ignore file not found error in diagnostics"
- @return                        "Number of severe diagnostics"
+	Run diagnostics on translation unit.
+	Prints each diangostic if it is more or
+	equal to the min_severity. By default, ignores 
+	the file not found error, but you can override
+	it by unsetting ignore_file_not_found.
+	@param min_severity          : "Minimal severity for a diagnostic to be counted"
+	@param ignore_file_not_found : "Whether to ignore file not found error in diagnostics"
+	@return                        "Number of severe diagnostics"
 *>
 fn usz runDiagnostics(
-  CXTranslationUnit tu,
-  String header_name,
-  CXDiagnosticSeverity min_severity,
-  bool ignore_file_not_found = true)
-  @inline
+	CXTranslationUnit tu,
+	String header_name,
+	CXDiagnosticSeverity min_severity,
+	bool ignore_file_not_found = true)
+	@inline
 {
-  CUInt diagnostics_count = clang::getNumDiagnostics(tu);
-  usz severe_count;
-  for (CUInt i; i < diagnostics_count; ++i) {
-    CXDiagnostic diag = clang::getDiagnostic(tu, i); 
-    defer clang::disposeDiagnostic(diag);
+	CUInt diagnostics_count = clang::getNumDiagnostics(tu);
+	usz severe_count;
+	for (CUInt i; i < diagnostics_count; ++i) {
+		CXDiagnostic diag = clang::getDiagnostic(tu, i); 
+		defer clang::disposeDiagnostic(diag);
 
-    CXSourceLocation diag_loc = clang::getDiagnosticLocation(diag);
-    CUInt line, col;
-    clang::getFileLocation(diag_loc, null, &line, &col, null);
+		CXSourceLocation diag_loc = clang::getDiagnosticLocation(diag);
+		CUInt line, col;
+		clang::getFileLocation(diag_loc, null, &line, &col, null);
 
-    CXString diag_spell = clang::getDiagnosticSpelling(diag);
-    defer clang::disposeString(diag_spell);
-    String diag_str = misc::convStr(diag_spell);
+		CXString diag_spell = clang::getDiagnosticSpelling(diag);
+		defer clang::disposeString(diag_spell);
+		String diag_str = misc::convStr(diag_spell);
 
-    if (clang::getDiagnosticSeverity(diag) >= min_severity) {
-      // Do not count if some file is not found and we don't ignore it
-      if (ignore_file_not_found && diag_str.ends_with("file not found")) {
-        ++severe_count;
-      }
-      err::diag(header_name, line, col, diag_str);
-    }
-  }
-  return severe_count;
+		if (clang::getDiagnosticSeverity(diag) >= min_severity) {
+		// Do not count if some file is not found and we don't ignore it
+		if (ignore_file_not_found && diag_str.ends_with("file not found")) {
+			++severe_count;
+		}
+		err::diag(header_name, line, col, diag_str);
+		}
+	}
+	return severe_count;
 }
 
 
@@ -178,26 +179,26 @@ fn usz runDiagnostics(
  the corresponding fault if error occured
 *>
 fn void? checkCode(
-  CXErrorCode code)
+	CXErrorCode code)
 {
-  switch (code) {
-    case ERROR_SUCCESS: 
-      break;
-    case ERROR_FAILURE:
-    case ERROR_AST_READ_ERROR:
-      return bg::CLANG_PARSE_ERROR~;
-    case ERROR_CRASHED:
-      return bg::CLANG_CRASH~;
-    case ERROR_INVALID_ARGUMENTS:
-      return bg::INVALID_ARGUMENTS~;
-  }
+	switch (code) {
+		case ERROR_SUCCESS: 
+		break;
+		case ERROR_FAILURE:
+		case ERROR_AST_READ_ERROR:
+		return bg::CLANG_PARSE_ERROR~;
+		case ERROR_CRASHED:
+		return bg::CLANG_CRASH~;
+		case ERROR_INVALID_ARGUMENTS:
+		return bg::INVALID_ARGUMENTS~;
+	}
 }
 
 
 const CXTranslationUnit_Flags TRANSLATION_UNIT_PARSE_FLAGS =
-    CXTranslationUnit_Flags.TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD
-  | CXTranslationUnit_Flags.TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES
-  | CXTranslationUnit_Flags.TRANSLATION_UNIT_SKIP_FUNCTION_BODIES
-  | CXTranslationUnit_Flags.TRANSLATION_UNIT_KEEP_GOING;
+		CXTranslationUnit_Flags.TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD
+	| CXTranslationUnit_Flags.TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES
+	| CXTranslationUnit_Flags.TRANSLATION_UNIT_SKIP_FUNCTION_BODIES
+	| CXTranslationUnit_Flags.TRANSLATION_UNIT_KEEP_GOING;
 
 

--- a/bindgen.c3l/src/bgstr.c3
+++ b/bindgen.c3l/src/bgstr.c3
@@ -478,7 +478,7 @@ macro String convertToSnakeOrScreaming(
   // If last token is '_', we do not insert '_' after prelast token
   usz last_token_index = tokens.len() - ((*tokens)[^1][0] == '_' ? 2 : 1); 
 
-  String res = (String) allocator::alloc_array(alloc, char, size);
+  String res = (String)alloc::alloc_array(alloc, char, size);
   
   usz last = 0;
   foreach (i, t : tokens) {
@@ -520,7 +520,7 @@ macro String convertToCamelOrPascal(
     size += t.len;
   }
 
-  String res = (String) allocator::alloc_array(alloc, char, size);
+  String res = (String)alloc::alloc_array(alloc, char, size);
   
   $if $to_camel:
     bool has_underscore = (*tokens)[0][0] == '_';

--- a/bindgen.c3l/src/bgstr.c3
+++ b/bindgen.c3l/src/bgstr.c3
@@ -3,7 +3,7 @@ module bgimpl;
 import bgimpl::err;
 import std::collections::list;
 import std::collections::map;
-import std::ascii;
+import std::core::ascii;
 
 
 alias ListString = List{String};
@@ -153,7 +153,7 @@ fn String camelToPascal(
   @export("bgstr_camel_to_pascal")
 {
   String res = str.copy(alloc);
-  usz i;
+  sz i;
   while (i < str.len && str[i] == '_') ++i;
   if (i < str.len) res[i] = str[i].to_upper();
   return res;
@@ -193,7 +193,7 @@ fn String pascalToCamel(
   @export("bgstr_pascal_to_camel")
 {
   String res = str.copy(alloc);
-  usz i;
+  sz i;
   while (i < str.len && str[i] == '_') ++i;
   if (i < str.len) res[i] = str[i].to_lower();
   return res;
@@ -273,18 +273,18 @@ fn ListString parseSnakeCase(
   tokens.init(alloc, str.len / 2);
 
   // Treat possible beginning '_'
-  usz first = 0;
+  sz first = 0;
   while (first < str.len && str[first] == '_') ++first;
   if (first > 0) tokens.push(str[0..first-1]);
 
   // Treat possible closing '_' 
-  usz last = str.len - 1;
+  sz last = str.len - 1;
   while (last > 0 && str[last] == '_') --last;
 
   // Treat the rest [first..last]
-  for (usz i = first; i <= last;) {
+  for (sz i = first; i <= last;) {
     while (i <= last && str[i] == '_') ++i;
-    usz begin = i;
+    sz begin = i;
     while (i <= last && str[i] != '_') ++i;
     tokens.push(str[begin..i-1]);
   }
@@ -324,17 +324,17 @@ fn ListString parseCamelCase(
   tokens.init(alloc, str.len / 2);
 
   // Erase possible beginning '_'
-  isz first = 0;
+  sz first = 0;
   while (first < str.len && str[first] == '_') ++first;
   if (first > 0) tokens.push(str[0..first-1]);
 
   // Erase possible closing '_' 
-  isz last = str.len - 1;
+  sz last = str.len - 1;
   while (last >= 0 && str[last] == '_') --last;
 
   // Treat the rest [first..last]
-  for (usz i = first; i <= last;) {
-    usz begin = i++;
+  for (sz i = first; i <= last;) {
+    sz begin = i++;
 
     // Handle several upper cases and digits in a row
     bool is_prev_digit = false;
@@ -465,7 +465,7 @@ macro String convertToSnakeOrScreaming(
   ListString* tokens, 
   bool $to_snake) 
 {
-  usz size = 0;
+  sz size = 0;
   foreach (t : tokens) {
     size += t.len;
 
@@ -476,11 +476,11 @@ macro String convertToSnakeOrScreaming(
   --size;
 
   // If last token is '_', we do not insert '_' after prelast token
-  usz last_token_index = tokens.len() - ((*tokens)[^1][0] == '_' ? 2 : 1); 
+  sz last_token_index = tokens.len() - ((*tokens)[^1][0] == '_' ? 2 : 1); 
 
   String res = (String)alloc::alloc_array(alloc, char, size);
   
-  usz last = 0;
+  sz last = 0;
   foreach (i, t : tokens) {
     res[last:t.len] = t[..];
 
@@ -515,7 +515,7 @@ macro String convertToCamelOrPascal(
   ListString* tokens, 
   bool $to_camel) 
 {
-  usz size = 0;
+  sz size = 0;
   foreach (t : tokens) {
     size += t.len;
   }
@@ -526,11 +526,11 @@ macro String convertToCamelOrPascal(
     bool has_underscore = (*tokens)[0][0] == '_';
   $endif
 
-  usz last = 0;
+  sz last = 0;
   foreach (i, t : *tokens) {
     res[last:t.len] = t[..];
     
-    usz offset = 1;
+    sz offset = 1;
     $if $to_camel:
       if (i == (has_underscore ? 1 : 0)) offset = 0;
     $endif
@@ -545,7 +545,7 @@ macro String convertToCamelOrPascal(
       res[last] = res[last].to_upper();
     $endif
 
-    for (usz j = last + offset; j < last + t.len; ++j) {
+    for (sz j = last + offset; j < last + t.len; ++j) {
       res[j] = res[j].to_lower();
     }
 

--- a/bindgen.c3l/src/check.c3
+++ b/bindgen.c3l/src/check.c3
@@ -3,15 +3,15 @@ module bgimpl::check;
 import bindgen::bg;
 
 <*
- Applies fun to s, returning false
- if fun is null.
+	Applies fun to s, returning false
+	if fun is null.
 *>
 fn bool apply(
-  String s, 
-  BGCheckFn fun) 
-  @inline
+	String s, 
+	BGCheckFn fun) 
+	@inline
 {
-  if (fun == null) return false;
-  return fun(s);
+	if (fun == null) return false;
+	return fun(s);
 }
 

--- a/bindgen.c3l/src/clang.c3i
+++ b/bindgen.c3l/src/clang.c3i
@@ -2,340 +2,848 @@
 module clang;
 import libc;
 
+<*
+	Error codes returned by libclang routines.
+	Zero (\c CXError_Success) is the only error code indicating success.  Other
+	error codes, including not yet assigned non-zero values, indicate errors.
+*>
 constdef CXErrorCode : CInt {
-  ERROR_SUCCESS = 0,
-  ERROR_FAILURE = 1,
-  ERROR_CRASHED = 2,
-  ERROR_INVALID_ARGUMENTS = 3,
-  ERROR_AST_READ_ERROR = 4
+
+	<*
+		No error.
+	*>
+	ERROR_SUCCESS = 0,
+
+	<*
+		A generic error code, no further details are available.
+		Errors of this kind can get their own specific error codes in future
+		libclang versions.
+	*>
+	ERROR_FAILURE = 1,
+
+	<*
+		libclang crashed while performing the requested operation.
+	*>
+	ERROR_CRASHED = 2,
+
+	<*
+		The function detected that the arguments violate the function
+		contract.
+	*>
+	ERROR_INVALID_ARGUMENTS = 3,
+
+	<*
+		An AST deserialization error has occurred.
+	*>
+	ERROR_AST_READ_ERROR = 4
 }
 
+<*
+	A character string.
+	The \c CXString type is used to return strings from the interface when
+	the ownership of that string might differ from one call to the next.
+	Use \c clang_getCString() to retrieve the string data and, once finished
+	with the string data, call \c clang_disposeString() to free the string.
+*>
 struct CXString {
-  void* data;
-  CUInt private_flags;
+	void* data;
+	CUInt private_flags;
 }
+
 
 struct CXStringSet {
-  CXString* strings;
-  CUInt count;
+	CXString* strings;
+	CUInt count;
 }
 
+<*
+	Retrieve the character data associated with the given string.
+	The returned data is a reference and not owned by the user. This data
+	is only valid while the `CXString` is valid. This function is similar
+	to `std::string::c_str()`.
+*>
 extern fn ZString getCString(
-  CXString string)
+	CXString string)
 @cname("clang_getCString");
 
+<*
+	Free the given string.
+*>
 extern fn void disposeString(
-  CXString string)
+	CXString string)
 @cname("clang_disposeString");
 
+<*
+	Free the given string set.
+*>
 extern fn void disposeStringSet(
-  CXStringSet* set)
+	CXStringSet* set)
 @cname("clang_disposeStringSet");
 
+<*
+	Return the timestamp for use with Clang's
+	\c -fbuild-session-timestamp= option.
+*>
 extern fn CULongLong getBuildSessionTimestamp()
 @cname("clang_getBuildSessionTimestamp");
 
 alias CXVirtualFileOverlay = void*;
 
+<*
+	Create a \c CXVirtualFileOverlay object.
+	Must be disposed with \c clang_VirtualFileOverlay_dispose().
+	\param options is reserved, always pass 0.
+*>
 extern fn CXVirtualFileOverlay virtualFileOverlay_create(
-  CUInt options)
+	CUInt options)
 @cname("clang_VirtualFileOverlay_create");
 
+<*
+	Map an absolute virtual file path to an absolute real one.
+	The virtual path must be canonicalized (not contain "."/"..").
+	\returns 0 for success, non-zero to indicate an error.
+*>
 extern fn CXErrorCode virtualFileOverlay_addFileMapping(
-  CXVirtualFileOverlay,
-  ZString virtual_path,
-  ZString real_path)
+	CXVirtualFileOverlay,
+	ZString virtual_path,
+	ZString real_path)
 @cname("clang_VirtualFileOverlay_addFileMapping");
 
+<*
+	Set the case sensitivity for the \c CXVirtualFileOverlay object.
+	The \c CXVirtualFileOverlay object is case-sensitive by default, this
+	option can be used to override the default.
+	\returns 0 for success, non-zero to indicate an error.
+*>
 extern fn CXErrorCode virtualFileOverlay_setCaseSensitivity(
-  CXVirtualFileOverlay,
-  CInt case_sensitive)
+	CXVirtualFileOverlay,
+	CInt case_sensitive)
 @cname("clang_VirtualFileOverlay_setCaseSensitivity");
 
+<*
+	Write out the \c CXVirtualFileOverlay object to a char buffer.
+	\param options is reserved, always pass 0.
+	\param out_buffer_ptr pointer to receive the buffer pointer, which should be
+	disposed using \c clang_free().
+	\param out_buffer_size pointer to receive the buffer size.
+	\returns 0 for success, non-zero to indicate an error.
+*>
 extern fn CXErrorCode virtualFileOverlay_writeToBuffer(
-  CXVirtualFileOverlay,
-  CUInt options,
-  CChar** out_buffer_ptr,
-  CUInt* out_buffer_size)
+	CXVirtualFileOverlay,
+	CUInt options,
+	ZString* out_buffer_ptr,
+	CUInt* out_buffer_size)
 @cname("clang_VirtualFileOverlay_writeToBuffer");
 
+<*
+	free memory allocated by libclang, such as the buffer returned by
+	\c CXVirtualFileOverlay() or \c clang_ModuleMapDescriptor_writeToBuffer().
+	\param buffer memory pointer to free.
+*>
 extern fn void free(
-  void* buffer)
+	void* buffer)
 @cname("clang_free");
 
+<*
+	Dispose a \c CXVirtualFileOverlay object.
+*>
 extern fn void virtualFileOverlay_dispose(
-  CXVirtualFileOverlay)
+	CXVirtualFileOverlay)
 @cname("clang_VirtualFileOverlay_dispose");
 
 alias CXModuleMapDescriptor = void*;
 
+<*
+	Create a \c CXModuleMapDescriptor object.
+	Must be disposed with \c clang_ModuleMapDescriptor_dispose().
+	\param options is reserved, always pass 0.
+*>
 extern fn CXModuleMapDescriptor moduleMapDescriptor_create(
-  CUInt options)
+	CUInt options)
 @cname("clang_ModuleMapDescriptor_create");
 
+<*
+	Sets the framework module name that the module.modulemap describes.
+	\returns 0 for success, non-zero to indicate an error.
+*>
 extern fn CXErrorCode moduleMapDescriptor_setFrameworkModuleName(
-  CXModuleMapDescriptor,
-  ZString name)
+	CXModuleMapDescriptor,
+	ZString name)
 @cname("clang_ModuleMapDescriptor_setFrameworkModuleName");
 
+<*
+	Sets the umbrella header name that the module.modulemap describes.
+	\returns 0 for success, non-zero to indicate an error.
+*>
 extern fn CXErrorCode moduleMapDescriptor_setUmbrellaHeader(
-  CXModuleMapDescriptor,
-  ZString name)
+	CXModuleMapDescriptor,
+	ZString name)
 @cname("clang_ModuleMapDescriptor_setUmbrellaHeader");
 
+<*
+	Write out the \c CXModuleMapDescriptor object to a char buffer.
+	\param options is reserved, always pass 0.
+	\param out_buffer_ptr pointer to receive the buffer pointer, which should be
+	disposed using \c clang_free().
+	\param out_buffer_size pointer to receive the buffer size.
+	\returns 0 for success, non-zero to indicate an error.
+*>
 extern fn CXErrorCode moduleMapDescriptor_writeToBuffer(
-  CXModuleMapDescriptor,
-  CUInt options,
-  CChar** out_buffer_ptr,
-  CUInt* out_buffer_size)
+	CXModuleMapDescriptor,
+	CUInt options,
+	ZString* out_buffer_ptr,
+	CUInt* out_buffer_size)
 @cname("clang_ModuleMapDescriptor_writeToBuffer");
 
+<*
+	Dispose a \c CXModuleMapDescriptor object.
+*>
 extern fn void moduleMapDescriptor_dispose(
-  CXModuleMapDescriptor)
+	CXModuleMapDescriptor)
 @cname("clang_ModuleMapDescriptor_dispose");
 
 alias CXFile = void*;
 
+<*
+	Retrieve the complete file and path name of the given file.
+*>
 extern fn CXString getFileName(
-  CXFile s_file)
+	CXFile s_file)
 @cname("clang_getFileName");
 
+<*
+	Retrieve the last modification time of the given file.
+*>
 extern fn Time_t getFileTime(
-  CXFile s_file)
+	CXFile s_file)
 @cname("clang_getFileTime");
 
+<*
+	Uniquely identifies a CXFile, that refers to the same underlying file,
+	across an indexing session.
+*>
 struct CXFileUniqueID {
-  CULongLong[3] data;
+	CULongLong[3] data;
 }
 
+<*
+	Retrieve the unique ID for the given \c file.
+	\param file the file to get the ID for.
+	\param outID stores the returned CXFileUniqueID.
+	\returns If there was a failure getting the unique ID, returns non-zero,
+	otherwise returns 0.
+*>
 extern fn CInt getFileUniqueID(
-  CXFile file,
-  CXFileUniqueID* out_id)
+	CXFile file,
+	CXFileUniqueID* out_id)
 @cname("clang_getFileUniqueID");
 
+<*
+	Returns non-zero if the \c file1 and \c file2 point to the same file,
+	or they are both NULL.
+*>
 extern fn CInt file_isEqual(
-  CXFile file_1,
-  CXFile file_2)
+	CXFile file_1,
+	CXFile file_2)
 @cname("clang_File_isEqual");
 
+<*
+	Returns the real path name of \c file.
+	An empty string may be returned. Use \c clang_getFileName() in that case.
+*>
 extern fn CXString file_tryGetRealPathName(
-  CXFile file)
+	CXFile file)
 @cname("clang_File_tryGetRealPathName");
 
+<*
+	Identifies a specific source location within a translation
+	unit.
+	Use clang_getExpansionLocation() or clang_getSpellingLocation()
+	to map a source location to a particular file, line, and column.
+*>
 struct CXSourceLocation {
-  void*[2] ptr_data;
-  CUInt int_data;
+	void*[2] ptr_data;
+	CUInt int_data;
 }
 
+<*
+	Identifies a half-open character range in the source code.
+	Use clang_getRangeStart() and clang_getRangeEnd() to retrieve the
+	starting and end locations from a source range, respectively.
+*>
 struct CXSourceRange {
-  void*[2] ptr_data;
-  CUInt begin_int_data;
-  CUInt end_int_data;
+	void*[2] ptr_data;
+	CUInt begin_int_data;
+	CUInt end_int_data;
 }
 
+<*
+	Retrieve a NULL (invalid) source location.
+*>
 extern fn CXSourceLocation getNullLocation()
 @cname("clang_getNullLocation");
 
+<*
+	Determine whether two source locations, which must refer into
+	the same translation unit, refer to exactly the same point in the source
+	code.
+	\returns non-zero if the source locations refer to the same location, zero
+	if they refer to different locations.
+*>
 extern fn CUInt equalLocations(
-  CXSourceLocation loc_1,
-  CXSourceLocation loc_2)
+	CXSourceLocation loc_1,
+	CXSourceLocation loc_2)
 @cname("clang_equalLocations");
 
+<*
+	Determine for two source locations if the first comes
+	strictly before the second one in the source code.
+	\returns non-zero if the first source location comes
+	strictly before the second one, zero otherwise.
+*>
 extern fn CUInt isBeforeInTranslationUnit(
-  CXSourceLocation loc_1,
-  CXSourceLocation loc_2)
+	CXSourceLocation loc_1,
+	CXSourceLocation loc_2)
 @cname("clang_isBeforeInTranslationUnit");
 
+<*
+	Returns non-zero if the given source location is in a system header.
+*>
 extern fn CInt location_isInSystemHeader(
-  CXSourceLocation location)
+	CXSourceLocation location)
 @cname("clang_Location_isInSystemHeader");
 
+<*
+	Returns non-zero if the given source location is in the main file of
+	the corresponding translation unit.
+*>
 extern fn CInt location_isFromMainFile(
-  CXSourceLocation location)
+	CXSourceLocation location)
 @cname("clang_Location_isFromMainFile");
 
+<*
+	Retrieve a NULL (invalid) source range.
+*>
 extern fn CXSourceRange getNullRange()
 @cname("clang_getNullRange");
 
+<*
+	Retrieve a source range given the beginning and ending source
+	locations.
+*>
 extern fn CXSourceRange getRange(
-  CXSourceLocation begin,
-  CXSourceLocation end)
+	CXSourceLocation begin,
+	CXSourceLocation end)
 @cname("clang_getRange");
 
+<*
+	Determine whether two ranges are equivalent.
+	\returns non-zero if the ranges are the same, zero if they differ.
+*>
 extern fn CUInt equalRanges(
-  CXSourceRange range_1,
-  CXSourceRange range_2)
+	CXSourceRange range_1,
+	CXSourceRange range_2)
 @cname("clang_equalRanges");
 
+<*
+	Returns non-zero if \p range is null.
+*>
 extern fn CInt range_isNull(
-  CXSourceRange range)
+	CXSourceRange range)
 @cname("clang_Range_isNull");
 
+<*
+	Retrieve the file, line, column, and offset represented by
+	the given source location.
+	If the location refers into a macro expansion, retrieves the
+	location of the macro expansion.
+	\param location the location within a source file that will be decomposed
+	into its parts.
+	\param file [out] if non-NULL, will be set to the file to which the given
+	source location points.
+	\param line [out] if non-NULL, will be set to the line to which the given
+	source location points.
+	\param column [out] if non-NULL, will be set to the column to which the given
+	source location points.
+	\param offset [out] if non-NULL, will be set to the offset into the
+	buffer to which the given source location points.
+*>
 extern fn void getExpansionLocation(
-  CXSourceLocation location,
-  CXFile* file,
-  CUInt* line,
-  CUInt* column,
-  CUInt* offset)
+	CXSourceLocation location,
+	CXFile* file,
+	CUInt* line,
+	CUInt* column,
+	CUInt* offset)
 @cname("clang_getExpansionLocation");
 
+<*
+	Retrieve the file, line and column represented by the given source
+	location, as specified in a # line directive.
+	Example: given the following source code in a file somefile.c
+	\code
+	#123 "dummy.c" 1
+	static int func(void)
+	{
+	return 0;
+	}
+	\endcode
+	the location information returned by this function would be
+	File: dummy.c Line: 124 Column: 12
+	whereas clang_getExpansionLocation would have returned
+	File: somefile.c Line: 3 Column: 12
+	\param location the location within a source file that will be decomposed
+	into its parts.
+	\param filename [out] if non-NULL, will be set to the filename of the
+	source location. Note that filenames returned will be for "virtual" files,
+	which don't necessarily exist on the machine running clang - e.g. when
+	parsing preprocessed output obtained from a different environment. If
+	a non-NULL value is passed in, remember to dispose of the returned value
+	using \c clang_disposeString() once you've finished with it. For an invalid
+	source location, an empty string is returned.
+	\param line [out] if non-NULL, will be set to the line number of the
+	source location. For an invalid source location, zero is returned.
+	\param column [out] if non-NULL, will be set to the column number of the
+	source location. For an invalid source location, zero is returned.
+*>
 extern fn void getPresumedLocation(
-  CXSourceLocation location,
-  CXString* filename,
-  CUInt* line,
-  CUInt* column)
+	CXSourceLocation location,
+	CXString* filename,
+	CUInt* line,
+	CUInt* column)
 @cname("clang_getPresumedLocation");
 
+<*
+	Legacy API to retrieve the file, line, column, and offset represented
+	by the given source location.
+	This interface has been replaced by the newer interface
+	#clang_getExpansionLocation(). See that interface's documentation for
+	details.
+*>
 extern fn void getInstantiationLocation(
-  CXSourceLocation location,
-  CXFile* file,
-  CUInt* line,
-  CUInt* column,
-  CUInt* offset)
+	CXSourceLocation location,
+	CXFile* file,
+	CUInt* line,
+	CUInt* column,
+	CUInt* offset)
 @cname("clang_getInstantiationLocation");
 
+<*
+	Retrieve the file, line, column, and offset represented by
+	the given source location.
+	If the location refers into a macro instantiation, return where the
+	location was originally spelled in the source file.
+	\param location the location within a source file that will be decomposed
+	into its parts.
+	\param file [out] if non-NULL, will be set to the file to which the given
+	source location points.
+	\param line [out] if non-NULL, will be set to the line to which the given
+	source location points.
+	\param column [out] if non-NULL, will be set to the column to which the given
+	source location points.
+	\param offset [out] if non-NULL, will be set to the offset into the
+	buffer to which the given source location points.
+*>
 extern fn void getSpellingLocation(
-  CXSourceLocation location,
-  CXFile* file,
-  CUInt* line,
-  CUInt* column,
-  CUInt* offset)
+	CXSourceLocation location,
+	CXFile* file,
+	CUInt* line,
+	CUInt* column,
+	CUInt* offset)
 @cname("clang_getSpellingLocation");
 
+<*
+	Retrieve the file, line, column, and offset represented by
+	the given source location.
+	If the location refers into a macro expansion, return where the macro was
+	expanded or where the macro argument was written, if the location points at
+	a macro argument.
+	\param location the location within a source file that will be decomposed
+	into its parts.
+	\param file [out] if non-NULL, will be set to the file to which the given
+	source location points.
+	\param line [out] if non-NULL, will be set to the line to which the given
+	source location points.
+	\param column [out] if non-NULL, will be set to the column to which the given
+	source location points.
+	\param offset [out] if non-NULL, will be set to the offset into the
+	buffer to which the given source location points.
+*>
 extern fn void getFileLocation(
-  CXSourceLocation location,
-  CXFile* file,
-  CUInt* line,
-  CUInt* column,
-  CUInt* offset)
+	CXSourceLocation location,
+	CXFile* file,
+	CUInt* line,
+	CUInt* column,
+	CUInt* offset)
 @cname("clang_getFileLocation");
 
+<*
+	Retrieve a source location representing the first character within a
+	source range.
+*>
 extern fn CXSourceLocation getRangeStart(
-  CXSourceRange range)
+	CXSourceRange range)
 @cname("clang_getRangeStart");
 
+<*
+	Retrieve a source location representing the last character within a
+	source range.
+*>
 extern fn CXSourceLocation getRangeEnd(
-  CXSourceRange range)
+	CXSourceRange range)
 @cname("clang_getRangeEnd");
 
+<*
+	Identifies an array of ranges.
+*>
 struct CXSourceRangeList {
-  CUInt count;
-  CXSourceRange* ranges;
+	CUInt count;
+	CXSourceRange* ranges;
 }
 
+<*
+	Destroy the given \c CXSourceRangeList.
+*>
 extern fn void disposeSourceRangeList(
-  CXSourceRangeList* ranges)
+	CXSourceRangeList* ranges)
 @cname("clang_disposeSourceRangeList");
 
+<*
+	Describes the severity of a particular diagnostic.
+*>
 constdef CXDiagnosticSeverity : CInt {
-  DIAGNOSTIC_IGNORED = 0,
-  DIAGNOSTIC_NOTE = 1,
-  DIAGNOSTIC_WARNING = 2,
-  DIAGNOSTIC_ERROR = 3,
-  DIAGNOSTIC_FATAL = 4
+
+	<*
+		A diagnostic that has been suppressed, e.g., by a command-line
+		option.
+	*>
+	DIAGNOSTIC_IGNORED = 0,
+
+	<*
+		This diagnostic is a note that should be attached to the
+		previous (non-note) diagnostic.
+	*>
+	DIAGNOSTIC_NOTE = 1,
+
+	<*
+		This diagnostic indicates suspicious code that may not be
+		wrong.
+	*>
+	DIAGNOSTIC_WARNING = 2,
+
+	<*
+		This diagnostic indicates that the code is ill-formed.
+	*>
+	DIAGNOSTIC_ERROR = 3,
+
+	<*
+		This diagnostic indicates that the code is ill-formed such
+		that future parser recovery is unlikely to produce useful
+		results.
+	*>
+	DIAGNOSTIC_FATAL = 4
 }
 
 alias CXDiagnostic = void*;
 
 alias CXDiagnosticSet = void*;
 
+<*
+	Determine the number of diagnostics in a CXDiagnosticSet.
+*>
 extern fn CUInt getNumDiagnosticsInSet(
-  CXDiagnosticSet diags)
+	CXDiagnosticSet diags)
 @cname("clang_getNumDiagnosticsInSet");
 
+<*
+	Retrieve a diagnostic associated with the given CXDiagnosticSet.
+	\param Diags the CXDiagnosticSet to query.
+	\param Index the zero-based diagnostic number to retrieve.
+	\returns the requested diagnostic. This diagnostic must be freed
+	via a call to \c clang_disposeDiagnostic().
+*>
 extern fn CXDiagnostic getDiagnosticInSet(
-  CXDiagnosticSet diags,
-  CUInt index)
+	CXDiagnosticSet diags,
+	CUInt index)
 @cname("clang_getDiagnosticInSet");
 
+<*
+	Describes the kind of error that occurred (if any) in a call to
+	\c clang_loadDiagnostics.
+*>
 constdef CXLoadDiag_Error : CInt {
-  LOAD_DIAG_NONE = 0,
-  LOAD_DIAG_UNKNOWN = 1,
-  LOAD_DIAG_CANNOT_LOAD = 2,
-  LOAD_DIAG_INVALID_FILE = 3
+
+	<*
+		Indicates that no error occurred.
+	*>
+	LOAD_DIAG_NONE = 0,
+
+	<*
+		Indicates that an unknown error occurred while attempting to
+		deserialize diagnostics.
+	*>
+	LOAD_DIAG_UNKNOWN = 1,
+
+	<*
+		Indicates that the file containing the serialized diagnostics
+		could not be opened.
+	*>
+	LOAD_DIAG_CANNOT_LOAD = 2,
+
+	<*
+		Indicates that the serialized diagnostics file is invalid or
+		corrupt.
+	*>
+	LOAD_DIAG_INVALID_FILE = 3
 }
 
+<*
+	Deserialize a set of diagnostics from a Clang diagnostics bitcode
+	file.
+	\param file The name of the file to deserialize.
+	\param error A pointer to a enum value recording if there was a problem
+	deserializing the diagnostics.
+	\param errorString A pointer to a CXString for recording the error string
+	if the file was not successfully loaded.
+	\returns A loaded CXDiagnosticSet if successful, and NULL otherwise.  These
+	diagnostics should be released using clang_disposeDiagnosticSet().
+*>
 extern fn CXDiagnosticSet loadDiagnostics(
-  ZString file,
-  CXLoadDiag_Error* error,
-  CXString* error_string)
+	ZString file,
+	CXLoadDiag_Error* error,
+	CXString* error_string)
 @cname("clang_loadDiagnostics");
 
+<*
+	Release a CXDiagnosticSet and all of its contained diagnostics.
+*>
 extern fn void disposeDiagnosticSet(
-  CXDiagnosticSet diags)
+	CXDiagnosticSet diags)
 @cname("clang_disposeDiagnosticSet");
 
+<*
+	Retrieve the child diagnostics of a CXDiagnostic.
+	This CXDiagnosticSet does not need to be released by
+	clang_disposeDiagnosticSet.
+*>
 extern fn CXDiagnosticSet getChildDiagnostics(
-  CXDiagnostic d)
+	CXDiagnostic d)
 @cname("clang_getChildDiagnostics");
 
+<*
+	Destroy a diagnostic.
+*>
 extern fn void disposeDiagnostic(
-  CXDiagnostic diagnostic)
+	CXDiagnostic diagnostic)
 @cname("clang_disposeDiagnostic");
 
+<*
+	Options to control the display of diagnostics.
+	The values in this enum are meant to be combined to customize the
+	behavior of \c clang_formatDiagnostic().
+*>
 constdef CXDiagnosticDisplayOptions : CInt {
-  DIAGNOSTIC_DISPLAY_SOURCE_LOCATION = 1,
-  DIAGNOSTIC_DISPLAY_COLUMN = 2,
-  DIAGNOSTIC_DISPLAY_SOURCE_RANGES = 4,
-  DIAGNOSTIC_DISPLAY_OPTION = 8,
-  DIAGNOSTIC_DISPLAY_CATEGORY_ID = 16,
-  DIAGNOSTIC_DISPLAY_CATEGORY_NAME = 32
+
+	<*
+		Display the source-location information where the
+		diagnostic was located.
+		When set, diagnostics will be prefixed by the file, line, and
+		(optionally) column to which the diagnostic refers. For example,
+		\code
+		test.c:28: warning: extra tokens at end of #endif directive
+		\endcode
+		This option corresponds to the clang flag \c -fshow-source-location.
+	*>
+	DIAGNOSTIC_DISPLAY_SOURCE_LOCATION = 1,
+
+	<*
+		If displaying the source-location information of the
+		diagnostic, also include the column number.
+		This option corresponds to the clang flag \c -fshow-column.
+	*>
+	DIAGNOSTIC_DISPLAY_COLUMN = 2,
+
+	<*
+		If displaying the source-location information of the
+		diagnostic, also include information about source ranges in a
+		machine-parsable format.
+		This option corresponds to the clang flag
+		\c -fdiagnostics-print-source-range-info.
+	*>
+	DIAGNOSTIC_DISPLAY_SOURCE_RANGES = 4,
+
+	<*
+		Display the option name associated with this diagnostic, if any.
+		The option name displayed (e.g., -Wconversion) will be placed in brackets
+		after the diagnostic text. This option corresponds to the clang flag
+		\c -fdiagnostics-show-option.
+	*>
+	DIAGNOSTIC_DISPLAY_OPTION = 8,
+
+	<*
+		Display the category number associated with this diagnostic, if any.
+		The category number is displayed within brackets after the diagnostic text.
+		This option corresponds to the clang flag
+		\c -fdiagnostics-show-category=id.
+	*>
+	DIAGNOSTIC_DISPLAY_CATEGORY_ID = 16,
+
+	<*
+		Display the category name associated with this diagnostic, if any.
+		The category name is displayed within brackets after the diagnostic text.
+		This option corresponds to the clang flag
+		\c -fdiagnostics-show-category=name.
+	*>
+	DIAGNOSTIC_DISPLAY_CATEGORY_NAME = 32
 }
 
+<*
+	Format the given diagnostic in a manner that is suitable for display.
+	This routine will format the given diagnostic to a string, rendering
+	the diagnostic according to the various options given. The
+	\c clang_defaultDiagnosticDisplayOptions() function returns the set of
+	options that most closely mimics the behavior of the clang compiler.
+	\param Diagnostic The diagnostic to print.
+	\param Options A set of options that control the diagnostic display,
+	created by combining \c CXDiagnosticDisplayOptions values.
+	\returns A new string containing for formatted diagnostic.
+*>
 extern fn CXString formatDiagnostic(
-  CXDiagnostic diagnostic,
-  CUInt options)
+	CXDiagnostic diagnostic,
+	CUInt options)
 @cname("clang_formatDiagnostic");
 
+<*
+	Retrieve the set of display options most similar to the
+	default behavior of the clang compiler.
+	\returns A set of display options suitable for use with \c
+	clang_formatDiagnostic().
+*>
 extern fn CUInt defaultDiagnosticDisplayOptions()
 @cname("clang_defaultDiagnosticDisplayOptions");
 
+<*
+	Determine the severity of the given diagnostic.
+*>
 extern fn CXDiagnosticSeverity getDiagnosticSeverity(
-  CXDiagnostic)
+	CXDiagnostic)
 @cname("clang_getDiagnosticSeverity");
 
+<*
+	Retrieve the source location of the given diagnostic.
+	This location is where Clang would print the caret ('^') when
+	displaying the diagnostic on the command line.
+*>
 extern fn CXSourceLocation getDiagnosticLocation(
-  CXDiagnostic)
+	CXDiagnostic)
 @cname("clang_getDiagnosticLocation");
 
+<*
+	Retrieve the text of the given diagnostic.
+*>
 extern fn CXString getDiagnosticSpelling(
-  CXDiagnostic)
+	CXDiagnostic)
 @cname("clang_getDiagnosticSpelling");
 
+<*
+	Retrieve the name of the command-line option that enabled this
+	diagnostic.
+	\param Diag The diagnostic to be queried.
+	\param Disable If non-NULL, will be set to the option that disables this
+	diagnostic (if any).
+	\returns A string that contains the command-line option used to enable this
+	warning, such as "-Wconversion" or "-pedantic".
+*>
 extern fn CXString getDiagnosticOption(
-  CXDiagnostic diag,
-  CXString* disable)
+	CXDiagnostic diag,
+	CXString* disable)
 @cname("clang_getDiagnosticOption");
 
+<*
+	Retrieve the category number for this diagnostic.
+	Diagnostics can be categorized into groups along with other, related
+	diagnostics (e.g., diagnostics under the same warning flag). This routine
+	retrieves the category number for the given diagnostic.
+	\returns The number of the category that contains this diagnostic, or zero
+	if this diagnostic is uncategorized.
+*>
 extern fn CUInt getDiagnosticCategory(
-  CXDiagnostic)
+	CXDiagnostic)
 @cname("clang_getDiagnosticCategory");
 
+<*
+	Retrieve the name of a particular diagnostic category.  This
+	is now deprecated.  Use clang_getDiagnosticCategoryText()
+	instead.
+	\param Category A diagnostic category number, as returned by
+	\c clang_getDiagnosticCategory().
+	\returns The name of the given diagnostic category.
+*>
 extern fn CXString getDiagnosticCategoryName(
-  CUInt category)
+	CUInt category)
 @cname("clang_getDiagnosticCategoryName");
 
+<*
+	Retrieve the diagnostic category text for a given diagnostic.
+	\returns The text of the given diagnostic category.
+*>
 extern fn CXString getDiagnosticCategoryText(
-  CXDiagnostic)
+	CXDiagnostic)
 @cname("clang_getDiagnosticCategoryText");
 
+<*
+	Determine the number of source ranges associated with the given
+	diagnostic.
+*>
 extern fn CUInt getDiagnosticNumRanges(
-  CXDiagnostic)
+	CXDiagnostic)
 @cname("clang_getDiagnosticNumRanges");
 
+<*
+	Retrieve a source range associated with the diagnostic.
+	A diagnostic's source ranges highlight important elements in the source
+	code. On the command line, Clang displays source ranges by
+	underlining them with '~' characters.
+	\param Diagnostic the diagnostic whose range is being extracted.
+	\param Range the zero-based index specifying which range to
+	\returns the requested source range.
+*>
 extern fn CXSourceRange getDiagnosticRange(
-  CXDiagnostic diagnostic,
-  CUInt range)
+	CXDiagnostic diagnostic,
+	CUInt range)
 @cname("clang_getDiagnosticRange");
 
+<*
+	Determine the number of fix-it hints associated with the
+	given diagnostic.
+*>
 extern fn CUInt getDiagnosticNumFixIts(
-  CXDiagnostic diagnostic)
+	CXDiagnostic diagnostic)
 @cname("clang_getDiagnosticNumFixIts");
 
+<*
+	Retrieve the replacement information for a given fix-it.
+	Fix-its are described in terms of a source range whose contents
+	should be replaced by a string. This approach generalizes over
+	three kinds of operations: removal of source code (the range covers
+	the code to be removed and the replacement string is empty),
+	replacement of source code (the range covers the code to be
+	replaced and the replacement string provides the new code), and
+	insertion (both the start and end of the range point at the
+	insertion location, and the replacement string provides the text to
+	insert).
+	\param Diagnostic The diagnostic whose fix-its are being queried.
+	\param FixIt The zero-based index of the fix-it.
+	\param ReplacementRange The source range whose contents will be
+	replaced with the returned replacement string. Note that source
+	ranges are half-open ranges [a, b), so the source code should be
+	replaced from a and up to (but not including) b.
+	\returns A string containing text that should be replace the source
+	code indicated by the \c ReplacementRange.
+*>
 extern fn CXString getDiagnosticFixIt(
-  CXDiagnostic diagnostic,
-  CUInt fix_it,
-  CXSourceRange* replacement_range)
+	CXDiagnostic diagnostic,
+	CUInt fix_it,
+	CXSourceRange* replacement_range)
 @cname("clang_getDiagnosticFixIt");
 
 alias CXIndex = void*;
@@ -346,2228 +854,7177 @@ alias CXTranslationUnit = void*;
 
 alias CXClientData = void*;
 
+<*
+	Provides the contents of a file that has not yet been saved to disk.
+	Each CXUnsavedFile instance provides the name of a file on the
+	system along with the current contents of that file that have not
+	yet been saved to disk.
+*>
 struct CXUnsavedFile {
-  ZString filename;
-  ZString contents;
-  CULong length;
+	ZString filename;
+	ZString contents;
+	CULong length;
 }
 
+<*
+	Describes the availability of a particular entity, which indicates
+	whether the use of this entity will result in a warning or error due to
+	it being deprecated or unavailable.
+*>
 constdef CXAvailabilityKind : CInt {
-  AVAILABILITY_AVAILABLE = 0,
-  AVAILABILITY_DEPRECATED = 1,
-  AVAILABILITY_NOT_AVAILABLE = 2,
-  AVAILABILITY_NOT_ACCESSIBLE = 3
+
+	<*
+		The entity is available.
+	*>
+	AVAILABILITY_AVAILABLE = 0,
+
+	<*
+		The entity is available, but has been deprecated (and its use is
+		not recommended).
+	*>
+	AVAILABILITY_DEPRECATED = 1,
+
+	<*
+		The entity is not available; any use of it will be an error.
+	*>
+	AVAILABILITY_NOT_AVAILABLE = 2,
+
+	<*
+		The entity is available, but not accessible; any use of it will be
+		an error.
+	*>
+	AVAILABILITY_NOT_ACCESSIBLE = 3
 }
 
+<*
+	Describes a version number of the form major.minor.subminor.
+*>
 struct CXVersion {
-  CInt major;
-  CInt minor;
-  CInt subminor;
+	CInt major;
+	CInt minor;
+	CInt subminor;
 }
 
+<*
+	Describes the exception specification of a cursor.
+	A negative value indicates that the cursor is not a function declaration.
+*>
 constdef CXCursor_ExceptionSpecificationKind : CInt {
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_NONE = 0,
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC_NONE = 1,
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC = 2,
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_MS_ANY = 3,
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_BASIC_NOEXCEPT = 4,
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_COMPUTED_NOEXCEPT = 5,
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_UNEVALUATED = 6,
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_UNINSTANTIATED = 7,
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_UNPARSED = 8,
-  CURSOR_EXCEPTION_SPECIFICATION_KIND_NO_THROW = 9
+
+	<*
+		The cursor has no exception specification.
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_NONE = 0,
+
+	<*
+		The cursor has exception specification throw()
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC_NONE = 1,
+
+	<*
+		The cursor has exception specification throw(T1, T2)
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC = 2,
+
+	<*
+		The cursor has exception specification throw(...).
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_MS_ANY = 3,
+
+	<*
+		The cursor has exception specification basic noexcept.
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_BASIC_NOEXCEPT = 4,
+
+	<*
+		The cursor has exception specification computed noexcept.
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_COMPUTED_NOEXCEPT = 5,
+
+	<*
+		The exception specification has not yet been evaluated.
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_UNEVALUATED = 6,
+
+	<*
+		The exception specification has not yet been instantiated.
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_UNINSTANTIATED = 7,
+
+	<*
+		The exception specification has not been parsed yet.
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_UNPARSED = 8,
+
+	<*
+		The cursor has a __declspec(nothrow) exception specification.
+	*>
+	CURSOR_EXCEPTION_SPECIFICATION_KIND_NO_THROW = 9
 }
 
+<*
+	Provides a shared context for creating translation units.
+	It provides two options:
+	- excludeDeclarationsFromPCH: When non-zero, allows enumeration of "local"
+	declarations (when loading any new translation units). A "local" declaration
+	is one that belongs in the translation unit itself and not in a precompiled
+	header that was used by the translation unit. If zero, all declarations
+	will be enumerated.
+	Here is an example:
+	\code
+	// excludeDeclsFromPCH = 1, displayDiagnostics=1
+	Idx = clang_createIndex(1, 1);
+	// IndexTest.pch was produced with the following command:
+	// "clang -x c IndexTest.h -emit-ast -o IndexTest.pch"
+	TU = clang_createTranslationUnit(Idx, "IndexTest.pch");
+	// This will load all the symbols from 'IndexTest.pch'
+	clang_visitChildren(clang_getTranslationUnitCursor(TU),
+	TranslationUnitVisitor, 0);
+	clang_disposeTranslationUnit(TU);
+	// This will load all the symbols from 'IndexTest.c', excluding symbols
+	// from 'IndexTest.pch'.
+	char *args[] = { "-Xclang", "-include-pch=IndexTest.pch" };
+	TU = clang_createTranslationUnitFromSourceFile(Idx, "IndexTest.c", 2, args,
+	0, 0);
+	clang_visitChildren(clang_getTranslationUnitCursor(TU),
+	TranslationUnitVisitor, 0);
+	clang_disposeTranslationUnit(TU);
+	\endcode
+	This process of creating the 'pch', loading it separately, and using it (via
+	-include-pch) allows 'excludeDeclsFromPCH' to remove redundant callbacks
+	(which gives the indexer the same performance benefit as the compiler).
+*>
 extern fn CXIndex createIndex(
-  CInt exclude_declarations_from_pch,
-  CInt display_diagnostics)
+	CInt exclude_declarations_from_pch,
+	CInt display_diagnostics)
 @cname("clang_createIndex");
 
+<*
+	Destroy the given index.
+	The index must not be destroyed until all of the translation units created
+	within that index have been destroyed.
+*>
 extern fn void disposeIndex(
-  CXIndex index)
+	CXIndex index)
 @cname("clang_disposeIndex");
 
+
 constdef CXChoice : CInt {
-  CHOICE_DEFAULT = 0,
-  CHOICE_ENABLED = 1,
-  CHOICE_DISABLED = 2
+
+	<*
+		Use the default value of an option that may depend on the process
+		environment.
+	*>
+	CHOICE_DEFAULT = 0,
+
+	<*
+		Enable the option.
+	*>
+	CHOICE_ENABLED = 1,
+
+	<*
+		Disable the option.
+	*>
+	CHOICE_DISABLED = 2
 }
+
 
 constdef CXGlobalOptFlags : CInt {
-  GLOBAL_OPT_NONE = 0,
-  GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_INDEXING = 1,
-  GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_EDITING = 2,
-  GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_ALL = 3
+
+	<*
+		Used to indicate that no special CXIndex options are needed.
+	*>
+	GLOBAL_OPT_NONE = 0,
+
+	<*
+		Used to indicate that threads that libclang creates for indexing
+		purposes should use background priority.
+		Affects #clang_indexSourceFile, #clang_indexTranslationUnit,
+		#clang_parseTranslationUnit, #clang_saveTranslationUnit.
+	*>
+	GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_INDEXING = 1,
+
+	<*
+		Used to indicate that threads that libclang creates for editing
+		purposes should use background priority.
+		Affects #clang_reparseTranslationUnit, #clang_codeCompleteAt,
+		#clang_annotateTokens
+	*>
+	GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_EDITING = 2,
+
+	<*
+		Used to indicate that all threads that libclang creates should use
+		background priority.
+	*>
+	GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_ALL = 3
 }
 
+<*
+	Index initialization options.
+	0 is the default value of each member of this struct except for Size.
+	Initialize the struct in one of the following three ways to avoid adapting
+	code each time a new member is added to it:
+	\code
+	CXIndexOptions Opts;
+	memset(&Opts, 0, sizeof(Opts));
+	Opts.Size = sizeof(CXIndexOptions);
+	\endcode
+	or explicitly initialize the first data member and zero-initialize the rest:
+	\code
+	CXIndexOptions Opts = { sizeof(CXIndexOptions) };
+	\endcode
+	or to prevent the -Wmissing-field-initializers warning for the above version:
+	\code
+	CXIndexOptions Opts{};
+	Opts.Size = sizeof(CXIndexOptions);
+	\endcode
+*>
 struct CXIndexOptions {
-  CUInt size;
-  char thread_background_priority_for_indexing;
-  char thread_background_priority_for_editing;
-  bitstruct : ushort {
-    CUInt exclude_declarations_from_pch : 0..0;
-    CUInt display_diagnostics : 1..1;
-    CUInt store_preambles_in_memory : 2..2;
-    CUInt x : 3..15;
-  }
-  ZString* preamble_storage_path;
-  ZString* invocation_emission_path;
+	CUInt size;
+	char thread_background_priority_for_indexing;
+	char thread_background_priority_for_editing;
+	bitstruct : ushort {
+		CUInt exclude_declarations_from_pch : 0..0;
+		CUInt display_diagnostics : 1..1;
+		CUInt store_preambles_in_memory : 2..2;
+		CUInt x : 3..15;
+	}
+	ZString preamble_storage_path;
+	ZString invocation_emission_path;
 }
 
+<*
+	Provides a shared context for creating translation units.
+	Call this function instead of clang_createIndex() if you need to configure
+	the additional options in CXIndexOptions.
+	\returns The created index or null in case of error, such as an unsupported
+	value of options->Size.
+	For example:
+	\code
+	CXIndex createIndex(const char *ApplicationTemporaryPath) {
+	const int ExcludeDeclarationsFromPCH = 1;
+	const int DisplayDiagnostics = 1;
+	CXIndex Idx;
+	#if CINDEX_VERSION_MINOR >= 64
+	CXIndexOptions Opts;
+	memset(&Opts, 0, sizeof(Opts));
+	Opts.Size = sizeof(CXIndexOptions);
+	Opts.ThreadBackgroundPriorityForIndexing = 1;
+	Opts.ExcludeDeclarationsFromPCH = ExcludeDeclarationsFromPCH;
+	Opts.DisplayDiagnostics = DisplayDiagnostics;
+	Opts.PreambleStoragePath = ApplicationTemporaryPath;
+	Idx = clang_createIndexWithOptions(&Opts);
+	if (Idx)
+	return Idx;
+	fprintf(stderr,
+	"clang_createIndexWithOptions() failed. "
+	"CINDEX_VERSION_MINOR = %d, sizeof(CXIndexOptions) = %u\n",
+	CINDEX_VERSION_MINOR, Opts.Size);
+	#else
+	(void)ApplicationTemporaryPath;
+	#endif
+	Idx = clang_createIndex(ExcludeDeclarationsFromPCH, DisplayDiagnostics);
+	clang_CXIndex_setGlobalOptions(
+	Idx, clang_CXIndex_getGlobalOptions(Idx) |
+	CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
+	return Idx;
+	}
+	\endcode
+	\sa clang_createIndex()
+*>
 extern fn CXIndex createIndexWithOptions(
-  CXIndexOptions* options)
+	CXIndexOptions* options)
 @cname("clang_createIndexWithOptions");
 
+<*
+	Sets general options associated with a CXIndex.
+	This function is DEPRECATED. Set
+	CXIndexOptions::ThreadBackgroundPriorityForIndexing and/or
+	CXIndexOptions::ThreadBackgroundPriorityForEditing and call
+	clang_createIndexWithOptions() instead.
+	For example:
+	\code
+	CXIndex idx = ...;
+	clang_CXIndex_setGlobalOptions(idx,
+	clang_CXIndex_getGlobalOptions(idx) |
+	CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
+	\endcode
+	\param options A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags.
+*>
 extern fn void cXIndex_setGlobalOptions(
-  CXIndex,
-  CUInt options)
+	CXIndex,
+	CUInt options)
 @cname("clang_CXIndex_setGlobalOptions");
 
+<*
+	Gets the general options associated with a CXIndex.
+	This function allows to obtain the final option values used by libclang after
+	specifying the option policies via CXChoice enumerators.
+	\returns A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags that
+	are associated with the given CXIndex object.
+*>
 extern fn CUInt cXIndex_getGlobalOptions(
-  CXIndex)
+	CXIndex)
 @cname("clang_CXIndex_getGlobalOptions");
 
+<*
+	Sets the invocation emission path option in a CXIndex.
+	This function is DEPRECATED. Set CXIndexOptions::InvocationEmissionPath and
+	call clang_createIndexWithOptions() instead.
+	The invocation emission path specifies a path which will contain log
+	files for certain libclang invocations. A null value (default) implies that
+	libclang invocations are not logged..
+*>
 extern fn void cXIndex_setInvocationEmissionPathOption(
-  CXIndex,
-  ZString* path)
+	CXIndex,
+	ZString path)
 @cname("clang_CXIndex_setInvocationEmissionPathOption");
 
+<*
+	Determine whether the given header is guarded against
+	multiple inclusions, either with the conventional
+	\#ifndef/\#define/\#endif macro guards or with \#pragma once.
+*>
 extern fn CUInt isFileMultipleIncludeGuarded(
-  CXTranslationUnit tu,
-  CXFile file)
+	CXTranslationUnit tu,
+	CXFile file)
 @cname("clang_isFileMultipleIncludeGuarded");
 
+<*
+	Retrieve a file handle within the given translation unit.
+	\param tu the translation unit
+	\param file_name the name of the file.
+	\returns the file handle for the named file in the translation unit \p tu,
+	or a NULL file handle if the file was not a part of this translation unit.
+*>
 extern fn CXFile getFile(
-  CXTranslationUnit tu,
-  ZString file_name)
+	CXTranslationUnit tu,
+	ZString file_name)
 @cname("clang_getFile");
 
+<*
+	Retrieve the buffer associated with the given file.
+	\param tu the translation unit
+	\param file the file for which to retrieve the buffer.
+	\param size [out] if non-NULL, will be set to the size of the buffer.
+	\returns a pointer to the buffer in memory that holds the contents of
+	\p file, or a NULL pointer when the file is not loaded.
+*>
 extern fn ZString getFileContents(
-  CXTranslationUnit tu,
-  CXFile file,
-  usz* size)
+	CXTranslationUnit tu,
+	CXFile file,
+	sz* size)
 @cname("clang_getFileContents");
 
+<*
+	Retrieves the source location associated with a given file/line/column
+	in a particular translation unit.
+*>
 extern fn CXSourceLocation getLocation(
-  CXTranslationUnit tu,
-  CXFile file,
-  CUInt line,
-  CUInt column)
+	CXTranslationUnit tu,
+	CXFile file,
+	CUInt line,
+	CUInt column)
 @cname("clang_getLocation");
 
+<*
+	Retrieves the source location associated with a given character offset
+	in a particular translation unit.
+*>
 extern fn CXSourceLocation getLocationForOffset(
-  CXTranslationUnit tu,
-  CXFile file,
-  CUInt offset)
+	CXTranslationUnit tu,
+	CXFile file,
+	CUInt offset)
 @cname("clang_getLocationForOffset");
 
+<*
+	Retrieve all ranges that were skipped by the preprocessor.
+	The preprocessor will skip lines when they are surrounded by an
+	if/ifdef/ifndef directive whose condition does not evaluate to true.
+*>
 extern fn CXSourceRangeList* getSkippedRanges(
-  CXTranslationUnit tu,
-  CXFile file)
+	CXTranslationUnit tu,
+	CXFile file)
 @cname("clang_getSkippedRanges");
 
+<*
+	Retrieve all ranges from all files that were skipped by the
+	preprocessor.
+	The preprocessor will skip lines when they are surrounded by an
+	if/ifdef/ifndef directive whose condition does not evaluate to true.
+*>
 extern fn CXSourceRangeList* getAllSkippedRanges(
-  CXTranslationUnit tu)
+	CXTranslationUnit tu)
 @cname("clang_getAllSkippedRanges");
 
+<*
+	Determine the number of diagnostics produced for the given
+	translation unit.
+*>
 extern fn CUInt getNumDiagnostics(
-  CXTranslationUnit unit)
+	CXTranslationUnit unit)
 @cname("clang_getNumDiagnostics");
 
+<*
+	Retrieve a diagnostic associated with the given translation unit.
+	\param Unit the translation unit to query.
+	\param Index the zero-based diagnostic number to retrieve.
+	\returns the requested diagnostic. This diagnostic must be freed
+	via a call to \c clang_disposeDiagnostic().
+*>
 extern fn CXDiagnostic getDiagnostic(
-  CXTranslationUnit unit,
-  CUInt index)
+	CXTranslationUnit unit,
+	CUInt index)
 @cname("clang_getDiagnostic");
 
+<*
+	Retrieve the complete set of diagnostics associated with a
+	translation unit.
+	\param Unit the translation unit to query.
+*>
 extern fn CXDiagnosticSet getDiagnosticSetFromTU(
-  CXTranslationUnit unit)
+	CXTranslationUnit unit)
 @cname("clang_getDiagnosticSetFromTU");
 
+<*
+	Get the original translation unit source file name.
+*>
 extern fn CXString getTranslationUnitSpelling(
-  CXTranslationUnit ct_unit)
+	CXTranslationUnit ct_unit)
 @cname("clang_getTranslationUnitSpelling");
 
+<*
+	Return the CXTranslationUnit for a given source file and the provided
+	command line arguments one would pass to the compiler.
+	Note: The 'source_filename' argument is optional.  If the caller provides a
+	NULL pointer, the name of the source file is expected to reside in the
+	specified command line arguments.
+	Note: When encountered in 'clang_command_line_args', the following options
+	are ignored:
+	'-c'
+	'-emit-ast'
+	'-fsyntax-only'
+	'-o \<output file>'  (both '-o' and '\<output file>' are ignored)
+	\param CIdx The index object with which the translation unit will be
+	associated.
+	\param source_filename The name of the source file to load, or NULL if the
+	source file is included in \p clang_command_line_args.
+	\param num_clang_command_line_args The number of command-line arguments in
+	\p clang_command_line_args.
+	\param clang_command_line_args The command-line arguments that would be
+	passed to the \c clang executable if it were being invoked out-of-process.
+	These command-line options will be parsed and will affect how the translation
+	unit is parsed. Note that the following options are ignored: '-c',
+	'-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
+	\param num_unsaved_files the number of unsaved file entries in \p
+	unsaved_files.
+	\param unsaved_files the files that have not yet been saved to disk
+	but may be required for code completion, including the contents of
+	those files.  The contents and name of these files (as specified by
+	CXUnsavedFile) are copied when necessary, so the client only needs to
+	guarantee their validity until the call to this function returns.
+*>
 extern fn CXTranslationUnit createTranslationUnitFromSourceFile(
-  CXIndex c_idx,
-  ZString source_filename,
-  CInt num_clang_command_line_args,
-  ZString* clang_command_line_args,
-  CUInt num_unsaved_files,
-  CXUnsavedFile* unsaved_files)
+	CXIndex c_idx,
+	ZString source_filename,
+	CInt num_clang_command_line_args,
+	ZString* clang_command_line_args,
+	CUInt num_unsaved_files,
+	CXUnsavedFile* unsaved_files)
 @cname("clang_createTranslationUnitFromSourceFile");
 
+<*
+	Same as \c clang_createTranslationUnit2, but returns
+	the \c CXTranslationUnit instead of an error code.  In case of an error this
+	routine returns a \c NULL \c CXTranslationUnit, without further detailed
+	error codes.
+*>
 extern fn CXTranslationUnit createTranslationUnit(
-  CXIndex c_idx,
-  ZString ast_filename)
+	CXIndex c_idx,
+	ZString ast_filename)
 @cname("clang_createTranslationUnit");
 
+<*
+	Create a translation unit from an AST file (\c -emit-ast).
+	\param[out] out_TU A non-NULL pointer to store the created
+	\c CXTranslationUnit.
+	\returns Zero on success, otherwise returns an error code.
+*>
 extern fn CXErrorCode createTranslationUnit2(
-  CXIndex c_idx,
-  ZString ast_filename,
-  CXTranslationUnit* out_tu)
+	CXIndex c_idx,
+	ZString ast_filename,
+	CXTranslationUnit* out_tu)
 @cname("clang_createTranslationUnit2");
 
+<*
+	Flags that control the creation of translation units.
+	The enumerators in this enumeration type are meant to be bitwise
+	ORed together to specify which options should be used when
+	constructing the translation unit.
+*>
 constdef CXTranslationUnit_Flags : CInt {
-  TRANSLATION_UNIT_NONE = 0,
-  TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD = 1,
-  TRANSLATION_UNIT_INCOMPLETE = 2,
-  TRANSLATION_UNIT_PRECOMPILED_PREAMBLE = 4,
-  TRANSLATION_UNIT_CACHE_COMPLETION_RESULTS = 8,
-  TRANSLATION_UNIT_FOR_SERIALIZATION = 16,
-  TRANSLATION_UNIT_CXX_CHAINED_PCH = 32,
-  TRANSLATION_UNIT_SKIP_FUNCTION_BODIES = 64,
-  TRANSLATION_UNIT_INCLUDE_BRIEF_COMMENTS_IN_CODE_COMPLETION = 128,
-  TRANSLATION_UNIT_CREATE_PREAMBLE_ON_FIRST_PARSE = 256,
-  TRANSLATION_UNIT_KEEP_GOING = 512,
-  TRANSLATION_UNIT_SINGLE_FILE_PARSE = 1024,
-  TRANSLATION_UNIT_LIMIT_SKIP_FUNCTION_BODIES_TO_PREAMBLE = 2048,
-  TRANSLATION_UNIT_INCLUDE_ATTRIBUTED_TYPES = 4096,
-  TRANSLATION_UNIT_VISIT_IMPLICIT_ATTRIBUTES = 8192,
-  TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES = 16384,
-  TRANSLATION_UNIT_RETAIN_EXCLUDED_CONDITIONAL_BLOCKS = 32768
+
+	<*
+		Used to indicate that no special translation-unit options are
+		needed.
+	*>
+	TRANSLATION_UNIT_NONE = 0,
+
+	<*
+		Used to indicate that the parser should construct a "detailed"
+		preprocessing record, including all macro definitions and instantiations.
+		Constructing a detailed preprocessing record requires more memory
+		and time to parse, since the information contained in the record
+		is usually not retained. However, it can be useful for
+		applications that require more detailed information about the
+		behavior of the preprocessor.
+	*>
+	TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD = 1,
+
+	<*
+		Used to indicate that the translation unit is incomplete.
+		When a translation unit is considered "incomplete", semantic
+		analysis that is typically performed at the end of the
+		translation unit will be suppressed. For example, this suppresses
+		the completion of tentative declarations in C and of
+		instantiation of implicitly-instantiation function templates in
+		C++. This option is typically used when parsing a header with the
+		intent of producing a precompiled header.
+	*>
+	TRANSLATION_UNIT_INCOMPLETE = 2,
+
+	<*
+		Used to indicate that the translation unit should be built with an
+		implicit precompiled header for the preamble.
+		An implicit precompiled header is used as an optimization when a
+		particular translation unit is likely to be reparsed many times
+		when the sources aren't changing that often. In this case, an
+		implicit precompiled header will be built containing all of the
+		initial includes at the top of the main file (what we refer to as
+		the "preamble" of the file). In subsequent parses, if the
+		preamble or the files in it have not changed, \c
+		clang_reparseTranslationUnit() will re-use the implicit
+		precompiled header to improve parsing performance.
+	*>
+	TRANSLATION_UNIT_PRECOMPILED_PREAMBLE = 4,
+
+	<*
+		Used to indicate that the translation unit should cache some
+		code-completion results with each reparse of the source file.
+		Caching of code-completion results is a performance optimization that
+		introduces some overhead to reparsing but improves the performance of
+		code-completion operations.
+	*>
+	TRANSLATION_UNIT_CACHE_COMPLETION_RESULTS = 8,
+
+	<*
+		Used to indicate that the translation unit will be serialized with
+		\c clang_saveTranslationUnit.
+		This option is typically used when parsing a header with the intent of
+		producing a precompiled header.
+	*>
+	TRANSLATION_UNIT_FOR_SERIALIZATION = 16,
+
+	<*
+		DEPRECATED: Enabled chained precompiled preambles in C++.
+		Note: this is a *temporary* option that is available only while
+		we are testing C++ precompiled preamble support. It is deprecated.
+	*>
+	TRANSLATION_UNIT_CXX_CHAINED_PCH = 32,
+
+	<*
+		Used to indicate that function/method bodies should be skipped while
+		parsing.
+		This option can be used to search for declarations/definitions while
+		ignoring the usages.
+	*>
+	TRANSLATION_UNIT_SKIP_FUNCTION_BODIES = 64,
+
+	<*
+		Used to indicate that brief documentation comments should be
+		included into the set of code completions returned from this translation
+		unit.
+	*>
+	TRANSLATION_UNIT_INCLUDE_BRIEF_COMMENTS_IN_CODE_COMPLETION = 128,
+
+	<*
+		Used to indicate that the precompiled preamble should be created on
+		the first parse. Otherwise it will be created on the first reparse. This
+		trades runtime on the first parse (serializing the preamble takes time) for
+		reduced runtime on the second parse (can now reuse the preamble).
+	*>
+	TRANSLATION_UNIT_CREATE_PREAMBLE_ON_FIRST_PARSE = 256,
+
+	<*
+		Do not stop processing when fatal errors are encountered.
+		When fatal errors are encountered while parsing a translation unit,
+		semantic analysis is typically stopped early when compiling code. A common
+		source for fatal errors are unresolvable include files. For the
+		purposes of an IDE, this is undesirable behavior and as much information
+		as possible should be reported. Use this flag to enable this behavior.
+	*>
+	TRANSLATION_UNIT_KEEP_GOING = 512,
+
+	<*
+		Sets the preprocessor in a mode for parsing a single file only.
+	*>
+	TRANSLATION_UNIT_SINGLE_FILE_PARSE = 1024,
+
+	<*
+		Used in combination with CXTranslationUnit_SkipFunctionBodies to
+		constrain the skipping of function bodies to the preamble.
+		The function bodies of the main file are not skipped.
+	*>
+	TRANSLATION_UNIT_LIMIT_SKIP_FUNCTION_BODIES_TO_PREAMBLE = 2048,
+
+	<*
+		Used to indicate that attributed types should be included in CXType.
+	*>
+	TRANSLATION_UNIT_INCLUDE_ATTRIBUTED_TYPES = 4096,
+
+	<*
+		Used to indicate that implicit attributes should be visited.
+	*>
+	TRANSLATION_UNIT_VISIT_IMPLICIT_ATTRIBUTES = 8192,
+
+	<*
+		Used to indicate that non-errors from included files should be ignored.
+		If set, clang_getDiagnosticSetFromTU() will not report e.g. warnings from
+		included files anymore. This speeds up clang_getDiagnosticSetFromTU() for
+		the case where these warnings are not of interest, as for an IDE for
+		example, which typically shows only the diagnostics in the main file.
+	*>
+	TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES = 16384,
+
+	<*
+		Tells the preprocessor not to skip excluded conditional blocks.
+	*>
+	TRANSLATION_UNIT_RETAIN_EXCLUDED_CONDITIONAL_BLOCKS = 32768
 }
 
+<*
+	Returns the set of flags that is suitable for parsing a translation
+	unit that is being edited.
+	The set of flags returned provide options for \c clang_parseTranslationUnit()
+	to indicate that the translation unit is likely to be reparsed many times,
+	either explicitly (via \c clang_reparseTranslationUnit()) or implicitly
+	(e.g., by code completion (\c clang_codeCompletionAt())). The returned flag
+	set contains an unspecified set of optimizations (e.g., the precompiled
+	preamble) geared toward improving the performance of these routines. The
+	set of optimizations enabled may change from one version to the next.
+*>
 extern fn CUInt defaultEditingTranslationUnitOptions()
 @cname("clang_defaultEditingTranslationUnitOptions");
 
+<*
+	Same as \c clang_parseTranslationUnit2, but returns
+	the \c CXTranslationUnit instead of an error code.  In case of an error this
+	routine returns a \c NULL \c CXTranslationUnit, without further detailed
+	error codes.
+*>
 extern fn CXTranslationUnit parseTranslationUnit(
-  CXIndex c_idx,
-  ZString source_filename,
-  ZString* command_line_args,
-  CInt num_command_line_args,
-  CXUnsavedFile* unsaved_files,
-  CUInt num_unsaved_files,
-  CUInt options)
+	CXIndex c_idx,
+	ZString source_filename,
+	ZString* command_line_args,
+	CInt num_command_line_args,
+	CXUnsavedFile* unsaved_files,
+	CUInt num_unsaved_files,
+	CUInt options)
 @cname("clang_parseTranslationUnit");
 
+<*
+	Parse the given source file and the translation unit corresponding
+	to that file.
+	This routine is the main entry point for the Clang C API, providing the
+	ability to parse a source file into a translation unit that can then be
+	queried by other functions in the API. This routine accepts a set of
+	command-line arguments so that the compilation can be configured in the same
+	way that the compiler is configured on the command line.
+	\param CIdx The index object with which the translation unit will be
+	associated.
+	\param source_filename The name of the source file to load, or NULL if the
+	source file is included in \c command_line_args.
+	\param command_line_args The command-line arguments that would be
+	passed to the \c clang executable if it were being invoked out-of-process.
+	These command-line options will be parsed and will affect how the translation
+	unit is parsed. Note that the following options are ignored: '-c',
+	'-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
+	\param num_command_line_args The number of command-line arguments in
+	\c command_line_args.
+	\param unsaved_files the files that have not yet been saved to disk
+	but may be required for parsing, including the contents of
+	those files.  The contents and name of these files (as specified by
+	CXUnsavedFile) are copied when necessary, so the client only needs to
+	guarantee their validity until the call to this function returns.
+	\param num_unsaved_files the number of unsaved file entries in \p
+	unsaved_files.
+	\param options A bitmask of options that affects how the translation unit
+	is managed but not its compilation. This should be a bitwise OR of the
+	CXTranslationUnit_XXX flags.
+	\param[out] out_TU A non-NULL pointer to store the created
+	\c CXTranslationUnit, describing the parsed code and containing any
+	diagnostics produced by the compiler.
+	\returns Zero on success, otherwise returns an error code.
+*>
 extern fn CXErrorCode parseTranslationUnit2(
-  CXIndex c_idx,
-  ZString source_filename,
-  ZString* command_line_args,
-  CInt num_command_line_args,
-  CXUnsavedFile* unsaved_files,
-  CUInt num_unsaved_files,
-  CUInt options,
-  CXTranslationUnit* out_tu)
+	CXIndex c_idx,
+	ZString source_filename,
+	ZString* command_line_args,
+	CInt num_command_line_args,
+	CXUnsavedFile* unsaved_files,
+	CUInt num_unsaved_files,
+	CUInt options,
+	CXTranslationUnit* out_tu)
 @cname("clang_parseTranslationUnit2");
 
+<*
+	Same as clang_parseTranslationUnit2 but requires a full command line
+	for \c command_line_args including argv[0]. This is useful if the standard
+	library paths are relative to the binary.
+*>
 extern fn CXErrorCode parseTranslationUnit2FullArgv(
-  CXIndex c_idx,
-  ZString source_filename,
-  CChar** command_line_args,
-  CInt num_command_line_args,
-  CXUnsavedFile* unsaved_files,
-  CUInt num_unsaved_files,
-  CUInt options,
-  CXTranslationUnit* out_tu)
+	CXIndex c_idx,
+	ZString source_filename,
+	ZString* command_line_args,
+	CInt num_command_line_args,
+	CXUnsavedFile* unsaved_files,
+	CUInt num_unsaved_files,
+	CUInt options,
+	CXTranslationUnit* out_tu)
 @cname("clang_parseTranslationUnit2FullArgv");
 
+<*
+	Flags that control how translation units are saved.
+	The enumerators in this enumeration type are meant to be bitwise
+	ORed together to specify which options should be used when
+	saving the translation unit.
+*>
 constdef CXSaveTranslationUnit_Flags : CInt {
-  SAVE_TRANSLATION_UNIT_NONE = 0
+
+	<*
+		Used to indicate that no special saving options are needed.
+	*>
+	SAVE_TRANSLATION_UNIT_NONE = 0
 }
 
+<*
+	Returns the set of flags that is suitable for saving a translation
+	unit.
+	The set of flags returned provide options for
+	\c clang_saveTranslationUnit() by default. The returned flag
+	set contains an unspecified set of options that save translation units with
+	the most commonly-requested data.
+*>
 extern fn CUInt defaultSaveOptions(
-  CXTranslationUnit tu)
+	CXTranslationUnit tu)
 @cname("clang_defaultSaveOptions");
 
+<*
+	Describes the kind of error that occurred (if any) in a call to
+	\c clang_saveTranslationUnit().
+*>
 constdef CXSaveError : CInt {
-  SAVE_ERROR_NONE = 0,
-  SAVE_ERROR_UNKNOWN = 1,
-  SAVE_ERROR_TRANSLATION_ERRORS = 2,
-  SAVE_ERROR_INVALID_TU = 3
+
+	<*
+		Indicates that no error occurred while saving a translation unit.
+	*>
+	SAVE_ERROR_NONE = 0,
+
+	<*
+		Indicates that an unknown error occurred while attempting to save
+		the file.
+		This error typically indicates that file I/O failed when attempting to
+		write the file.
+	*>
+	SAVE_ERROR_UNKNOWN = 1,
+
+	<*
+		Indicates that errors during translation prevented this attempt
+		to save the translation unit.
+		Errors that prevent the translation unit from being saved can be
+		extracted using \c clang_getNumDiagnostics() and \c clang_getDiagnostic().
+	*>
+	SAVE_ERROR_TRANSLATION_ERRORS = 2,
+
+	<*
+		Indicates that the translation unit to be saved was somehow
+		invalid (e.g., NULL).
+	*>
+	SAVE_ERROR_INVALID_TU = 3
 }
 
+<*
+	Saves a translation unit into a serialized representation of
+	that translation unit on disk.
+	Any translation unit that was parsed without error can be saved
+	into a file. The translation unit can then be deserialized into a
+	new \c CXTranslationUnit with \c clang_createTranslationUnit() or,
+	if it is an incomplete translation unit that corresponds to a
+	header, used as a precompiled header when parsing other translation
+	units.
+	\param TU The translation unit to save.
+	\param FileName The file to which the translation unit will be saved.
+	\param options A bitmask of options that affects how the translation unit
+	is saved. This should be a bitwise OR of the
+	CXSaveTranslationUnit_XXX flags.
+	\returns A value that will match one of the enumerators of the CXSaveError
+	enumeration. Zero (CXSaveError_None) indicates that the translation unit was
+	saved successfully, while a non-zero value indicates that a problem occurred.
+*>
 extern fn CInt saveTranslationUnit(
-  CXTranslationUnit tu,
-  ZString file_name,
-  CUInt options)
+	CXTranslationUnit tu,
+	ZString file_name,
+	CUInt options)
 @cname("clang_saveTranslationUnit");
 
+<*
+	Suspend a translation unit in order to free memory associated with it.
+	A suspended translation unit uses significantly less memory but on the other
+	side does not support any other calls than \c clang_reparseTranslationUnit
+	to resume it or \c clang_disposeTranslationUnit to dispose it completely.
+*>
 extern fn CUInt suspendTranslationUnit(
-  CXTranslationUnit)
+	CXTranslationUnit)
 @cname("clang_suspendTranslationUnit");
 
+<*
+	Destroy the specified CXTranslationUnit object.
+*>
 extern fn void disposeTranslationUnit(
-  CXTranslationUnit)
+	CXTranslationUnit)
 @cname("clang_disposeTranslationUnit");
 
+<*
+	Flags that control the reparsing of translation units.
+	The enumerators in this enumeration type are meant to be bitwise
+	ORed together to specify which options should be used when
+	reparsing the translation unit.
+*>
 constdef CXReparse_Flags : CInt {
-  REPARSE_NONE = 0
+
+	<*
+		Used to indicate that no special reparsing options are needed.
+	*>
+	REPARSE_NONE = 0
 }
 
+<*
+	Returns the set of flags that is suitable for reparsing a translation
+	unit.
+	The set of flags returned provide options for
+	\c clang_reparseTranslationUnit() by default. The returned flag
+	set contains an unspecified set of optimizations geared toward common uses
+	of reparsing. The set of optimizations enabled may change from one version
+	to the next.
+*>
 extern fn CUInt defaultReparseOptions(
-  CXTranslationUnit tu)
+	CXTranslationUnit tu)
 @cname("clang_defaultReparseOptions");
 
+<*
+	Reparse the source files that produced this translation unit.
+	This routine can be used to re-parse the source files that originally
+	created the given translation unit, for example because those source files
+	have changed (either on disk or as passed via \p unsaved_files). The
+	source code will be reparsed with the same command-line options as it
+	was originally parsed.
+	Reparsing a translation unit invalidates all cursors and source locations
+	that refer into that translation unit. This makes reparsing a translation
+	unit semantically equivalent to destroying the translation unit and then
+	creating a new translation unit with the same command-line arguments.
+	However, it may be more efficient to reparse a translation
+	unit using this routine.
+	\param TU The translation unit whose contents will be re-parsed. The
+	translation unit must originally have been built with
+	\c clang_createTranslationUnitFromSourceFile().
+	\param num_unsaved_files The number of unsaved file entries in \p
+	unsaved_files.
+	\param unsaved_files The files that have not yet been saved to disk
+	but may be required for parsing, including the contents of
+	those files.  The contents and name of these files (as specified by
+	CXUnsavedFile) are copied when necessary, so the client only needs to
+	guarantee their validity until the call to this function returns.
+	\param options A bitset of options composed of the flags in CXReparse_Flags.
+	The function \c clang_defaultReparseOptions() produces a default set of
+	options recommended for most uses, based on the translation unit.
+	\returns 0 if the sources could be reparsed.  A non-zero error code will be
+	returned if reparsing was impossible, such that the translation unit is
+	invalid. In such cases, the only valid call for \c TU is
+	\c clang_disposeTranslationUnit(TU).  The error codes returned by this
+	routine are described by the \c CXErrorCode enum.
+*>
 extern fn CInt reparseTranslationUnit(
-  CXTranslationUnit tu,
-  CUInt num_unsaved_files,
-  CXUnsavedFile* unsaved_files,
-  CUInt options)
+	CXTranslationUnit tu,
+	CUInt num_unsaved_files,
+	CXUnsavedFile* unsaved_files,
+	CUInt options)
 @cname("clang_reparseTranslationUnit");
 
+<*
+	Categorizes how memory is being used by a translation unit.
+*>
 constdef CXTUResourceUsageKind : CInt {
-  TU_RESOURCE_USAGE_AST = 1,
-  TU_RESOURCE_USAGE_IDENTIFIERS = 2,
-  TU_RESOURCE_USAGE_SELECTORS = 3,
-  TU_RESOURCE_USAGE_GLOBAL_COMPLETION_RESULTS = 4,
-  TU_RESOURCE_USAGE_SOURCE_MANAGER_CONTENT_CACHE = 5,
-  TU_RESOURCE_USAGE_AST_SIDE_TABLES = 6,
-  TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_MALLOC = 7,
-  TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_M_MAP = 8,
-  TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_MALLOC = 9,
-  TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_M_MAP = 10,
-  TU_RESOURCE_USAGE_PREPROCESSOR = 11,
-  TU_RESOURCE_USAGE_PREPROCESSING_RECORD = 12,
-  TU_RESOURCE_USAGE_SOURCE_MANAGER_DATA_STRUCTURES = 13,
-  TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH = 14,
-  TU_RESOURCE_USAGE_MEMORY_IN_BYTES_BEGIN = 1,
-  TU_RESOURCE_USAGE_MEMORY_IN_BYTES_END = 14,
-  TU_RESOURCE_USAGE_FIRST = 1,
-  TU_RESOURCE_USAGE_LAST = 14
+	TU_RESOURCE_USAGE_AST = 1,
+	TU_RESOURCE_USAGE_IDENTIFIERS = 2,
+	TU_RESOURCE_USAGE_SELECTORS = 3,
+	TU_RESOURCE_USAGE_GLOBAL_COMPLETION_RESULTS = 4,
+	TU_RESOURCE_USAGE_SOURCE_MANAGER_CONTENT_CACHE = 5,
+	TU_RESOURCE_USAGE_AST_SIDE_TABLES = 6,
+	TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_MALLOC = 7,
+	TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_M_MAP = 8,
+	TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_MALLOC = 9,
+	TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_M_MAP = 10,
+	TU_RESOURCE_USAGE_PREPROCESSOR = 11,
+	TU_RESOURCE_USAGE_PREPROCESSING_RECORD = 12,
+	TU_RESOURCE_USAGE_SOURCE_MANAGER_DATA_STRUCTURES = 13,
+	TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH = 14,
+	TU_RESOURCE_USAGE_MEMORY_IN_BYTES_BEGIN = 1,
+	TU_RESOURCE_USAGE_MEMORY_IN_BYTES_END = 14,
+	TU_RESOURCE_USAGE_FIRST = 1,
+	TU_RESOURCE_USAGE_LAST = 14
 }
 
+<*
+	Returns the human-readable null-terminated C string that represents
+	the name of the memory category.  This string should never be freed.
+*>
 extern fn ZString getTUResourceUsageName(
-  CXTUResourceUsageKind kind)
+	CXTUResourceUsageKind kind)
 @cname("clang_getTUResourceUsageName");
 
+
 struct CXTUResourceUsageEntry {
-  CXTUResourceUsageKind kind;
-  CULong amount;
+	CXTUResourceUsageKind kind;
+	CULong amount;
 }
 
+<*
+	The memory usage of a CXTranslationUnit, broken into categories.
+*>
 struct CXTUResourceUsage {
-  void* data;
-  CUInt num_entries;
-  CXTUResourceUsageEntry* entries;
+	void* data;
+	CUInt num_entries;
+	CXTUResourceUsageEntry* entries;
 }
 
+<*
+	Return the memory usage of a translation unit.  This object
+	should be released with clang_disposeCXTUResourceUsage().
+*>
 extern fn CXTUResourceUsage getCXTUResourceUsage(
-  CXTranslationUnit tu)
+	CXTranslationUnit tu)
 @cname("clang_getCXTUResourceUsage");
 
+
 extern fn void disposeCXTUResourceUsage(
-  CXTUResourceUsage usage)
+	CXTUResourceUsage usage)
 @cname("clang_disposeCXTUResourceUsage");
 
+<*
+	Get target information for this translation unit.
+	The CXTargetInfo object cannot outlive the CXTranslationUnit object.
+*>
 extern fn CXTargetInfo getTranslationUnitTargetInfo(
-  CXTranslationUnit ct_unit)
+	CXTranslationUnit ct_unit)
 @cname("clang_getTranslationUnitTargetInfo");
 
+<*
+	Destroy the CXTargetInfo object.
+*>
 extern fn void targetInfo_dispose(
-  CXTargetInfo info)
+	CXTargetInfo info)
 @cname("clang_TargetInfo_dispose");
 
+<*
+	Get the normalized target triple as a string.
+	Returns the empty string in case of any error.
+*>
 extern fn CXString targetInfo_getTriple(
-  CXTargetInfo info)
+	CXTargetInfo info)
 @cname("clang_TargetInfo_getTriple");
 
+<*
+	Get the pointer width of the target in bits.
+	Returns -1 in case of error.
+*>
 extern fn CInt targetInfo_getPointerWidth(
-  CXTargetInfo info)
+	CXTargetInfo info)
 @cname("clang_TargetInfo_getPointerWidth");
 
+<*
+	Describes the kind of entity that a cursor refers to.
+*>
 constdef CXCursorKind : CInt {
-  CURSOR_UNEXPOSED_DECL = 1,
-  CURSOR_STRUCT_DECL = 2,
-  CURSOR_UNION_DECL = 3,
-  CURSOR_CLASS_DECL = 4,
-  CURSOR_ENUM_DECL = 5,
-  CURSOR_FIELD_DECL = 6,
-  CURSOR_ENUM_CONSTANT_DECL = 7,
-  CURSOR_FUNCTION_DECL = 8,
-  CURSOR_VAR_DECL = 9,
-  CURSOR_PARM_DECL = 10,
-  CURSOR_OBJ_C_INTERFACE_DECL = 11,
-  CURSOR_OBJ_C_CATEGORY_DECL = 12,
-  CURSOR_OBJ_C_PROTOCOL_DECL = 13,
-  CURSOR_OBJ_C_PROPERTY_DECL = 14,
-  CURSOR_OBJ_C_IVAR_DECL = 15,
-  CURSOR_OBJ_C_INSTANCE_METHOD_DECL = 16,
-  CURSOR_OBJ_C_CLASS_METHOD_DECL = 17,
-  CURSOR_OBJ_C_IMPLEMENTATION_DECL = 18,
-  CURSOR_OBJ_C_CATEGORY_IMPL_DECL = 19,
-  CURSOR_TYPEDEF_DECL = 20,
-  CURSOR_CXX_METHOD = 21,
-  CURSOR_NAMESPACE = 22,
-  CURSOR_LINKAGE_SPEC = 23,
-  CURSOR_CONSTRUCTOR = 24,
-  CURSOR_DESTRUCTOR = 25,
-  CURSOR_CONVERSION_FUNCTION = 26,
-  CURSOR_TEMPLATE_TYPE_PARAMETER = 27,
-  CURSOR_NON_TYPE_TEMPLATE_PARAMETER = 28,
-  CURSOR_TEMPLATE_TEMPLATE_PARAMETER = 29,
-  CURSOR_FUNCTION_TEMPLATE = 30,
-  CURSOR_CLASS_TEMPLATE = 31,
-  CURSOR_CLASS_TEMPLATE_PARTIAL_SPECIALIZATION = 32,
-  CURSOR_NAMESPACE_ALIAS = 33,
-  CURSOR_USING_DIRECTIVE = 34,
-  CURSOR_USING_DECLARATION = 35,
-  CURSOR_TYPE_ALIAS_DECL = 36,
-  CURSOR_OBJ_C_SYNTHESIZE_DECL = 37,
-  CURSOR_OBJ_C_DYNAMIC_DECL = 38,
-  CURSOR_CXX_ACCESS_SPECIFIER = 39,
-  CURSOR_FIRST_DECL = 1,
-  CURSOR_LAST_DECL = 39,
-  CURSOR_FIRST_REF = 40,
-  CURSOR_OBJ_C_SUPER_CLASS_REF = 40,
-  CURSOR_OBJ_C_PROTOCOL_REF = 41,
-  CURSOR_OBJ_C_CLASS_REF = 42,
-  CURSOR_TYPE_REF = 43,
-  CURSOR_CXX_BASE_SPECIFIER = 44,
-  CURSOR_TEMPLATE_REF = 45,
-  CURSOR_NAMESPACE_REF = 46,
-  CURSOR_MEMBER_REF = 47,
-  CURSOR_LABEL_REF = 48,
-  CURSOR_OVERLOADED_DECL_REF = 49,
-  CURSOR_VARIABLE_REF = 50,
-  CURSOR_LAST_REF = 50,
-  CURSOR_FIRST_INVALID = 70,
-  CURSOR_INVALID_FILE = 70,
-  CURSOR_NO_DECL_FOUND = 71,
-  CURSOR_NOT_IMPLEMENTED = 72,
-  CURSOR_INVALID_CODE = 73,
-  CURSOR_LAST_INVALID = 73,
-  CURSOR_FIRST_EXPR = 100,
-  CURSOR_UNEXPOSED_EXPR = 100,
-  CURSOR_DECL_REF_EXPR = 101,
-  CURSOR_MEMBER_REF_EXPR = 102,
-  CURSOR_CALL_EXPR = 103,
-  CURSOR_OBJ_C_MESSAGE_EXPR = 104,
-  CURSOR_BLOCK_EXPR = 105,
-  CURSOR_INTEGER_LITERAL = 106,
-  CURSOR_FLOATING_LITERAL = 107,
-  CURSOR_IMAGINARY_LITERAL = 108,
-  CURSOR_STRING_LITERAL = 109,
-  CURSOR_CHARACTER_LITERAL = 110,
-  CURSOR_PAREN_EXPR = 111,
-  CURSOR_UNARY_OPERATOR = 112,
-  CURSOR_ARRAY_SUBSCRIPT_EXPR = 113,
-  CURSOR_BINARY_OPERATOR = 114,
-  CURSOR_COMPOUND_ASSIGN_OPERATOR = 115,
-  CURSOR_CONDITIONAL_OPERATOR = 116,
-  CURSOR_C_STYLE_CAST_EXPR = 117,
-  CURSOR_COMPOUND_LITERAL_EXPR = 118,
-  CURSOR_INIT_LIST_EXPR = 119,
-  CURSOR_ADDR_LABEL_EXPR = 120,
-  CURSOR_STMT_EXPR = 121,
-  CURSOR_GENERIC_SELECTION_EXPR = 122,
-  CURSOR_GNU_NULL_EXPR = 123,
-  CURSOR_CXX_STATIC_CAST_EXPR = 124,
-  CURSOR_CXX_DYNAMIC_CAST_EXPR = 125,
-  CURSOR_CXX_REINTERPRET_CAST_EXPR = 126,
-  CURSOR_CXX_CONST_CAST_EXPR = 127,
-  CURSOR_CXX_FUNCTIONAL_CAST_EXPR = 128,
-  CURSOR_CXX_TYPEID_EXPR = 129,
-  CURSOR_CXX_BOOL_LITERAL_EXPR = 130,
-  CURSOR_CXX_NULL_PTR_LITERAL_EXPR = 131,
-  CURSOR_CXX_THIS_EXPR = 132,
-  CURSOR_CXX_THROW_EXPR = 133,
-  CURSOR_CXX_NEW_EXPR = 134,
-  CURSOR_CXX_DELETE_EXPR = 135,
-  CURSOR_UNARY_EXPR = 136,
-  CURSOR_OBJ_C_STRING_LITERAL = 137,
-  CURSOR_OBJ_C_ENCODE_EXPR = 138,
-  CURSOR_OBJ_C_SELECTOR_EXPR = 139,
-  CURSOR_OBJ_C_PROTOCOL_EXPR = 140,
-  CURSOR_OBJ_C_BRIDGED_CAST_EXPR = 141,
-  CURSOR_PACK_EXPANSION_EXPR = 142,
-  CURSOR_SIZE_OF_PACK_EXPR = 143,
-  CURSOR_LAMBDA_EXPR = 144,
-  CURSOR_OBJ_C_BOOL_LITERAL_EXPR = 145,
-  CURSOR_OBJ_C_SELF_EXPR = 146,
-  CURSOR_ARRAY_SECTION_EXPR = 147,
-  CURSOR_OBJ_C_AVAILABILITY_CHECK_EXPR = 148,
-  CURSOR_FIXED_POINT_LITERAL = 149,
-  CURSOR_OMP_ARRAY_SHAPING_EXPR = 150,
-  CURSOR_OMP_ITERATOR_EXPR = 151,
-  CURSOR_CXX_ADDRSPACE_CAST_EXPR = 152,
-  CURSOR_CONCEPT_SPECIALIZATION_EXPR = 153,
-  CURSOR_REQUIRES_EXPR = 154,
-  CURSOR_CXX_PAREN_LIST_INIT_EXPR = 155,
-  CURSOR_PACK_INDEXING_EXPR = 156,
-  CURSOR_LAST_EXPR = 156,
-  CURSOR_FIRST_STMT = 200,
-  CURSOR_UNEXPOSED_STMT = 200,
-  CURSOR_LABEL_STMT = 201,
-  CURSOR_COMPOUND_STMT = 202,
-  CURSOR_CASE_STMT = 203,
-  CURSOR_DEFAULT_STMT = 204,
-  CURSOR_IF_STMT = 205,
-  CURSOR_SWITCH_STMT = 206,
-  CURSOR_WHILE_STMT = 207,
-  CURSOR_DO_STMT = 208,
-  CURSOR_FOR_STMT = 209,
-  CURSOR_GOTO_STMT = 210,
-  CURSOR_INDIRECT_GOTO_STMT = 211,
-  CURSOR_CONTINUE_STMT = 212,
-  CURSOR_BREAK_STMT = 213,
-  CURSOR_RETURN_STMT = 214,
-  CURSOR_GCC_ASM_STMT = 215,
-  CURSOR_ASM_STMT = 215,
-  CURSOR_OBJ_C_AT_TRY_STMT = 216,
-  CURSOR_OBJ_C_AT_CATCH_STMT = 217,
-  CURSOR_OBJ_C_AT_FINALLY_STMT = 218,
-  CURSOR_OBJ_C_AT_THROW_STMT = 219,
-  CURSOR_OBJ_C_AT_SYNCHRONIZED_STMT = 220,
-  CURSOR_OBJ_C_AUTORELEASE_POOL_STMT = 221,
-  CURSOR_OBJ_C_FOR_COLLECTION_STMT = 222,
-  CURSOR_CXX_CATCH_STMT = 223,
-  CURSOR_CXX_TRY_STMT = 224,
-  CURSOR_CXX_FOR_RANGE_STMT = 225,
-  CURSOR_SEH_TRY_STMT = 226,
-  CURSOR_SEH_EXCEPT_STMT = 227,
-  CURSOR_SEH_FINALLY_STMT = 228,
-  CURSOR_MS_ASM_STMT = 229,
-  CURSOR_NULL_STMT = 230,
-  CURSOR_DECL_STMT = 231,
-  CURSOR_OMP_PARALLEL_DIRECTIVE = 232,
-  CURSOR_OMP_SIMD_DIRECTIVE = 233,
-  CURSOR_OMP_FOR_DIRECTIVE = 234,
-  CURSOR_OMP_SECTIONS_DIRECTIVE = 235,
-  CURSOR_OMP_SECTION_DIRECTIVE = 236,
-  CURSOR_OMP_SINGLE_DIRECTIVE = 237,
-  CURSOR_OMP_PARALLEL_FOR_DIRECTIVE = 238,
-  CURSOR_OMP_PARALLEL_SECTIONS_DIRECTIVE = 239,
-  CURSOR_OMP_TASK_DIRECTIVE = 240,
-  CURSOR_OMP_MASTER_DIRECTIVE = 241,
-  CURSOR_OMP_CRITICAL_DIRECTIVE = 242,
-  CURSOR_OMP_TASKYIELD_DIRECTIVE = 243,
-  CURSOR_OMP_BARRIER_DIRECTIVE = 244,
-  CURSOR_OMP_TASKWAIT_DIRECTIVE = 245,
-  CURSOR_OMP_FLUSH_DIRECTIVE = 246,
-  CURSOR_SEH_LEAVE_STMT = 247,
-  CURSOR_OMP_ORDERED_DIRECTIVE = 248,
-  CURSOR_OMP_ATOMIC_DIRECTIVE = 249,
-  CURSOR_OMP_FOR_SIMD_DIRECTIVE = 250,
-  CURSOR_OMP_PARALLEL_FOR_SIMD_DIRECTIVE = 251,
-  CURSOR_OMP_TARGET_DIRECTIVE = 252,
-  CURSOR_OMP_TEAMS_DIRECTIVE = 253,
-  CURSOR_OMP_TASKGROUP_DIRECTIVE = 254,
-  CURSOR_OMP_CANCELLATION_POINT_DIRECTIVE = 255,
-  CURSOR_OMP_CANCEL_DIRECTIVE = 256,
-  CURSOR_OMP_TARGET_DATA_DIRECTIVE = 257,
-  CURSOR_OMP_TASK_LOOP_DIRECTIVE = 258,
-  CURSOR_OMP_TASK_LOOP_SIMD_DIRECTIVE = 259,
-  CURSOR_OMP_DISTRIBUTE_DIRECTIVE = 260,
-  CURSOR_OMP_TARGET_ENTER_DATA_DIRECTIVE = 261,
-  CURSOR_OMP_TARGET_EXIT_DATA_DIRECTIVE = 262,
-  CURSOR_OMP_TARGET_PARALLEL_DIRECTIVE = 263,
-  CURSOR_OMP_TARGET_PARALLEL_FOR_DIRECTIVE = 264,
-  CURSOR_OMP_TARGET_UPDATE_DIRECTIVE = 265,
-  CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 266,
-  CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 267,
-  CURSOR_OMP_DISTRIBUTE_SIMD_DIRECTIVE = 268,
-  CURSOR_OMP_TARGET_PARALLEL_FOR_SIMD_DIRECTIVE = 269,
-  CURSOR_OMP_TARGET_SIMD_DIRECTIVE = 270,
-  CURSOR_OMP_TEAMS_DISTRIBUTE_DIRECTIVE = 271,
-  CURSOR_OMP_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 272,
-  CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 273,
-  CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 274,
-  CURSOR_OMP_TARGET_TEAMS_DIRECTIVE = 275,
-  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_DIRECTIVE = 276,
-  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 277,
-  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 278,
-  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 279,
-  CURSOR_BUILTIN_BIT_CAST_EXPR = 280,
-  CURSOR_OMP_MASTER_TASK_LOOP_DIRECTIVE = 281,
-  CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_DIRECTIVE = 282,
-  CURSOR_OMP_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 283,
-  CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 284,
-  CURSOR_OMP_PARALLEL_MASTER_DIRECTIVE = 285,
-  CURSOR_OMP_DEPOBJ_DIRECTIVE = 286,
-  CURSOR_OMP_SCAN_DIRECTIVE = 287,
-  CURSOR_OMP_TILE_DIRECTIVE = 288,
-  CURSOR_OMP_CANONICAL_LOOP = 289,
-  CURSOR_OMP_INTEROP_DIRECTIVE = 290,
-  CURSOR_OMP_DISPATCH_DIRECTIVE = 291,
-  CURSOR_OMP_MASKED_DIRECTIVE = 292,
-  CURSOR_OMP_UNROLL_DIRECTIVE = 293,
-  CURSOR_OMP_META_DIRECTIVE = 294,
-  CURSOR_OMP_GENERIC_LOOP_DIRECTIVE = 295,
-  CURSOR_OMP_TEAMS_GENERIC_LOOP_DIRECTIVE = 296,
-  CURSOR_OMP_TARGET_TEAMS_GENERIC_LOOP_DIRECTIVE = 297,
-  CURSOR_OMP_PARALLEL_GENERIC_LOOP_DIRECTIVE = 298,
-  CURSOR_OMP_TARGET_PARALLEL_GENERIC_LOOP_DIRECTIVE = 299,
-  CURSOR_OMP_PARALLEL_MASKED_DIRECTIVE = 300,
-  CURSOR_OMP_MASKED_TASK_LOOP_DIRECTIVE = 301,
-  CURSOR_OMP_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 302,
-  CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_DIRECTIVE = 303,
-  CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 304,
-  CURSOR_OMP_ERROR_DIRECTIVE = 305,
-  CURSOR_OMP_SCOPE_DIRECTIVE = 306,
-  CURSOR_OMP_REVERSE_DIRECTIVE = 307,
-  CURSOR_OMP_INTERCHANGE_DIRECTIVE = 308,
-  CURSOR_OMP_ASSUME_DIRECTIVE = 309,
-  CURSOR_OMP_STRIPE_DIRECTIVE = 310,
-  CURSOR_OMP_FUSE_DIRECTIVE = 311,
-  CURSOR_OPEN_ACC_COMPUTE_CONSTRUCT = 320,
-  CURSOR_OPEN_ACC_LOOP_CONSTRUCT = 321,
-  CURSOR_OPEN_ACC_COMBINED_CONSTRUCT = 322,
-  CURSOR_OPEN_ACC_DATA_CONSTRUCT = 323,
-  CURSOR_OPEN_ACC_ENTER_DATA_CONSTRUCT = 324,
-  CURSOR_OPEN_ACC_EXIT_DATA_CONSTRUCT = 325,
-  CURSOR_OPEN_ACC_HOST_DATA_CONSTRUCT = 326,
-  CURSOR_OPEN_ACC_WAIT_CONSTRUCT = 327,
-  CURSOR_OPEN_ACC_INIT_CONSTRUCT = 328,
-  CURSOR_OPEN_ACC_SHUTDOWN_CONSTRUCT = 329,
-  CURSOR_OPEN_ACC_SET_CONSTRUCT = 330,
-  CURSOR_OPEN_ACC_UPDATE_CONSTRUCT = 331,
-  CURSOR_OPEN_ACC_ATOMIC_CONSTRUCT = 332,
-  CURSOR_OPEN_ACC_CACHE_CONSTRUCT = 333,
-  CURSOR_LAST_STMT = 333,
-  CURSOR_TRANSLATION_UNIT = 350,
-  CURSOR_FIRST_ATTR = 400,
-  CURSOR_UNEXPOSED_ATTR = 400,
-  CURSOR_IB_ACTION_ATTR = 401,
-  CURSOR_IB_OUTLET_ATTR = 402,
-  CURSOR_IB_OUTLET_COLLECTION_ATTR = 403,
-  CURSOR_CXX_FINAL_ATTR = 404,
-  CURSOR_CXX_OVERRIDE_ATTR = 405,
-  CURSOR_ANNOTATE_ATTR = 406,
-  CURSOR_ASM_LABEL_ATTR = 407,
-  CURSOR_PACKED_ATTR = 408,
-  CURSOR_PURE_ATTR = 409,
-  CURSOR_CONST_ATTR = 410,
-  CURSOR_NO_DUPLICATE_ATTR = 411,
-  CURSOR_CUDA_CONSTANT_ATTR = 412,
-  CURSOR_CUDA_DEVICE_ATTR = 413,
-  CURSOR_CUDA_GLOBAL_ATTR = 414,
-  CURSOR_CUDA_HOST_ATTR = 415,
-  CURSOR_CUDA_SHARED_ATTR = 416,
-  CURSOR_VISIBILITY_ATTR = 417,
-  CURSOR_DLL_EXPORT = 418,
-  CURSOR_DLL_IMPORT = 419,
-  CURSOR_NS_RETURNS_RETAINED = 420,
-  CURSOR_NS_RETURNS_NOT_RETAINED = 421,
-  CURSOR_NS_RETURNS_AUTORELEASED = 422,
-  CURSOR_NS_CONSUMES_SELF = 423,
-  CURSOR_NS_CONSUMED = 424,
-  CURSOR_OBJ_C_EXCEPTION = 425,
-  CURSOR_OBJ_CNS_OBJECT = 426,
-  CURSOR_OBJ_C_INDEPENDENT_CLASS = 427,
-  CURSOR_OBJ_C_PRECISE_LIFETIME = 428,
-  CURSOR_OBJ_C_RETURNS_INNER_POINTER = 429,
-  CURSOR_OBJ_C_REQUIRES_SUPER = 430,
-  CURSOR_OBJ_C_ROOT_CLASS = 431,
-  CURSOR_OBJ_C_SUBCLASSING_RESTRICTED = 432,
-  CURSOR_OBJ_C_EXPLICIT_PROTOCOL_IMPL = 433,
-  CURSOR_OBJ_C_DESIGNATED_INITIALIZER = 434,
-  CURSOR_OBJ_C_RUNTIME_VISIBLE = 435,
-  CURSOR_OBJ_C_BOXABLE = 436,
-  CURSOR_FLAG_ENUM = 437,
-  CURSOR_CONVERGENT_ATTR = 438,
-  CURSOR_WARN_UNUSED_ATTR = 439,
-  CURSOR_WARN_UNUSED_RESULT_ATTR = 440,
-  CURSOR_ALIGNED_ATTR = 441,
-  CURSOR_LAST_ATTR = 441,
-  CURSOR_PREPROCESSING_DIRECTIVE = 500,
-  CURSOR_MACRO_DEFINITION = 501,
-  CURSOR_MACRO_EXPANSION = 502,
-  CURSOR_MACRO_INSTANTIATION = 502,
-  CURSOR_INCLUSION_DIRECTIVE = 503,
-  CURSOR_FIRST_PREPROCESSING = 500,
-  CURSOR_LAST_PREPROCESSING = 503,
-  CURSOR_MODULE_IMPORT_DECL = 600,
-  CURSOR_TYPE_ALIAS_TEMPLATE_DECL = 601,
-  CURSOR_STATIC_ASSERT = 602,
-  CURSOR_FRIEND_DECL = 603,
-  CURSOR_CONCEPT_DECL = 604,
-  CURSOR_FIRST_EXTRA_DECL = 600,
-  CURSOR_LAST_EXTRA_DECL = 604,
-  CURSOR_OVERLOAD_CANDIDATE = 700
+
+	<*
+		A declaration whose specific kind is not exposed via this
+		interface.
+		Unexposed declarations have the same operations as any other kind
+		of declaration; one can extract their location information,
+		spelling, find their definitions, etc. However, the specific kind
+		of the declaration is not reported.
+	*>
+	CURSOR_UNEXPOSED_DECL = 1,
+
+	<*
+		A C or C++ struct. *
+	*>
+	CURSOR_STRUCT_DECL = 2,
+
+	<*
+		A C or C++ union. *
+	*>
+	CURSOR_UNION_DECL = 3,
+
+	<*
+		A C++ class. *
+	*>
+	CURSOR_CLASS_DECL = 4,
+
+	<*
+		An enumeration. *
+	*>
+	CURSOR_ENUM_DECL = 5,
+
+	<*
+		A field (in C) or non-static data member (in C++) in a
+		struct, union, or C++ class.
+	*>
+	CURSOR_FIELD_DECL = 6,
+
+	<*
+		An enumerator constant. *
+	*>
+	CURSOR_ENUM_CONSTANT_DECL = 7,
+
+	<*
+		A function. *
+	*>
+	CURSOR_FUNCTION_DECL = 8,
+
+	<*
+		A variable. *
+	*>
+	CURSOR_VAR_DECL = 9,
+
+	<*
+		A function or method parameter. *
+	*>
+	CURSOR_PARM_DECL = 10,
+
+	<*
+		An Objective-C \@interface. *
+	*>
+	CURSOR_OBJ_C_INTERFACE_DECL = 11,
+
+	<*
+		An Objective-C \@interface for a category. *
+	*>
+	CURSOR_OBJ_C_CATEGORY_DECL = 12,
+
+	<*
+		An Objective-C \@protocol declaration. *
+	*>
+	CURSOR_OBJ_C_PROTOCOL_DECL = 13,
+
+	<*
+		An Objective-C \@property declaration. *
+	*>
+	CURSOR_OBJ_C_PROPERTY_DECL = 14,
+
+	<*
+		An Objective-C instance variable. *
+	*>
+	CURSOR_OBJ_C_IVAR_DECL = 15,
+
+	<*
+		An Objective-C instance method. *
+	*>
+	CURSOR_OBJ_C_INSTANCE_METHOD_DECL = 16,
+
+	<*
+		An Objective-C class method. *
+	*>
+	CURSOR_OBJ_C_CLASS_METHOD_DECL = 17,
+
+	<*
+		An Objective-C \@implementation. *
+	*>
+	CURSOR_OBJ_C_IMPLEMENTATION_DECL = 18,
+
+	<*
+		An Objective-C \@implementation for a category. *
+	*>
+	CURSOR_OBJ_C_CATEGORY_IMPL_DECL = 19,
+
+	<*
+		A typedef. *
+	*>
+	CURSOR_TYPEDEF_DECL = 20,
+
+	<*
+		A C++ class method. *
+	*>
+	CURSOR_CXX_METHOD = 21,
+
+	<*
+		A C++ namespace. *
+	*>
+	CURSOR_NAMESPACE = 22,
+
+	<*
+		A linkage specification, e.g. 'extern "C"'. *
+	*>
+	CURSOR_LINKAGE_SPEC = 23,
+
+	<*
+		A C++ constructor. *
+	*>
+	CURSOR_CONSTRUCTOR = 24,
+
+	<*
+		A C++ destructor. *
+	*>
+	CURSOR_DESTRUCTOR = 25,
+
+	<*
+		A C++ conversion function. *
+	*>
+	CURSOR_CONVERSION_FUNCTION = 26,
+
+	<*
+		A C++ template type parameter. *
+	*>
+	CURSOR_TEMPLATE_TYPE_PARAMETER = 27,
+
+	<*
+		A C++ non-type template parameter. *
+	*>
+	CURSOR_NON_TYPE_TEMPLATE_PARAMETER = 28,
+
+	<*
+		A C++ template template parameter. *
+	*>
+	CURSOR_TEMPLATE_TEMPLATE_PARAMETER = 29,
+
+	<*
+		A C++ function template. *
+	*>
+	CURSOR_FUNCTION_TEMPLATE = 30,
+
+	<*
+		A C++ class template. *
+	*>
+	CURSOR_CLASS_TEMPLATE = 31,
+
+	<*
+		A C++ class template partial specialization. *
+	*>
+	CURSOR_CLASS_TEMPLATE_PARTIAL_SPECIALIZATION = 32,
+
+	<*
+		A C++ namespace alias declaration. *
+	*>
+	CURSOR_NAMESPACE_ALIAS = 33,
+
+	<*
+		A C++ using directive. *
+	*>
+	CURSOR_USING_DIRECTIVE = 34,
+
+	<*
+		A C++ using declaration. *
+	*>
+	CURSOR_USING_DECLARATION = 35,
+
+	<*
+		A C++ alias declaration *
+	*>
+	CURSOR_TYPE_ALIAS_DECL = 36,
+
+	<*
+		An Objective-C \@synthesize definition. *
+	*>
+	CURSOR_OBJ_C_SYNTHESIZE_DECL = 37,
+
+	<*
+		An Objective-C \@dynamic definition. *
+	*>
+	CURSOR_OBJ_C_DYNAMIC_DECL = 38,
+
+	<*
+		An access specifier. *
+	*>
+	CURSOR_CXX_ACCESS_SPECIFIER = 39,
+
+	<*
+		An access specifier. *
+	*>
+	CURSOR_FIRST_DECL = 1,
+
+	<*
+		An access specifier. *
+	*>
+	CURSOR_LAST_DECL = 39,
+
+	<*
+		An access specifier. *
+	*>
+	CURSOR_FIRST_REF = 40,
+
+	<*
+		An access specifier. *
+	*>
+	CURSOR_OBJ_C_SUPER_CLASS_REF = 40,
+
+	<*
+		An access specifier. *
+	*>
+	CURSOR_OBJ_C_PROTOCOL_REF = 41,
+
+	<*
+		An access specifier. *
+	*>
+	CURSOR_OBJ_C_CLASS_REF = 42,
+
+	<*
+		A reference to a type declaration.
+		A type reference occurs anywhere where a type is named but not
+		declared. For example, given:
+		\code
+		typedef unsigned size_type;
+		size_type size;
+		\endcode
+		The typedef is a declaration of size_type (CXCursor_TypedefDecl),
+		while the type of the variable "size" is referenced. The cursor
+		referenced by the type of size is the typedef for size_type.
+	*>
+	CURSOR_TYPE_REF = 43,
+
+	<*
+		A reference to a type declaration.
+		A type reference occurs anywhere where a type is named but not
+		declared. For example, given:
+		\code
+		typedef unsigned size_type;
+		size_type size;
+		\endcode
+		The typedef is a declaration of size_type (CXCursor_TypedefDecl),
+		while the type of the variable "size" is referenced. The cursor
+		referenced by the type of size is the typedef for size_type.
+	*>
+	CURSOR_CXX_BASE_SPECIFIER = 44,
+
+	<*
+		A reference to a class template, function template, template
+		template parameter, or class template partial specialization.
+	*>
+	CURSOR_TEMPLATE_REF = 45,
+
+	<*
+		A reference to a namespace or namespace alias.
+	*>
+	CURSOR_NAMESPACE_REF = 46,
+
+	<*
+		A reference to a member of a struct, union, or class that occurs in
+		some non-expression context, e.g., a designated initializer.
+	*>
+	CURSOR_MEMBER_REF = 47,
+
+	<*
+		A reference to a labeled statement.
+		This cursor kind is used to describe the jump to "start_over" in the
+		goto statement in the following example:
+		\code
+		start_over:
+		++counter;
+		goto start_over;
+		\endcode
+		A label reference cursor refers to a label statement.
+	*>
+	CURSOR_LABEL_REF = 48,
+
+	<*
+		A reference to a set of overloaded functions or function templates
+		that has not yet been resolved to a specific function or function template.
+		An overloaded declaration reference cursor occurs in C++ templates where
+		a dependent name refers to a function. For example:
+		\code
+		template<typename T> void swap(T&, T&);
+		struct X { ... };
+		void swap(X&, X&);
+		template<typename T>
+		void reverse(T* first, T* last) {
+		while (first < last - 1) {
+		swap(*first, *--last);
+		++first;
+		}
+		}
+		struct Y { };
+		void swap(Y&, Y&);
+		\endcode
+		Here, the identifier "swap" is associated with an overloaded declaration
+		reference. In the template definition, "swap" refers to either of the two
+		"swap" functions declared above, so both results will be available. At
+		instantiation time, "swap" may also refer to other functions found via
+		argument-dependent lookup (e.g., the "swap" function at the end of the
+		example).
+		The functions \c clang_getNumOverloadedDecls() and
+		\c clang_getOverloadedDecl() can be used to retrieve the definitions
+		referenced by this cursor.
+	*>
+	CURSOR_OVERLOADED_DECL_REF = 49,
+
+	<*
+		A reference to a variable that occurs in some non-expression
+		context, e.g., a C++ lambda capture list.
+	*>
+	CURSOR_VARIABLE_REF = 50,
+
+	<*
+		A reference to a variable that occurs in some non-expression
+		context, e.g., a C++ lambda capture list.
+	*>
+	CURSOR_LAST_REF = 50,
+
+	<*
+		A reference to a variable that occurs in some non-expression
+		context, e.g., a C++ lambda capture list.
+	*>
+	CURSOR_FIRST_INVALID = 70,
+
+	<*
+		A reference to a variable that occurs in some non-expression
+		context, e.g., a C++ lambda capture list.
+	*>
+	CURSOR_INVALID_FILE = 70,
+
+	<*
+		A reference to a variable that occurs in some non-expression
+		context, e.g., a C++ lambda capture list.
+	*>
+	CURSOR_NO_DECL_FOUND = 71,
+
+	<*
+		A reference to a variable that occurs in some non-expression
+		context, e.g., a C++ lambda capture list.
+	*>
+	CURSOR_NOT_IMPLEMENTED = 72,
+
+	<*
+		A reference to a variable that occurs in some non-expression
+		context, e.g., a C++ lambda capture list.
+	*>
+	CURSOR_INVALID_CODE = 73,
+
+	<*
+		A reference to a variable that occurs in some non-expression
+		context, e.g., a C++ lambda capture list.
+	*>
+	CURSOR_LAST_INVALID = 73,
+
+	<*
+		A reference to a variable that occurs in some non-expression
+		context, e.g., a C++ lambda capture list.
+	*>
+	CURSOR_FIRST_EXPR = 100,
+
+	<*
+		An expression whose specific kind is not exposed via this
+		interface.
+		Unexposed expressions have the same operations as any other kind
+		of expression; one can extract their location information,
+		spelling, children, etc. However, the specific kind of the
+		expression is not reported.
+	*>
+	CURSOR_UNEXPOSED_EXPR = 100,
+
+	<*
+		An expression that refers to some value declaration, such
+		as a function, variable, or enumerator.
+	*>
+	CURSOR_DECL_REF_EXPR = 101,
+
+	<*
+		An expression that refers to a member of a struct, union,
+		class, Objective-C class, etc.
+	*>
+	CURSOR_MEMBER_REF_EXPR = 102,
+
+	<*
+		An expression that calls a function. *
+	*>
+	CURSOR_CALL_EXPR = 103,
+
+	<*
+		An expression that sends a message to an Objective-C
+		object or class. *
+	*>
+	CURSOR_OBJ_C_MESSAGE_EXPR = 104,
+
+	<*
+		An expression that represents a block literal. *
+	*>
+	CURSOR_BLOCK_EXPR = 105,
+
+	<*
+		An integer literal.
+	*>
+	CURSOR_INTEGER_LITERAL = 106,
+
+	<*
+		A floating point number literal.
+	*>
+	CURSOR_FLOATING_LITERAL = 107,
+
+	<*
+		An imaginary number literal.
+	*>
+	CURSOR_IMAGINARY_LITERAL = 108,
+
+	<*
+		A string literal.
+	*>
+	CURSOR_STRING_LITERAL = 109,
+
+	<*
+		A character literal.
+	*>
+	CURSOR_CHARACTER_LITERAL = 110,
+
+	<*
+		A parenthesized expression, e.g. "(1)".
+		This AST node is only formed if full location information is requested.
+	*>
+	CURSOR_PAREN_EXPR = 111,
+
+	<*
+		This represents the unary-expression's (except sizeof and
+		alignof).
+	*>
+	CURSOR_UNARY_OPERATOR = 112,
+
+	<*
+		[C99 6.5.2.1] Array Subscripting.
+	*>
+	CURSOR_ARRAY_SUBSCRIPT_EXPR = 113,
+
+	<*
+		A builtin binary operation expression such as "x + y" or
+		"x <= y".
+	*>
+	CURSOR_BINARY_OPERATOR = 114,
+
+	<*
+		Compound assignment such as "+=".
+	*>
+	CURSOR_COMPOUND_ASSIGN_OPERATOR = 115,
+
+	<*
+		The ?: ternary operator.
+	*>
+	CURSOR_CONDITIONAL_OPERATOR = 116,
+
+	<*
+		An explicit cast in C (C99 6.5.4) or a C-style cast in C++
+		(C++ [expr.cast]), which uses the syntax (Type)expr.
+		For example: (int)f.
+	*>
+	CURSOR_C_STYLE_CAST_EXPR = 117,
+
+	<*
+		[C99 6.5.2.5]
+	*>
+	CURSOR_COMPOUND_LITERAL_EXPR = 118,
+
+	<*
+		Describes an C or C++ initializer list.
+	*>
+	CURSOR_INIT_LIST_EXPR = 119,
+
+	<*
+		The GNU address of label extension, representing &&label.
+	*>
+	CURSOR_ADDR_LABEL_EXPR = 120,
+
+	<*
+		This is the GNU Statement Expression extension: ({int X=4; X;})
+	*>
+	CURSOR_STMT_EXPR = 121,
+
+	<*
+		Represents a C11 generic selection.
+	*>
+	CURSOR_GENERIC_SELECTION_EXPR = 122,
+
+	<*
+		Implements the GNU __null extension, which is a name for a null
+		pointer constant that has integral type (e.g., int or long) and is the same
+		size and alignment as a pointer.
+		The __null extension is typically only used by system headers, which define
+		NULL as __null in C++ rather than using 0 (which is an integer that may not
+		match the size of a pointer).
+	*>
+	CURSOR_GNU_NULL_EXPR = 123,
+
+	<*
+		C++'s static_cast<> expression.
+	*>
+	CURSOR_CXX_STATIC_CAST_EXPR = 124,
+
+	<*
+		C++'s dynamic_cast<> expression.
+	*>
+	CURSOR_CXX_DYNAMIC_CAST_EXPR = 125,
+
+	<*
+		C++'s reinterpret_cast<> expression.
+	*>
+	CURSOR_CXX_REINTERPRET_CAST_EXPR = 126,
+
+	<*
+		C++'s const_cast<> expression.
+	*>
+	CURSOR_CXX_CONST_CAST_EXPR = 127,
+
+	<*
+		Represents an explicit C++ type conversion that uses "functional"
+		notion (C++ [expr.type.conv]).
+		Example:
+		\code
+		x = int(0.5);
+		\endcode
+	*>
+	CURSOR_CXX_FUNCTIONAL_CAST_EXPR = 128,
+
+	<*
+		A C++ typeid expression (C++ [expr.typeid]).
+	*>
+	CURSOR_CXX_TYPEID_EXPR = 129,
+
+	<*
+		[C++ 2.13.5] C++ Boolean Literal.
+	*>
+	CURSOR_CXX_BOOL_LITERAL_EXPR = 130,
+
+	<*
+		[C++0x 2.14.7] C++ Pointer Literal.
+	*>
+	CURSOR_CXX_NULL_PTR_LITERAL_EXPR = 131,
+
+	<*
+		Represents the "this" expression in C++
+	*>
+	CURSOR_CXX_THIS_EXPR = 132,
+
+	<*
+		[C++ 15] C++ Throw Expression.
+		This handles 'throw' and 'throw' assignment-expression. When
+		assignment-expression isn't present, Op will be null.
+	*>
+	CURSOR_CXX_THROW_EXPR = 133,
+
+	<*
+		A new expression for memory allocation and constructor calls, e.g:
+		"new CXXNewExpr(foo)".
+	*>
+	CURSOR_CXX_NEW_EXPR = 134,
+
+	<*
+		A delete expression for memory deallocation and destructor calls,
+		e.g. "delete[] pArray".
+	*>
+	CURSOR_CXX_DELETE_EXPR = 135,
+
+	<*
+		A unary expression. (noexcept, sizeof, or other traits)
+	*>
+	CURSOR_UNARY_EXPR = 136,
+
+	<*
+		An Objective-C string literal i.e. @"foo".
+	*>
+	CURSOR_OBJ_C_STRING_LITERAL = 137,
+
+	<*
+		An Objective-C \@encode expression.
+	*>
+	CURSOR_OBJ_C_ENCODE_EXPR = 138,
+
+	<*
+		An Objective-C \@selector expression.
+	*>
+	CURSOR_OBJ_C_SELECTOR_EXPR = 139,
+
+	<*
+		An Objective-C \@protocol expression.
+	*>
+	CURSOR_OBJ_C_PROTOCOL_EXPR = 140,
+
+	<*
+		An Objective-C "bridged" cast expression, which casts between
+		Objective-C pointers and C pointers, transferring ownership in the process.
+		\code
+		NSString *str = (__bridge_transfer NSString *)CFCreateString();
+		\endcode
+	*>
+	CURSOR_OBJ_C_BRIDGED_CAST_EXPR = 141,
+
+	<*
+		Represents a C++0x pack expansion that produces a sequence of
+		expressions.
+		A pack expansion expression contains a pattern (which itself is an
+		expression) followed by an ellipsis. For example:
+		\code
+		template<typename F, typename ...Types>
+		void forward(F f, Types &&...args) {
+		f(static_cast<Types&&>(args)...);
+		}
+		\endcode
+	*>
+	CURSOR_PACK_EXPANSION_EXPR = 142,
+
+	<*
+		Represents an expression that computes the length of a parameter
+		pack.
+		\code
+		template<typename ...Types>
+		struct count {
+		static const unsigned value = sizeof...(Types);
+		};
+		\endcode
+	*>
+	CURSOR_SIZE_OF_PACK_EXPR = 143,
+	CURSOR_LAMBDA_EXPR = 144,
+
+	<*
+		Objective-c Boolean Literal.
+	*>
+	CURSOR_OBJ_C_BOOL_LITERAL_EXPR = 145,
+
+	<*
+		Represents the "self" expression in an Objective-C method.
+	*>
+	CURSOR_OBJ_C_SELF_EXPR = 146,
+
+	<*
+		OpenMP 5.0 [2.1.5, Array Section].
+		OpenACC 3.3 [2.7.1, Data Specification for Data Clauses (Sub Arrays)]
+	*>
+	CURSOR_ARRAY_SECTION_EXPR = 147,
+
+	<*
+		Represents an @available(...) check.
+	*>
+	CURSOR_OBJ_C_AVAILABILITY_CHECK_EXPR = 148,
+
+	<*
+		Fixed point literal
+	*>
+	CURSOR_FIXED_POINT_LITERAL = 149,
+
+	<*
+		OpenMP 5.0 [2.1.4, Array Shaping].
+	*>
+	CURSOR_OMP_ARRAY_SHAPING_EXPR = 150,
+
+	<*
+		OpenMP 5.0 [2.1.6 Iterators]
+	*>
+	CURSOR_OMP_ITERATOR_EXPR = 151,
+
+	<*
+		OpenCL's addrspace_cast<> expression.
+	*>
+	CURSOR_CXX_ADDRSPACE_CAST_EXPR = 152,
+
+	<*
+		Expression that references a C++20 concept.
+	*>
+	CURSOR_CONCEPT_SPECIALIZATION_EXPR = 153,
+
+	<*
+		Expression that references a C++20 requires expression.
+	*>
+	CURSOR_REQUIRES_EXPR = 154,
+
+	<*
+		Expression that references a C++20 parenthesized list aggregate
+		initializer.
+	*>
+	CURSOR_CXX_PAREN_LIST_INIT_EXPR = 155,
+
+	<*
+		Represents a C++26 pack indexing expression.
+	*>
+	CURSOR_PACK_INDEXING_EXPR = 156,
+
+	<*
+		Represents a C++26 pack indexing expression.
+	*>
+	CURSOR_LAST_EXPR = 156,
+
+	<*
+		Represents a C++26 pack indexing expression.
+	*>
+	CURSOR_FIRST_STMT = 200,
+
+	<*
+		A statement whose specific kind is not exposed via this
+		interface.
+		Unexposed statements have the same operations as any other kind of
+		statement; one can extract their location information, spelling,
+		children, etc. However, the specific kind of the statement is not
+		reported.
+	*>
+	CURSOR_UNEXPOSED_STMT = 200,
+
+	<*
+		A labelled statement in a function.
+		This cursor kind is used to describe the "start_over:" label statement in
+		the following example:
+		\code
+		start_over:
+		++counter;
+		\endcode
+	*>
+	CURSOR_LABEL_STMT = 201,
+
+	<*
+		A group of statements like { stmt stmt }.
+		This cursor kind is used to describe compound statements, e.g. function
+		bodies.
+	*>
+	CURSOR_COMPOUND_STMT = 202,
+
+	<*
+		A case statement.
+	*>
+	CURSOR_CASE_STMT = 203,
+
+	<*
+		A default statement.
+	*>
+	CURSOR_DEFAULT_STMT = 204,
+
+	<*
+		An if statement
+	*>
+	CURSOR_IF_STMT = 205,
+
+	<*
+		A switch statement.
+	*>
+	CURSOR_SWITCH_STMT = 206,
+
+	<*
+		A while statement.
+	*>
+	CURSOR_WHILE_STMT = 207,
+
+	<*
+		A do statement.
+	*>
+	CURSOR_DO_STMT = 208,
+
+	<*
+		A for statement.
+	*>
+	CURSOR_FOR_STMT = 209,
+
+	<*
+		A goto statement.
+	*>
+	CURSOR_GOTO_STMT = 210,
+
+	<*
+		An indirect goto statement.
+	*>
+	CURSOR_INDIRECT_GOTO_STMT = 211,
+
+	<*
+		A continue statement.
+	*>
+	CURSOR_CONTINUE_STMT = 212,
+
+	<*
+		A break statement.
+	*>
+	CURSOR_BREAK_STMT = 213,
+
+	<*
+		A return statement.
+	*>
+	CURSOR_RETURN_STMT = 214,
+
+	<*
+		A GCC inline assembly statement extension.
+	*>
+	CURSOR_GCC_ASM_STMT = 215,
+
+	<*
+		A GCC inline assembly statement extension.
+	*>
+	CURSOR_ASM_STMT = 215,
+
+	<*
+		Objective-C's overall \@try-\@catch-\@finally statement.
+	*>
+	CURSOR_OBJ_C_AT_TRY_STMT = 216,
+
+	<*
+		Objective-C's \@catch statement.
+	*>
+	CURSOR_OBJ_C_AT_CATCH_STMT = 217,
+
+	<*
+		Objective-C's \@finally statement.
+	*>
+	CURSOR_OBJ_C_AT_FINALLY_STMT = 218,
+
+	<*
+		Objective-C's \@throw statement.
+	*>
+	CURSOR_OBJ_C_AT_THROW_STMT = 219,
+
+	<*
+		Objective-C's \@synchronized statement.
+	*>
+	CURSOR_OBJ_C_AT_SYNCHRONIZED_STMT = 220,
+
+	<*
+		Objective-C's autorelease pool statement.
+	*>
+	CURSOR_OBJ_C_AUTORELEASE_POOL_STMT = 221,
+
+	<*
+		Objective-C's collection statement.
+	*>
+	CURSOR_OBJ_C_FOR_COLLECTION_STMT = 222,
+
+	<*
+		C++'s catch statement.
+	*>
+	CURSOR_CXX_CATCH_STMT = 223,
+
+	<*
+		C++'s try statement.
+	*>
+	CURSOR_CXX_TRY_STMT = 224,
+
+	<*
+		C++'s for (* : *) statement.
+	*>
+	CURSOR_CXX_FOR_RANGE_STMT = 225,
+
+	<*
+		Windows Structured Exception Handling's try statement.
+	*>
+	CURSOR_SEH_TRY_STMT = 226,
+
+	<*
+		Windows Structured Exception Handling's except statement.
+	*>
+	CURSOR_SEH_EXCEPT_STMT = 227,
+
+	<*
+		Windows Structured Exception Handling's finally statement.
+	*>
+	CURSOR_SEH_FINALLY_STMT = 228,
+
+	<*
+		A MS inline assembly statement extension.
+	*>
+	CURSOR_MS_ASM_STMT = 229,
+
+	<*
+		The null statement ";": C99 6.8.3p3.
+		This cursor kind is used to describe the null statement.
+	*>
+	CURSOR_NULL_STMT = 230,
+
+	<*
+		Adaptor class for mixing declarations with statements and
+		expressions.
+	*>
+	CURSOR_DECL_STMT = 231,
+
+	<*
+		OpenMP parallel directive.
+	*>
+	CURSOR_OMP_PARALLEL_DIRECTIVE = 232,
+
+	<*
+		OpenMP SIMD directive.
+	*>
+	CURSOR_OMP_SIMD_DIRECTIVE = 233,
+
+	<*
+		OpenMP for directive.
+	*>
+	CURSOR_OMP_FOR_DIRECTIVE = 234,
+
+	<*
+		OpenMP sections directive.
+	*>
+	CURSOR_OMP_SECTIONS_DIRECTIVE = 235,
+
+	<*
+		OpenMP section directive.
+	*>
+	CURSOR_OMP_SECTION_DIRECTIVE = 236,
+
+	<*
+		OpenMP single directive.
+	*>
+	CURSOR_OMP_SINGLE_DIRECTIVE = 237,
+
+	<*
+		OpenMP parallel for directive.
+	*>
+	CURSOR_OMP_PARALLEL_FOR_DIRECTIVE = 238,
+
+	<*
+		OpenMP parallel sections directive.
+	*>
+	CURSOR_OMP_PARALLEL_SECTIONS_DIRECTIVE = 239,
+
+	<*
+		OpenMP task directive.
+	*>
+	CURSOR_OMP_TASK_DIRECTIVE = 240,
+
+	<*
+		OpenMP master directive.
+	*>
+	CURSOR_OMP_MASTER_DIRECTIVE = 241,
+
+	<*
+		OpenMP critical directive.
+	*>
+	CURSOR_OMP_CRITICAL_DIRECTIVE = 242,
+
+	<*
+		OpenMP taskyield directive.
+	*>
+	CURSOR_OMP_TASKYIELD_DIRECTIVE = 243,
+
+	<*
+		OpenMP barrier directive.
+	*>
+	CURSOR_OMP_BARRIER_DIRECTIVE = 244,
+
+	<*
+		OpenMP taskwait directive.
+	*>
+	CURSOR_OMP_TASKWAIT_DIRECTIVE = 245,
+
+	<*
+		OpenMP flush directive.
+	*>
+	CURSOR_OMP_FLUSH_DIRECTIVE = 246,
+
+	<*
+		Windows Structured Exception Handling's leave statement.
+	*>
+	CURSOR_SEH_LEAVE_STMT = 247,
+
+	<*
+		OpenMP ordered directive.
+	*>
+	CURSOR_OMP_ORDERED_DIRECTIVE = 248,
+
+	<*
+		OpenMP atomic directive.
+	*>
+	CURSOR_OMP_ATOMIC_DIRECTIVE = 249,
+
+	<*
+		OpenMP for SIMD directive.
+	*>
+	CURSOR_OMP_FOR_SIMD_DIRECTIVE = 250,
+
+	<*
+		OpenMP parallel for SIMD directive.
+	*>
+	CURSOR_OMP_PARALLEL_FOR_SIMD_DIRECTIVE = 251,
+
+	<*
+		OpenMP target directive.
+	*>
+	CURSOR_OMP_TARGET_DIRECTIVE = 252,
+
+	<*
+		OpenMP teams directive.
+	*>
+	CURSOR_OMP_TEAMS_DIRECTIVE = 253,
+
+	<*
+		OpenMP taskgroup directive.
+	*>
+	CURSOR_OMP_TASKGROUP_DIRECTIVE = 254,
+
+	<*
+		OpenMP cancellation point directive.
+	*>
+	CURSOR_OMP_CANCELLATION_POINT_DIRECTIVE = 255,
+
+	<*
+		OpenMP cancel directive.
+	*>
+	CURSOR_OMP_CANCEL_DIRECTIVE = 256,
+
+	<*
+		OpenMP target data directive.
+	*>
+	CURSOR_OMP_TARGET_DATA_DIRECTIVE = 257,
+
+	<*
+		OpenMP taskloop directive.
+	*>
+	CURSOR_OMP_TASK_LOOP_DIRECTIVE = 258,
+
+	<*
+		OpenMP taskloop simd directive.
+	*>
+	CURSOR_OMP_TASK_LOOP_SIMD_DIRECTIVE = 259,
+
+	<*
+		OpenMP distribute directive.
+	*>
+	CURSOR_OMP_DISTRIBUTE_DIRECTIVE = 260,
+
+	<*
+		OpenMP target enter data directive.
+	*>
+	CURSOR_OMP_TARGET_ENTER_DATA_DIRECTIVE = 261,
+
+	<*
+		OpenMP target exit data directive.
+	*>
+	CURSOR_OMP_TARGET_EXIT_DATA_DIRECTIVE = 262,
+
+	<*
+		OpenMP target parallel directive.
+	*>
+	CURSOR_OMP_TARGET_PARALLEL_DIRECTIVE = 263,
+
+	<*
+		OpenMP target parallel for directive.
+	*>
+	CURSOR_OMP_TARGET_PARALLEL_FOR_DIRECTIVE = 264,
+
+	<*
+		OpenMP target update directive.
+	*>
+	CURSOR_OMP_TARGET_UPDATE_DIRECTIVE = 265,
+
+	<*
+		OpenMP distribute parallel for directive.
+	*>
+	CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 266,
+
+	<*
+		OpenMP distribute parallel for simd directive.
+	*>
+	CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 267,
+
+	<*
+		OpenMP distribute simd directive.
+	*>
+	CURSOR_OMP_DISTRIBUTE_SIMD_DIRECTIVE = 268,
+
+	<*
+		OpenMP target parallel for simd directive.
+	*>
+	CURSOR_OMP_TARGET_PARALLEL_FOR_SIMD_DIRECTIVE = 269,
+
+	<*
+		OpenMP target simd directive.
+	*>
+	CURSOR_OMP_TARGET_SIMD_DIRECTIVE = 270,
+
+	<*
+		OpenMP teams distribute directive.
+	*>
+	CURSOR_OMP_TEAMS_DISTRIBUTE_DIRECTIVE = 271,
+
+	<*
+		OpenMP teams distribute simd directive.
+	*>
+	CURSOR_OMP_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 272,
+
+	<*
+		OpenMP teams distribute parallel for simd directive.
+	*>
+	CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 273,
+
+	<*
+		OpenMP teams distribute parallel for directive.
+	*>
+	CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 274,
+
+	<*
+		OpenMP target teams directive.
+	*>
+	CURSOR_OMP_TARGET_TEAMS_DIRECTIVE = 275,
+
+	<*
+		OpenMP target teams distribute directive.
+	*>
+	CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_DIRECTIVE = 276,
+
+	<*
+		OpenMP target teams distribute parallel for directive.
+	*>
+	CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 277,
+
+	<*
+		OpenMP target teams distribute parallel for simd directive.
+	*>
+	CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 278,
+
+	<*
+		OpenMP target teams distribute simd directive.
+	*>
+	CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 279,
+
+	<*
+		C++2a std::bit_cast expression.
+	*>
+	CURSOR_BUILTIN_BIT_CAST_EXPR = 280,
+
+	<*
+		OpenMP master taskloop directive.
+	*>
+	CURSOR_OMP_MASTER_TASK_LOOP_DIRECTIVE = 281,
+
+	<*
+		OpenMP parallel master taskloop directive.
+	*>
+	CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_DIRECTIVE = 282,
+
+	<*
+		OpenMP master taskloop simd directive.
+	*>
+	CURSOR_OMP_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 283,
+
+	<*
+		OpenMP parallel master taskloop simd directive.
+	*>
+	CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 284,
+
+	<*
+		OpenMP parallel master directive.
+	*>
+	CURSOR_OMP_PARALLEL_MASTER_DIRECTIVE = 285,
+
+	<*
+		OpenMP depobj directive.
+	*>
+	CURSOR_OMP_DEPOBJ_DIRECTIVE = 286,
+
+	<*
+		OpenMP scan directive.
+	*>
+	CURSOR_OMP_SCAN_DIRECTIVE = 287,
+
+	<*
+		OpenMP tile directive.
+	*>
+	CURSOR_OMP_TILE_DIRECTIVE = 288,
+
+	<*
+		OpenMP canonical loop.
+	*>
+	CURSOR_OMP_CANONICAL_LOOP = 289,
+
+	<*
+		OpenMP interop directive.
+	*>
+	CURSOR_OMP_INTEROP_DIRECTIVE = 290,
+
+	<*
+		OpenMP dispatch directive.
+	*>
+	CURSOR_OMP_DISPATCH_DIRECTIVE = 291,
+
+	<*
+		OpenMP masked directive.
+	*>
+	CURSOR_OMP_MASKED_DIRECTIVE = 292,
+
+	<*
+		OpenMP unroll directive.
+	*>
+	CURSOR_OMP_UNROLL_DIRECTIVE = 293,
+
+	<*
+		OpenMP metadirective directive.
+	*>
+	CURSOR_OMP_META_DIRECTIVE = 294,
+
+	<*
+		OpenMP loop directive.
+	*>
+	CURSOR_OMP_GENERIC_LOOP_DIRECTIVE = 295,
+
+	<*
+		OpenMP teams loop directive.
+	*>
+	CURSOR_OMP_TEAMS_GENERIC_LOOP_DIRECTIVE = 296,
+
+	<*
+		OpenMP target teams loop directive.
+	*>
+	CURSOR_OMP_TARGET_TEAMS_GENERIC_LOOP_DIRECTIVE = 297,
+
+	<*
+		OpenMP parallel loop directive.
+	*>
+	CURSOR_OMP_PARALLEL_GENERIC_LOOP_DIRECTIVE = 298,
+
+	<*
+		OpenMP target parallel loop directive.
+	*>
+	CURSOR_OMP_TARGET_PARALLEL_GENERIC_LOOP_DIRECTIVE = 299,
+
+	<*
+		OpenMP parallel masked directive.
+	*>
+	CURSOR_OMP_PARALLEL_MASKED_DIRECTIVE = 300,
+
+	<*
+		OpenMP masked taskloop directive.
+	*>
+	CURSOR_OMP_MASKED_TASK_LOOP_DIRECTIVE = 301,
+
+	<*
+		OpenMP masked taskloop simd directive.
+	*>
+	CURSOR_OMP_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 302,
+
+	<*
+		OpenMP parallel masked taskloop directive.
+	*>
+	CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_DIRECTIVE = 303,
+
+	<*
+		OpenMP parallel masked taskloop simd directive.
+	*>
+	CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 304,
+
+	<*
+		OpenMP error directive.
+	*>
+	CURSOR_OMP_ERROR_DIRECTIVE = 305,
+
+	<*
+		OpenMP scope directive.
+	*>
+	CURSOR_OMP_SCOPE_DIRECTIVE = 306,
+
+	<*
+		OpenMP reverse directive.
+	*>
+	CURSOR_OMP_REVERSE_DIRECTIVE = 307,
+
+	<*
+		OpenMP interchange directive.
+	*>
+	CURSOR_OMP_INTERCHANGE_DIRECTIVE = 308,
+
+	<*
+		OpenMP assume directive.
+	*>
+	CURSOR_OMP_ASSUME_DIRECTIVE = 309,
+
+	<*
+		OpenMP assume directive.
+	*>
+	CURSOR_OMP_STRIPE_DIRECTIVE = 310,
+
+	<*
+		OpenMP fuse directive
+	*>
+	CURSOR_OMP_FUSE_DIRECTIVE = 311,
+
+	<*
+		OpenACC Compute Construct.
+	*>
+	CURSOR_OPEN_ACC_COMPUTE_CONSTRUCT = 320,
+
+	<*
+		OpenACC Loop Construct.
+	*>
+	CURSOR_OPEN_ACC_LOOP_CONSTRUCT = 321,
+
+	<*
+		OpenACC Combined Constructs.
+	*>
+	CURSOR_OPEN_ACC_COMBINED_CONSTRUCT = 322,
+
+	<*
+		OpenACC data Construct.
+	*>
+	CURSOR_OPEN_ACC_DATA_CONSTRUCT = 323,
+
+	<*
+		OpenACC enter data Construct.
+	*>
+	CURSOR_OPEN_ACC_ENTER_DATA_CONSTRUCT = 324,
+
+	<*
+		OpenACC exit data Construct.
+	*>
+	CURSOR_OPEN_ACC_EXIT_DATA_CONSTRUCT = 325,
+
+	<*
+		OpenACC host_data Construct.
+	*>
+	CURSOR_OPEN_ACC_HOST_DATA_CONSTRUCT = 326,
+
+	<*
+		OpenACC wait Construct.
+	*>
+	CURSOR_OPEN_ACC_WAIT_CONSTRUCT = 327,
+
+	<*
+		OpenACC init Construct.
+	*>
+	CURSOR_OPEN_ACC_INIT_CONSTRUCT = 328,
+
+	<*
+		OpenACC shutdown Construct.
+	*>
+	CURSOR_OPEN_ACC_SHUTDOWN_CONSTRUCT = 329,
+
+	<*
+		OpenACC set Construct.
+	*>
+	CURSOR_OPEN_ACC_SET_CONSTRUCT = 330,
+
+	<*
+		OpenACC update Construct.
+	*>
+	CURSOR_OPEN_ACC_UPDATE_CONSTRUCT = 331,
+
+	<*
+		OpenACC atomic Construct.
+	*>
+	CURSOR_OPEN_ACC_ATOMIC_CONSTRUCT = 332,
+
+	<*
+		OpenACC cache Construct.
+	*>
+	CURSOR_OPEN_ACC_CACHE_CONSTRUCT = 333,
+
+	<*
+		OpenACC cache Construct.
+	*>
+	CURSOR_LAST_STMT = 333,
+
+	<*
+		Cursor that represents the translation unit itself.
+		The translation unit cursor exists primarily to act as the root
+		cursor for traversing the contents of a translation unit.
+	*>
+	CURSOR_TRANSLATION_UNIT = 350,
+
+	<*
+		Cursor that represents the translation unit itself.
+		The translation unit cursor exists primarily to act as the root
+		cursor for traversing the contents of a translation unit.
+	*>
+	CURSOR_FIRST_ATTR = 400,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_UNEXPOSED_ATTR = 400,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_IB_ACTION_ATTR = 401,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_IB_OUTLET_ATTR = 402,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_IB_OUTLET_COLLECTION_ATTR = 403,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_CXX_FINAL_ATTR = 404,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_CXX_OVERRIDE_ATTR = 405,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_ANNOTATE_ATTR = 406,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_ASM_LABEL_ATTR = 407,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_PACKED_ATTR = 408,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_PURE_ATTR = 409,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_CONST_ATTR = 410,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_NO_DUPLICATE_ATTR = 411,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_CUDA_CONSTANT_ATTR = 412,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_CUDA_DEVICE_ATTR = 413,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_CUDA_GLOBAL_ATTR = 414,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_CUDA_HOST_ATTR = 415,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_CUDA_SHARED_ATTR = 416,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_VISIBILITY_ATTR = 417,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_DLL_EXPORT = 418,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_DLL_IMPORT = 419,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_NS_RETURNS_RETAINED = 420,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_NS_RETURNS_NOT_RETAINED = 421,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_NS_RETURNS_AUTORELEASED = 422,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_NS_CONSUMES_SELF = 423,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_NS_CONSUMED = 424,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_EXCEPTION = 425,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_CNS_OBJECT = 426,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_INDEPENDENT_CLASS = 427,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_PRECISE_LIFETIME = 428,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_RETURNS_INNER_POINTER = 429,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_REQUIRES_SUPER = 430,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_ROOT_CLASS = 431,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_SUBCLASSING_RESTRICTED = 432,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_EXPLICIT_PROTOCOL_IMPL = 433,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_DESIGNATED_INITIALIZER = 434,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_RUNTIME_VISIBLE = 435,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_OBJ_C_BOXABLE = 436,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_FLAG_ENUM = 437,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_CONVERGENT_ATTR = 438,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_WARN_UNUSED_ATTR = 439,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_WARN_UNUSED_RESULT_ATTR = 440,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_ALIGNED_ATTR = 441,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_LAST_ATTR = 441,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_PREPROCESSING_DIRECTIVE = 500,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_MACRO_DEFINITION = 501,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_MACRO_EXPANSION = 502,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_MACRO_INSTANTIATION = 502,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_INCLUSION_DIRECTIVE = 503,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_FIRST_PREPROCESSING = 500,
+
+	<*
+		An attribute whose specific kind is not exposed via this
+		interface.
+	*>
+	CURSOR_LAST_PREPROCESSING = 503,
+
+	<*
+		A module import declaration.
+	*>
+	CURSOR_MODULE_IMPORT_DECL = 600,
+
+	<*
+		A module import declaration.
+	*>
+	CURSOR_TYPE_ALIAS_TEMPLATE_DECL = 601,
+
+	<*
+		A static_assert or _Static_assert node
+	*>
+	CURSOR_STATIC_ASSERT = 602,
+
+	<*
+		a friend declaration.
+	*>
+	CURSOR_FRIEND_DECL = 603,
+
+	<*
+		a concept declaration.
+	*>
+	CURSOR_CONCEPT_DECL = 604,
+
+	<*
+		a concept declaration.
+	*>
+	CURSOR_FIRST_EXTRA_DECL = 600,
+
+	<*
+		a concept declaration.
+	*>
+	CURSOR_LAST_EXTRA_DECL = 604,
+
+	<*
+		A code completion overload candidate.
+	*>
+	CURSOR_OVERLOAD_CANDIDATE = 700
 }
 
+<*
+	A cursor representing some element in the abstract syntax tree for
+	a translation unit.
+	The cursor abstraction unifies the different kinds of entities in a
+	program--declaration, statements, expressions, references to declarations,
+	etc.--under a single "cursor" abstraction with a common set of operations.
+	Common operation for a cursor include: getting the physical location in
+	a source file where the cursor points, getting the name associated with a
+	cursor, and retrieving cursors for any child nodes of a particular cursor.
+	Cursors can be produced in two specific ways.
+	clang_getTranslationUnitCursor() produces a cursor for a translation unit,
+	from which one can use clang_visitChildren() to explore the rest of the
+	translation unit. clang_getCursor() maps from a physical source location
+	to the entity that resides at that location, allowing one to map from the
+	source code into the AST.
+*>
 struct CXCursor {
-  CXCursorKind kind;
-  CInt xdata;
-  void*[3] data;
+	CXCursorKind kind;
+	CInt xdata;
+	void*[3] data;
 }
 
+<*
+	Retrieve the NULL cursor, which represents no entity.
+*>
 extern fn CXCursor getNullCursor()
 @cname("clang_getNullCursor");
 
+<*
+	Retrieve the cursor that represents the given translation unit.
+	The translation unit cursor can be used to start traversing the
+	various declarations within the given translation unit.
+*>
 extern fn CXCursor getTranslationUnitCursor(
-  CXTranslationUnit)
+	CXTranslationUnit)
 @cname("clang_getTranslationUnitCursor");
 
+<*
+	Determine whether two cursors are equivalent.
+*>
 extern fn CUInt equalCursors(
-  CXCursor,
-  CXCursor)
+	CXCursor,
+	CXCursor)
 @cname("clang_equalCursors");
 
+<*
+	Returns non-zero if \p cursor is null.
+*>
 extern fn CInt cursor_isNull(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_Cursor_isNull");
 
+<*
+	Compute a hash value for the given cursor.
+*>
 extern fn CUInt hashCursor(
-  CXCursor)
+	CXCursor)
 @cname("clang_hashCursor");
 
+<*
+	Retrieve the kind of the given cursor.
+*>
 extern fn CXCursorKind getCursorKind(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCursorKind");
 
+<*
+	Determine whether the given cursor kind represents a declaration.
+*>
 extern fn CUInt isDeclaration(
-  CXCursorKind)
+	CXCursorKind)
 @cname("clang_isDeclaration");
 
+<*
+	Determine whether the given declaration is invalid.
+	A declaration is invalid if it could not be parsed successfully.
+	\returns non-zero if the cursor represents a declaration and it is
+	invalid, otherwise NULL.
+*>
 extern fn CUInt isInvalidDeclaration(
-  CXCursor)
+	CXCursor)
 @cname("clang_isInvalidDeclaration");
 
+<*
+	Determine whether the given cursor kind represents a simple
+	reference.
+	Note that other kinds of cursors (such as expressions) can also refer to
+	other cursors. Use clang_getCursorReferenced() to determine whether a
+	particular cursor refers to another entity.
+*>
 extern fn CUInt isReference(
-  CXCursorKind)
+	CXCursorKind)
 @cname("clang_isReference");
 
+<*
+	Determine whether the given cursor kind represents an expression.
+*>
 extern fn CUInt isExpression(
-  CXCursorKind)
+	CXCursorKind)
 @cname("clang_isExpression");
 
+<*
+	Determine whether the given cursor kind represents a statement.
+*>
 extern fn CUInt isStatement(
-  CXCursorKind)
+	CXCursorKind)
 @cname("clang_isStatement");
 
+<*
+	Determine whether the given cursor kind represents an attribute.
+*>
 extern fn CUInt isAttribute(
-  CXCursorKind)
+	CXCursorKind)
 @cname("clang_isAttribute");
 
+<*
+	Determine whether the given cursor has any attributes.
+*>
 extern fn CUInt cursor_hasAttrs(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_hasAttrs");
 
+<*
+	Determine whether the given cursor kind represents an invalid
+	cursor.
+*>
 extern fn CUInt isInvalid(
-  CXCursorKind)
+	CXCursorKind)
 @cname("clang_isInvalid");
 
+<*
+	Determine whether the given cursor kind represents a translation
+	unit.
+*>
 extern fn CUInt isTranslationUnit(
-  CXCursorKind)
+	CXCursorKind)
 @cname("clang_isTranslationUnit");
 
+<*
+	Determine whether the given cursor represents a preprocessing
+	element, such as a preprocessor directive or macro instantiation.
+*>
 extern fn CUInt isPreprocessing(
-  CXCursorKind)
+	CXCursorKind)
 @cname("clang_isPreprocessing");
 
+<*
+	Determine whether the given cursor represents a currently
+	unexposed piece of the AST (e.g., CXCursor_UnexposedStmt).
+*>
 extern fn CUInt isUnexposed(
-  CXCursorKind)
+	CXCursorKind)
 @cname("clang_isUnexposed");
 
+<*
+	Describe the linkage of the entity referred to by a cursor.
+*>
 constdef CXLinkageKind : CInt {
-  LINKAGE_INVALID = 0,
-  LINKAGE_NO_LINKAGE = 1,
-  LINKAGE_INTERNAL = 2,
-  LINKAGE_UNIQUE_EXTERNAL = 3,
-  LINKAGE_EXTERNAL = 4
+
+	<*
+		This value indicates that no linkage information is available
+		for a provided CXCursor. *
+	*>
+	LINKAGE_INVALID = 0,
+
+	<*
+		This is the linkage for variables, parameters, and so on that
+		have automatic storage.  This covers normal (non-extern) local variables.
+	*>
+	LINKAGE_NO_LINKAGE = 1,
+
+	<*
+		This is the linkage for static variables and static functions. *
+	*>
+	LINKAGE_INTERNAL = 2,
+
+	<*
+		This is the linkage for entities with external linkage that live
+		in C++ anonymous namespaces.*
+	*>
+	LINKAGE_UNIQUE_EXTERNAL = 3,
+
+	<*
+		This is the linkage for entities with true, external linkage. *
+	*>
+	LINKAGE_EXTERNAL = 4
 }
 
+<*
+	Determine the linkage of the entity referred to by a given cursor.
+*>
 extern fn CXLinkageKind getCursorLinkage(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorLinkage");
 
+
 constdef CXVisibilityKind : CInt {
-  VISIBILITY_INVALID = 0,
-  VISIBILITY_HIDDEN = 1,
-  VISIBILITY_PROTECTED = 2,
-  VISIBILITY_DEFAULT = 3
+
+	<*
+		This value indicates that no visibility information is available
+		for a provided CXCursor. *
+	*>
+	VISIBILITY_INVALID = 0,
+
+	<*
+		Symbol not seen by the linker. *
+	*>
+	VISIBILITY_HIDDEN = 1,
+
+	<*
+		Symbol seen by the linker but resolves to a symbol inside this object. *
+	*>
+	VISIBILITY_PROTECTED = 2,
+
+	<*
+		Symbol seen by the linker and acts like a normal symbol. *
+	*>
+	VISIBILITY_DEFAULT = 3
 }
 
+<*
+	Describe the visibility of the entity referred to by a cursor.
+	This returns the default visibility if not explicitly specified by
+	a visibility attribute. The default visibility may be changed by
+	commandline arguments.
+	\param cursor The cursor to query.
+	\returns The visibility of the cursor.
+*>
 extern fn CXVisibilityKind getCursorVisibility(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorVisibility");
 
+<*
+	Determine the availability of the entity that this cursor refers to,
+	taking the current target platform into account.
+	\param cursor The cursor to query.
+	\returns The availability of the cursor.
+*>
 extern fn CXAvailabilityKind getCursorAvailability(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorAvailability");
 
+<*
+	Describes the availability of a given entity on a particular platform, e.g.,
+	a particular class might only be available on Mac OS 10.7 or newer.
+*>
 struct CXPlatformAvailability {
-  CXString platform;
-  CXVersion introduced;
-  CXVersion deprecated;
-  CXVersion obsoleted;
-  CInt unavailable;
-  CXString message;
+	CXString platform;
+	CXVersion introduced;
+	CXVersion deprecated;
+	CXVersion obsoleted;
+	CInt unavailable;
+	CXString message;
 }
 
+<*
+	Determine the availability of the entity that this cursor refers to
+	on any platforms for which availability information is known.
+	\param cursor The cursor to query.
+	\param always_deprecated If non-NULL, will be set to indicate whether the
+	entity is deprecated on all platforms.
+	\param deprecated_message If non-NULL, will be set to the message text
+	provided along with the unconditional deprecation of this entity. The client
+	is responsible for deallocating this string.
+	\param always_unavailable If non-NULL, will be set to indicate whether the
+	entity is unavailable on all platforms.
+	\param unavailable_message If non-NULL, will be set to the message text
+	provided along with the unconditional unavailability of this entity. The
+	client is responsible for deallocating this string.
+	\param availability If non-NULL, an array of CXPlatformAvailability instances
+	that will be populated with platform availability information, up to either
+	the number of platforms for which availability information is available (as
+	returned by this function) or \c availability_size, whichever is smaller.
+	\param availability_size The number of elements available in the
+	\c availability array.
+	\returns The number of platforms (N) for which availability information is
+	available (which is unrelated to \c availability_size).
+	Note that the client is responsible for calling
+	\c clang_disposeCXPlatformAvailability to free each of the
+	platform-availability structures returned. There are
+	\c min(N, availability_size) such structures.
+*>
 extern fn CInt getCursorPlatformAvailability(
-  CXCursor cursor,
-  CInt* always_deprecated,
-  CXString* deprecated_message,
-  CInt* always_unavailable,
-  CXString* unavailable_message,
-  CXPlatformAvailability* availability,
-  CInt availability_size)
+	CXCursor cursor,
+	CInt* always_deprecated,
+	CXString* deprecated_message,
+	CInt* always_unavailable,
+	CXString* unavailable_message,
+	CXPlatformAvailability* availability,
+	CInt availability_size)
 @cname("clang_getCursorPlatformAvailability");
 
+<*
+	Free the memory associated with a \c CXPlatformAvailability structure.
+*>
 extern fn void disposeCXPlatformAvailability(
-  CXPlatformAvailability* availability)
+	CXPlatformAvailability* availability)
 @cname("clang_disposeCXPlatformAvailability");
 
+<*
+	If cursor refers to a variable declaration and it has initializer returns
+	cursor referring to the initializer otherwise return null cursor.
+*>
 extern fn CXCursor cursor_getVarDeclInitializer(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_Cursor_getVarDeclInitializer");
 
+<*
+	If cursor refers to a variable declaration that has global storage returns 1.
+	If cursor refers to a variable declaration that doesn't have global storage
+	returns 0. Otherwise returns -1.
+*>
 extern fn CInt cursor_hasVarDeclGlobalStorage(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_Cursor_hasVarDeclGlobalStorage");
 
+<*
+	If cursor refers to a variable declaration that has external storage
+	returns 1. If cursor refers to a variable declaration that doesn't have
+	external storage returns 0. Otherwise returns -1.
+*>
 extern fn CInt cursor_hasVarDeclExternalStorage(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_Cursor_hasVarDeclExternalStorage");
 
+<*
+	Describe the "language" of the entity referred to by a cursor.
+*>
 constdef CXLanguageKind : CInt {
-  LANGUAGE_INVALID = 0,
-  LANGUAGE_C = 1,
-  LANGUAGE_OBJ_C = 2,
-  LANGUAGE_C_PLUS_PLUS = 3
+	LANGUAGE_INVALID = 0,
+	LANGUAGE_C = 1,
+	LANGUAGE_OBJ_C = 2,
+	LANGUAGE_C_PLUS_PLUS = 3
 }
 
+<*
+	Determine the "language" of the entity referred to by a given cursor.
+*>
 extern fn CXLanguageKind getCursorLanguage(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorLanguage");
 
+<*
+	Describe the "thread-local storage (TLS) kind" of the declaration
+	referred to by a cursor.
+*>
 constdef CXTLSKind : CInt {
-  TLS_NONE = 0,
-  TLS_DYNAMIC = 1,
-  TLS_STATIC = 2
+	TLS_NONE = 0,
+	TLS_DYNAMIC = 1,
+	TLS_STATIC = 2
 }
 
+<*
+	Determine the "thread-local storage (TLS) kind" of the declaration
+	referred to by a cursor.
+*>
 extern fn CXTLSKind getCursorTLSKind(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorTLSKind");
 
+<*
+	Returns the translation unit that a cursor originated from.
+*>
 extern fn CXTranslationUnit cursor_getTranslationUnit(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_getTranslationUnit");
 
 alias CXCursorSet = void*;
 
+<*
+	Creates an empty CXCursorSet.
+*>
 extern fn CXCursorSet createCXCursorSet()
 @cname("clang_createCXCursorSet");
 
+<*
+	Disposes a CXCursorSet and releases its associated memory.
+*>
 extern fn void disposeCXCursorSet(
-  CXCursorSet cset)
+	CXCursorSet cset)
 @cname("clang_disposeCXCursorSet");
 
+<*
+	Queries a CXCursorSet to see if it contains a specific CXCursor.
+	\returns non-zero if the set contains the specified cursor.
+*>
 extern fn CUInt cXCursorSet_contains(
-  CXCursorSet cset,
-  CXCursor cursor)
+	CXCursorSet cset,
+	CXCursor cursor)
 @cname("clang_CXCursorSet_contains");
 
+<*
+	Inserts a CXCursor into a CXCursorSet.
+	\returns zero if the CXCursor was already in the set, and non-zero otherwise.
+*>
 extern fn CUInt cXCursorSet_insert(
-  CXCursorSet cset,
-  CXCursor cursor)
+	CXCursorSet cset,
+	CXCursor cursor)
 @cname("clang_CXCursorSet_insert");
 
+<*
+	Determine the semantic parent of the given cursor.
+	The semantic parent of a cursor is the cursor that semantically contains
+	the given \p cursor. For many declarations, the lexical and semantic parents
+	are equivalent (the lexical parent is returned by
+	\c clang_getCursorLexicalParent()). They diverge when declarations or
+	definitions are provided out-of-line. For example:
+	\code
+	class C {
+	void f();
+	};
+	void C::f() { }
+	\endcode
+	In the out-of-line definition of \c C::f, the semantic parent is
+	the class \c C, of which this function is a member. The lexical parent is
+	the place where the declaration actually occurs in the source code; in this
+	case, the definition occurs in the translation unit. In general, the
+	lexical parent for a given entity can change without affecting the semantics
+	of the program, and the lexical parent of different declarations of the
+	same entity may be different. Changing the semantic parent of a declaration,
+	on the other hand, can have a major impact on semantics, and redeclarations
+	of a particular entity should all have the same semantic context.
+	In the example above, both declarations of \c C::f have \c C as their
+	semantic context, while the lexical context of the first \c C::f is \c C
+	and the lexical context of the second \c C::f is the translation unit.
+	For global declarations, the semantic parent is the translation unit.
+*>
 extern fn CXCursor getCursorSemanticParent(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorSemanticParent");
 
+<*
+	Determine the lexical parent of the given cursor.
+	The lexical parent of a cursor is the cursor in which the given \p cursor
+	was actually written. For many declarations, the lexical and semantic parents
+	are equivalent (the semantic parent is returned by
+	\c clang_getCursorSemanticParent()). They diverge when declarations or
+	definitions are provided out-of-line. For example:
+	\code
+	class C {
+	void f();
+	};
+	void C::f() { }
+	\endcode
+	In the out-of-line definition of \c C::f, the semantic parent is
+	the class \c C, of which this function is a member. The lexical parent is
+	the place where the declaration actually occurs in the source code; in this
+	case, the definition occurs in the translation unit. In general, the
+	lexical parent for a given entity can change without affecting the semantics
+	of the program, and the lexical parent of different declarations of the
+	same entity may be different. Changing the semantic parent of a declaration,
+	on the other hand, can have a major impact on semantics, and redeclarations
+	of a particular entity should all have the same semantic context.
+	In the example above, both declarations of \c C::f have \c C as their
+	semantic context, while the lexical context of the first \c C::f is \c C
+	and the lexical context of the second \c C::f is the translation unit.
+	For declarations written in the global scope, the lexical parent is
+	the translation unit.
+*>
 extern fn CXCursor getCursorLexicalParent(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorLexicalParent");
 
+<*
+	Determine the set of methods that are overridden by the given
+	method.
+	In both Objective-C and C++, a method (aka virtual member function,
+	in C++) can override a virtual method in a base class. For
+	Objective-C, a method is said to override any method in the class's
+	base class, its protocols, or its categories' protocols, that has the same
+	selector and is of the same kind (class or instance).
+	If no such method exists, the search continues to the class's superclass,
+	its protocols, and its categories, and so on. A method from an Objective-C
+	implementation is considered to override the same methods as its
+	corresponding method in the interface.
+	For C++, a virtual member function overrides any virtual member
+	function with the same signature that occurs in its base
+	classes. With multiple inheritance, a virtual member function can
+	override several virtual member functions coming from different
+	base classes.
+	In all cases, this function determines the immediate overridden
+	method, rather than all of the overridden methods. For example, if
+	a method is originally declared in a class A, then overridden in B
+	(which in inherits from A) and also in C (which inherited from B),
+	then the only overridden method returned from this function when
+	invoked on C's method will be B's method. The client may then
+	invoke this function again, given the previously-found overridden
+	methods, to map out the complete method-override set.
+	\param cursor A cursor representing an Objective-C or C++
+	method. This routine will compute the set of methods that this
+	method overrides.
+	\param overridden A pointer whose pointee will be replaced with a
+	pointer to an array of cursors, representing the set of overridden
+	methods. If there are no overridden methods, the pointee will be
+	set to NULL. The pointee must be freed via a call to
+	\c clang_disposeOverriddenCursors().
+	\param num_overridden A pointer to the number of overridden
+	functions, will be set to the number of overridden functions in the
+	array pointed to by \p overridden.
+*>
 extern fn void getOverriddenCursors(
-  CXCursor cursor,
-  CXCursor** overridden,
-  CUInt* num_overridden)
+	CXCursor cursor,
+	CXCursor** overridden,
+	CUInt* num_overridden)
 @cname("clang_getOverriddenCursors");
 
+<*
+	Free the set of overridden cursors returned by \c
+	clang_getOverriddenCursors().
+*>
 extern fn void disposeOverriddenCursors(
-  CXCursor* overridden)
+	CXCursor* overridden)
 @cname("clang_disposeOverriddenCursors");
 
+<*
+	Retrieve the file that is included by the given inclusion directive
+	cursor.
+*>
 extern fn CXFile getIncludedFile(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getIncludedFile");
 
+<*
+	Map a source location to the cursor that describes the entity at that
+	location in the source code.
+	clang_getCursor() maps an arbitrary source location within a translation
+	unit down to the most specific cursor that describes the entity at that
+	location. For example, given an expression \c x + y, invoking
+	clang_getCursor() with a source location pointing to "x" will return the
+	cursor for "x"; similarly for "y". If the cursor points anywhere between
+	"x" or "y" (e.g., on the + or the whitespace around it), clang_getCursor()
+	will return a cursor referring to the "+" expression.
+	\returns a cursor representing the entity at the given source location, or
+	a NULL cursor if no such entity can be found.
+*>
 extern fn CXCursor getCursor(
-  CXTranslationUnit,
-  CXSourceLocation)
+	CXTranslationUnit,
+	CXSourceLocation)
 @cname("clang_getCursor");
 
+<*
+	Retrieve the physical location of the source constructor referenced
+	by the given cursor.
+	The location of a declaration is typically the location of the name of that
+	declaration, where the name of that declaration would occur if it is
+	unnamed, or some keyword that introduces that particular declaration.
+	The location of a reference is where that reference occurs within the
+	source code.
+*>
 extern fn CXSourceLocation getCursorLocation(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCursorLocation");
 
+<*
+	Retrieve the physical extent of the source construct referenced by
+	the given cursor.
+	The extent of a cursor starts with the file/line/column pointing at the
+	first character within the source construct that the cursor refers to and
+	ends with the last character within that source construct. For a
+	declaration, the extent covers the declaration itself. For a reference,
+	the extent covers the location of the reference (e.g., where the referenced
+	entity was actually used).
+*>
 extern fn CXSourceRange getCursorExtent(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCursorExtent");
 
+<*
+	Describes the kind of type
+*>
 constdef CXTypeKind : CInt {
-  TYPE_INVALID = 0,
-  TYPE_UNEXPOSED = 1,
-  TYPE_VOID = 2,
-  TYPE_BOOL = 3,
-  TYPE_CHAR_U = 4,
-  TYPE_UCHAR = 5,
-  TYPE_CHAR_16 = 6,
-  TYPE_CHAR_32 = 7,
-  TYPE_USHORT = 8,
-  TYPE_UINT = 9,
-  TYPE_ULONG = 10,
-  TYPE_ULONGLONG = 11,
-  TYPE_UINT128 = 12,
-  TYPE_CHARS = 13,
-  TYPE_SCHAR = 14,
-  TYPE_WCHAR = 15,
-  TYPE_SHORT = 16,
-  TYPE_INT = 17,
-  TYPE_LONG = 18,
-  TYPE_LONG_LONG = 19,
-  TYPE_INT_128 = 20,
-  TYPE_FLOAT = 21,
-  TYPE_DOUBLE = 22,
-  TYPE_LONG_DOUBLE = 23,
-  TYPE_NULL_PTR = 24,
-  TYPE_OVERLOAD = 25,
-  TYPE_DEPENDENT = 26,
-  TYPE_OBJ_C_ID = 27,
-  TYPE_OBJ_C_CLASS = 28,
-  TYPE_OBJ_C_SEL = 29,
-  TYPE_FLOAT_128 = 30,
-  TYPE_HALF = 31,
-  TYPE_FLOAT_16 = 32,
-  TYPE_SHORT_ACCUM = 33,
-  TYPE_ACCUM = 34,
-  TYPE_LONG_ACCUM = 35,
-  TYPE_U_SHORT_ACCUM = 36,
-  TYPE_U_ACCUM = 37,
-  TYPE_U_LONG_ACCUM = 38,
-  TYPE_B_FLOAT_16 = 39,
-  TYPE_IBM_128 = 40,
-  TYPE_FIRST_BUILTIN = 2,
-  TYPE_LAST_BUILTIN = 40,
-  TYPE_COMPLEX = 100,
-  TYPE_POINTER = 101,
-  TYPE_BLOCK_POINTER = 102,
-  TYPE_L_VALUE_REFERENCE = 103,
-  TYPE_R_VALUE_REFERENCE = 104,
-  TYPE_RECORD = 105,
-  TYPE_ENUM = 106,
-  TYPE_TYPEDEF = 107,
-  TYPE_OBJ_C_INTERFACE = 108,
-  TYPE_OBJ_C_OBJECT_POINTER = 109,
-  TYPE_FUNCTION_NO_PROTO = 110,
-  TYPE_FUNCTION_PROTO = 111,
-  TYPE_CONSTANT_ARRAY = 112,
-  TYPE_VECTOR = 113,
-  TYPE_INCOMPLETE_ARRAY = 114,
-  TYPE_VARIABLE_ARRAY = 115,
-  TYPE_DEPENDENT_SIZED_ARRAY = 116,
-  TYPE_MEMBER_POINTER = 117,
-  TYPE_AUTO = 118,
-  TYPE_ELABORATED = 119,
-  TYPE_PIPE = 120,
-  TYPE_OCL_IMAGE_1_D_RO = 121,
-  TYPE_OCL_IMAGE_1_D_ARRAY_RO = 122,
-  TYPE_OCL_IMAGE_1_D_BUFFER_RO = 123,
-  TYPE_OCL_IMAGE_2_D_RO = 124,
-  TYPE_OCL_IMAGE_2_D_ARRAY_RO = 125,
-  TYPE_OCL_IMAGE_2_D_DEPTH_RO = 126,
-  TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_RO = 127,
-  TYPE_OCL_IMAGE_2_D_MSAARO = 128,
-  TYPE_OCL_IMAGE_2_D_ARRAY_MSAARO = 129,
-  TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_RO = 130,
-  TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_RO = 131,
-  TYPE_OCL_IMAGE_3_D_RO = 132,
-  TYPE_OCL_IMAGE_1_D_WO = 133,
-  TYPE_OCL_IMAGE_1_D_ARRAY_WO = 134,
-  TYPE_OCL_IMAGE_1_D_BUFFER_WO = 135,
-  TYPE_OCL_IMAGE_2_D_WO = 136,
-  TYPE_OCL_IMAGE_2_D_ARRAY_WO = 137,
-  TYPE_OCL_IMAGE_2_D_DEPTH_WO = 138,
-  TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_WO = 139,
-  TYPE_OCL_IMAGE_2_D_MSAAWO = 140,
-  TYPE_OCL_IMAGE_2_D_ARRAY_MSAAWO = 141,
-  TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_WO = 142,
-  TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_WO = 143,
-  TYPE_OCL_IMAGE_3_D_WO = 144,
-  TYPE_OCL_IMAGE_1_D_RW = 145,
-  TYPE_OCL_IMAGE_1_D_ARRAY_RW = 146,
-  TYPE_OCL_IMAGE_1_D_BUFFER_RW = 147,
-  TYPE_OCL_IMAGE_2_D_RW = 148,
-  TYPE_OCL_IMAGE_2_D_ARRAY_RW = 149,
-  TYPE_OCL_IMAGE_2_D_DEPTH_RW = 150,
-  TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_RW = 151,
-  TYPE_OCL_IMAGE_2_D_MSAARW = 152,
-  TYPE_OCL_IMAGE_2_D_ARRAY_MSAARW = 153,
-  TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_RW = 154,
-  TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_RW = 155,
-  TYPE_OCL_IMAGE_3_D_RW = 156,
-  TYPE_OCL_SAMPLER = 157,
-  TYPE_OCL_EVENT = 158,
-  TYPE_OCL_QUEUE = 159,
-  TYPE_OCL_RESERVE_ID = 160,
-  TYPE_OBJ_C_OBJECT = 161,
-  TYPE_OBJ_C_TYPE_PARAM = 162,
-  TYPE_ATTRIBUTED = 163,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_PAYLOAD = 164,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_PAYLOAD = 165,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_REF_PAYLOAD = 166,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_PAYLOAD = 167,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_RESULT = 168,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT = 169,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_REF_RESULT = 170,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_RESULT = 171,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REFERENCE_STREAMOUT = 172,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REFERENCE_STREAMOUT = 173,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REFERENCE_STREAMIN = 174,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REFERENCE_STREAMIN = 175,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REF_STREAMOUT = 172,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REF_STREAMOUT = 173,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REF_STREAMIN = 174,
-  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REF_STREAMIN = 175,
-  TYPE_EXT_VECTOR = 176,
-  TYPE_ATOMIC = 177,
-  TYPE_BTF_TAG_ATTRIBUTED = 178,
-  TYPE_HLSL_RESOURCE = 179,
-  TYPE_HLSL_ATTRIBUTED_RESOURCE = 180,
-  TYPE_HLSL_INLINE_SPIRV = 181
+
+	<*
+		Represents an invalid type (e.g., where no type is available).
+	*>
+	TYPE_INVALID = 0,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_UNEXPOSED = 1,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_VOID = 2,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_BOOL = 3,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_CHAR_U = 4,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_UCHAR = 5,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_CHAR_16 = 6,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_CHAR_32 = 7,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_USHORT = 8,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_UINT = 9,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_ULONG = 10,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_ULONGLONG = 11,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_UINT128 = 12,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_CHARS = 13,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_SCHAR = 14,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_WCHAR = 15,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_SHORT = 16,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_INT = 17,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_LONG = 18,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_LONGLONG = 19,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_INT128 = 20,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_FLOAT = 21,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_DOUBLE = 22,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_LONG_DOUBLE = 23,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_NULL_PTR = 24,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_OVERLOAD = 25,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_DEPENDENT = 26,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_OBJ_C_ID = 27,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_OBJ_C_CLASS = 28,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_OBJ_C_SEL = 29,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_FLOAT_128 = 30,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_HALF = 31,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_FLOAT_16 = 32,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_SHORT_ACCUM = 33,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_ACCUM = 34,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_LONG_ACCUM = 35,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_U_SHORT_ACCUM = 36,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_U_ACCUM = 37,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_U_LONG_ACCUM = 38,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_B_FLOAT_16 = 39,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_IBM_128 = 40,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_FIRST_BUILTIN = 2,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_LAST_BUILTIN = 40,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_COMPLEX = 100,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_POINTER = 101,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_BLOCK_POINTER = 102,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_L_VALUE_REFERENCE = 103,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_R_VALUE_REFERENCE = 104,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_RECORD = 105,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_ENUM = 106,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_TYPEDEF = 107,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_OBJ_C_INTERFACE = 108,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_OBJ_C_OBJECT_POINTER = 109,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_FUNCTION_NO_PROTO = 110,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_FUNCTION_PROTO = 111,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_CONSTANT_ARRAY = 112,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_VECTOR = 113,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_INCOMPLETE_ARRAY = 114,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_VARIABLE_ARRAY = 115,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_DEPENDENT_SIZED_ARRAY = 116,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_MEMBER_POINTER = 117,
+
+	<*
+		A type whose specific kind is not exposed via this
+		interface.
+	*>
+	TYPE_AUTO = 118,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_ELABORATED = 119,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_PIPE = 120,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_1_D_RO = 121,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_1_D_ARRAY_RO = 122,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_1_D_BUFFER_RO = 123,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_RO = 124,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_RO = 125,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_DEPTH_RO = 126,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_RO = 127,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_MSAARO = 128,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_MSAARO = 129,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_RO = 130,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_RO = 131,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_3_D_RO = 132,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_1_D_WO = 133,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_1_D_ARRAY_WO = 134,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_1_D_BUFFER_WO = 135,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_WO = 136,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_WO = 137,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_DEPTH_WO = 138,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_WO = 139,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_MSAAWO = 140,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_MSAAWO = 141,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_WO = 142,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_WO = 143,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_3_D_WO = 144,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_1_D_RW = 145,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_1_D_ARRAY_RW = 146,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_1_D_BUFFER_RW = 147,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_RW = 148,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_RW = 149,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_DEPTH_RW = 150,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_RW = 151,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_MSAARW = 152,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_MSAARW = 153,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_RW = 154,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_RW = 155,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_IMAGE_3_D_RW = 156,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_SAMPLER = 157,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_EVENT = 158,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_QUEUE = 159,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_RESERVE_ID = 160,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OBJ_C_OBJECT = 161,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OBJ_C_TYPE_PARAM = 162,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_ATTRIBUTED = 163,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_PAYLOAD = 164,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_PAYLOAD = 165,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_REF_PAYLOAD = 166,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_PAYLOAD = 167,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_RESULT = 168,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT = 169,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_REF_RESULT = 170,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_RESULT = 171,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REFERENCE_STREAMOUT = 172,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REFERENCE_STREAMOUT = 173,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REFERENCE_STREAMIN = 174,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REFERENCE_STREAMIN = 175,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REF_STREAMOUT = 172,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REF_STREAMOUT = 173,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REF_STREAMIN = 174,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REF_STREAMIN = 175,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_EXT_VECTOR = 176,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_ATOMIC = 177,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_BTF_TAG_ATTRIBUTED = 178,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_HLSL_RESOURCE = 179,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_HLSL_ATTRIBUTED_RESOURCE = 180,
+
+	<*
+		Represents a type that was referred to using an elaborated type keyword.
+		E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+	*>
+	TYPE_HLSL_INLINE_SPIRV = 181
 }
 
+<*
+	Describes the calling convention of a function type
+*>
 constdef CXCallingConv : CInt {
-  CALLING_CONV_DEFAULT = 0,
-  CALLING_CONV_C = 1,
-  CALLING_CONV_X86_STD_CALL = 2,
-  CALLING_CONV_X86_FAST_CALL = 3,
-  CALLING_CONV_X86_THIS_CALL = 4,
-  CALLING_CONV_X86_PASCAL = 5,
-  CALLING_CONV_AAPCS = 6,
-  CALLING_CONV_AAPCS_VFP = 7,
-  CALLING_CONV_X86_REG_CALL = 8,
-  CALLING_CONV_INTEL_OCL_BICC = 9,
-  CALLING_CONV_WIN_64 = 10,
-  CALLING_CONV_X86_64_WIN_64 = 10,
-  CALLING_CONV_X86_64_SYS_V = 11,
-  CALLING_CONV_X86_VECTOR_CALL = 12,
-  CALLING_CONV_SWIFT = 13,
-  CALLING_CONV_PRESERVE_MOST = 14,
-  CALLING_CONV_PRESERVE_ALL = 15,
-  CALLING_CONV_A_ARCH_64_VECTOR_CALL = 16,
-  CALLING_CONV_SWIFT_ASYNC = 17,
-  CALLING_CONV_A_ARCH_64_SVEPCS = 18,
-  CALLING_CONV_M68_K_RTD = 19,
-  CALLING_CONV_PRESERVE_NONE = 20,
-  CALLING_CONV_RISCV_VECTOR_CALL = 21,
-  CALLING_CONV_RISCVVLS_CALL_32 = 22,
-  CALLING_CONV_RISCVVLS_CALL_64 = 23,
-  CALLING_CONV_RISCVVLS_CALL_128 = 24,
-  CALLING_CONV_RISCVVLS_CALL_256 = 25,
-  CALLING_CONV_RISCVVLS_CALL_512 = 26,
-  CALLING_CONV_RISCVVLS_CALL_1024 = 27,
-  CALLING_CONV_RISCVVLS_CALL_2048 = 28,
-  CALLING_CONV_RISCVVLS_CALL_4096 = 29,
-  CALLING_CONV_RISCVVLS_CALL_8192 = 30,
-  CALLING_CONV_RISCVVLS_CALL_16384 = 31,
-  CALLING_CONV_RISCVVLS_CALL_32768 = 32,
-  CALLING_CONV_RISCVVLS_CALL_65536 = 33,
-  CALLING_CONV_INVALID = 100,
-  CALLING_CONV_UNEXPOSED = 200
+	CALLING_CONV_DEFAULT = 0,
+	CALLING_CONV_C = 1,
+	CALLING_CONV_X86_STD_CALL = 2,
+	CALLING_CONV_X86_FAST_CALL = 3,
+	CALLING_CONV_X86_THIS_CALL = 4,
+	CALLING_CONV_X86_PASCAL = 5,
+	CALLING_CONV_AAPCS = 6,
+	CALLING_CONV_AAPCS_VFP = 7,
+	CALLING_CONV_X86_REG_CALL = 8,
+	CALLING_CONV_INTEL_OCL_BICC = 9,
+	CALLING_CONV_WIN_64 = 10,
+	CALLING_CONV_X86_64_WIN_64 = 10,
+	CALLING_CONV_X86_64_SYS_V = 11,
+	CALLING_CONV_X86_VECTOR_CALL = 12,
+	CALLING_CONV_SWIFT = 13,
+	CALLING_CONV_PRESERVE_MOST = 14,
+	CALLING_CONV_PRESERVE_ALL = 15,
+	CALLING_CONV_A_ARCH_64_VECTOR_CALL = 16,
+	CALLING_CONV_SWIFT_ASYNC = 17,
+	CALLING_CONV_A_ARCH_64_SVEPCS = 18,
+	CALLING_CONV_M68_K_RTD = 19,
+	CALLING_CONV_PRESERVE_NONE = 20,
+	CALLING_CONV_RISCV_VECTOR_CALL = 21,
+	CALLING_CONV_RISCVVLS_CALL_32 = 22,
+	CALLING_CONV_RISCVVLS_CALL_64 = 23,
+	CALLING_CONV_RISCVVLS_CALL_128 = 24,
+	CALLING_CONV_RISCVVLS_CALL_256 = 25,
+	CALLING_CONV_RISCVVLS_CALL_512 = 26,
+	CALLING_CONV_RISCVVLS_CALL_1024 = 27,
+	CALLING_CONV_RISCVVLS_CALL_2048 = 28,
+	CALLING_CONV_RISCVVLS_CALL_4096 = 29,
+	CALLING_CONV_RISCVVLS_CALL_8192 = 30,
+	CALLING_CONV_RISCVVLS_CALL_16384 = 31,
+	CALLING_CONV_RISCVVLS_CALL_32768 = 32,
+	CALLING_CONV_RISCVVLS_CALL_65536 = 33,
+	CALLING_CONV_INVALID = 100,
+	CALLING_CONV_UNEXPOSED = 200
 }
 
+<*
+	The type of an element in the abstract syntax tree.
+*>
 struct CXType {
-  CXTypeKind kind;
-  void*[2] data;
+	CXTypeKind kind;
+	void*[2] data;
 }
 
+<*
+	Retrieve the type of a CXCursor (if any).
+*>
 extern fn CXType getCursorType(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getCursorType");
 
+<*
+	Pretty-print the underlying type using the rules of the
+	language of the translation unit from which it came.
+	If the type is invalid, an empty string is returned.
+*>
 extern fn CXString getTypeSpelling(
-  CXType ct)
+	CXType ct)
 @cname("clang_getTypeSpelling");
 
+<*
+	Retrieve the underlying type of a typedef declaration.
+	If the cursor does not reference a typedef declaration, an invalid type is
+	returned.
+*>
 extern fn CXType getTypedefDeclUnderlyingType(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getTypedefDeclUnderlyingType");
 
+<*
+	Retrieve the integer type of an enum declaration.
+	If the cursor does not reference an enum declaration, an invalid type is
+	returned.
+*>
 extern fn CXType getEnumDeclIntegerType(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getEnumDeclIntegerType");
 
+<*
+	Retrieve the integer value of an enum constant declaration as a signed
+	long long.
+	If the cursor does not reference an enum constant declaration, LLONG_MIN is
+	returned. Since this is also potentially a valid constant value, the kind of
+	the cursor must be verified before calling this function.
+*>
 extern fn CLongLong getEnumConstantDeclValue(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getEnumConstantDeclValue");
 
+<*
+	Retrieve the integer value of an enum constant declaration as an unsigned
+	long long.
+	If the cursor does not reference an enum constant declaration, ULLONG_MAX is
+	returned. Since this is also potentially a valid constant value, the kind of
+	the cursor must be verified before calling this function.
+*>
 extern fn CULongLong getEnumConstantDeclUnsignedValue(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getEnumConstantDeclUnsignedValue");
 
+<*
+	Returns non-zero if the cursor specifies a Record member that is a bit-field.
+*>
 extern fn CUInt cursor_isBitField(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isBitField");
 
+<*
+	Retrieve the bit width of a bit-field declaration as an integer.
+	If the cursor does not reference a bit-field, or if the bit-field's width
+	expression cannot be evaluated, -1 is returned.
+	For example:
+	\code
+	if (clang_Cursor_isBitField(Cursor)) {
+	int Width = clang_getFieldDeclBitWidth(Cursor);
+	if (Width != -1) {
+	// The bit-field width is not value-dependent.
+	}
+	}
+	\endcode
+*>
 extern fn CInt getFieldDeclBitWidth(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getFieldDeclBitWidth");
 
+<*
+	Retrieve the number of non-variadic arguments associated with a given
+	cursor.
+	The number of arguments can be determined for calls as well as for
+	declarations of functions or methods. For other cursors -1 is returned.
+*>
 extern fn CInt cursor_getNumArguments(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getNumArguments");
 
+<*
+	Retrieve the argument cursor of a function or method.
+	The argument cursor can be determined for calls as well as for declarations
+	of functions or methods. For other cursors and for invalid indices, an
+	invalid cursor is returned.
+*>
 extern fn CXCursor cursor_getArgument(
-  CXCursor c,
-  CUInt i)
+	CXCursor c,
+	CUInt i)
 @cname("clang_Cursor_getArgument");
 
+<*
+	Describes the kind of a template argument.
+	See the definition of llvm::clang::TemplateArgument::ArgKind for full
+	element descriptions.
+*>
 constdef CXTemplateArgumentKind : CInt {
-  TEMPLATE_ARGUMENT_KIND_NULL = 0,
-  TEMPLATE_ARGUMENT_KIND_TYPE = 1,
-  TEMPLATE_ARGUMENT_KIND_DECLARATION = 2,
-  TEMPLATE_ARGUMENT_KIND_NULL_PTR = 3,
-  TEMPLATE_ARGUMENT_KIND_INTEGRAL = 4,
-  TEMPLATE_ARGUMENT_KIND_TEMPLATE = 5,
-  TEMPLATE_ARGUMENT_KIND_TEMPLATE_EXPANSION = 6,
-  TEMPLATE_ARGUMENT_KIND_EXPRESSION = 7,
-  TEMPLATE_ARGUMENT_KIND_PACK = 8,
-  TEMPLATE_ARGUMENT_KIND_INVALID = 9
+	TEMPLATE_ARGUMENT_KIND_NULL = 0,
+	TEMPLATE_ARGUMENT_KIND_TYPE = 1,
+	TEMPLATE_ARGUMENT_KIND_DECLARATION = 2,
+	TEMPLATE_ARGUMENT_KIND_NULL_PTR = 3,
+	TEMPLATE_ARGUMENT_KIND_INTEGRAL = 4,
+	TEMPLATE_ARGUMENT_KIND_TEMPLATE = 5,
+	TEMPLATE_ARGUMENT_KIND_TEMPLATE_EXPANSION = 6,
+	TEMPLATE_ARGUMENT_KIND_EXPRESSION = 7,
+	TEMPLATE_ARGUMENT_KIND_PACK = 8,
+	TEMPLATE_ARGUMENT_KIND_INVALID = 9
 }
 
+<*
+	Returns the number of template args of a function, struct, or class decl
+	representing a template specialization.
+	If the argument cursor cannot be converted into a template function
+	declaration, -1 is returned.
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+	template <>
+	void foo<float, -7, true>();
+	The value 3 would be returned from this call.
+*>
 extern fn CInt cursor_getNumTemplateArguments(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getNumTemplateArguments");
 
+<*
+	Retrieve the kind of the I'th template argument of the CXCursor C.
+	If the argument CXCursor does not represent a FunctionDecl, StructDecl, or
+	ClassTemplatePartialSpecialization, an invalid template argument kind is
+	returned.
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+	template <>
+	void foo<float, -7, true>();
+	For I = 0, 1, and 2, Type, Integral, and Integral will be returned,
+	respectively.
+*>
 extern fn CXTemplateArgumentKind cursor_getTemplateArgumentKind(
-  CXCursor c,
-  CUInt i)
+	CXCursor c,
+	CUInt i)
 @cname("clang_Cursor_getTemplateArgumentKind");
 
+<*
+	Retrieve a CXType representing the type of a TemplateArgument of a
+	function decl representing a template specialization.
+	If the argument CXCursor does not represent a FunctionDecl, StructDecl,
+	ClassDecl or ClassTemplatePartialSpecialization whose I'th template argument
+	has a kind of CXTemplateArgKind_Integral, an invalid type is returned.
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+	template <>
+	void foo<float, -7, true>();
+	If called with I = 0, "float", will be returned.
+	Invalid types will be returned for I == 1 or 2.
+*>
 extern fn CXType cursor_getTemplateArgumentType(
-  CXCursor c,
-  CUInt i)
+	CXCursor c,
+	CUInt i)
 @cname("clang_Cursor_getTemplateArgumentType");
 
+<*
+	Retrieve the value of an Integral TemplateArgument (of a function
+	decl representing a template specialization) as a signed long long.
+	It is undefined to call this function on a CXCursor that does not represent a
+	FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization
+	whose I'th template argument is not an integral value.
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+	template <>
+	void foo<float, -7, true>();
+	If called with I = 1 or 2, -7 or true will be returned, respectively.
+	For I == 0, this function's behavior is undefined.
+*>
 extern fn CLongLong cursor_getTemplateArgumentValue(
-  CXCursor c,
-  CUInt i)
+	CXCursor c,
+	CUInt i)
 @cname("clang_Cursor_getTemplateArgumentValue");
 
+<*
+	Retrieve the value of an Integral TemplateArgument (of a function
+	decl representing a template specialization) as an unsigned long long.
+	It is undefined to call this function on a CXCursor that does not represent a
+	FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization or
+	whose I'th template argument is not an integral value.
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+	template <>
+	void foo<float, 2147483649, true>();
+	If called with I = 1 or 2, 2147483649 or true will be returned, respectively.
+	For I == 0, this function's behavior is undefined.
+*>
 extern fn CULongLong cursor_getTemplateArgumentUnsignedValue(
-  CXCursor c,
-  CUInt i)
+	CXCursor c,
+	CUInt i)
 @cname("clang_Cursor_getTemplateArgumentUnsignedValue");
 
+<*
+	Determine whether two CXTypes represent the same type.
+	\returns non-zero if the CXTypes represent the same type and
+	zero otherwise.
+*>
 extern fn CUInt equalTypes(
-  CXType a,
-  CXType b)
+	CXType a,
+	CXType b)
 @cname("clang_equalTypes");
 
+<*
+	Return the canonical type for a CXType.
+	Clang's type system explicitly models typedefs and all the ways
+	a specific type can be represented.  The canonical type is the underlying
+	type with all the "sugar" removed.  For example, if 'T' is a typedef
+	for 'int', the canonical type for 'T' would be 'int'.
+*>
 extern fn CXType getCanonicalType(
-  CXType t)
+	CXType t)
 @cname("clang_getCanonicalType");
 
+<*
+	Determine whether a CXType has the "const" qualifier set,
+	without looking through typedefs that may have added "const" at a
+	different level.
+*>
 extern fn CUInt isConstQualifiedType(
-  CXType t)
+	CXType t)
 @cname("clang_isConstQualifiedType");
 
+<*
+	Determine whether a  CXCursor that is a macro, is
+	function like.
+*>
 extern fn CUInt cursor_isMacroFunctionLike(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isMacroFunctionLike");
 
+<*
+	Determine whether a  CXCursor that is a macro, is a
+	builtin one.
+*>
 extern fn CUInt cursor_isMacroBuiltin(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isMacroBuiltin");
 
+<*
+	Determine whether a  CXCursor that is a function declaration, is an
+	inline declaration.
+*>
 extern fn CUInt cursor_isFunctionInlined(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isFunctionInlined");
 
+<*
+	Determine whether a CXType has the "volatile" qualifier set,
+	without looking through typedefs that may have added "volatile" at
+	a different level.
+*>
 extern fn CUInt isVolatileQualifiedType(
-  CXType t)
+	CXType t)
 @cname("clang_isVolatileQualifiedType");
 
+<*
+	Determine whether a CXType has the "restrict" qualifier set,
+	without looking through typedefs that may have added "restrict" at a
+	different level.
+*>
 extern fn CUInt isRestrictQualifiedType(
-  CXType t)
+	CXType t)
 @cname("clang_isRestrictQualifiedType");
 
+<*
+	Returns the address space of the given type.
+*>
 extern fn CUInt getAddressSpace(
-  CXType t)
+	CXType t)
 @cname("clang_getAddressSpace");
 
+<*
+	Returns the typedef name of the given type.
+*>
 extern fn CXString getTypedefName(
-  CXType ct)
+	CXType ct)
 @cname("clang_getTypedefName");
 
+<*
+	For pointer types, returns the type of the pointee.
+*>
 extern fn CXType getPointeeType(
-  CXType t)
+	CXType t)
 @cname("clang_getPointeeType");
 
+<*
+	Retrieve the unqualified variant of the given type, removing as
+	little sugar as possible.
+	For example, given the following series of typedefs:
+	\code
+	typedef int Integer;
+	typedef const Integer CInteger;
+	typedef CInteger DifferenceType;
+	\endcode
+	Executing \c clang_getUnqualifiedType() on a \c CXType that
+	represents \c DifferenceType, will desugar to a type representing
+	\c Integer, that has no qualifiers.
+	And, executing \c clang_getUnqualifiedType() on the type of the
+	first argument of the following function declaration:
+	\code
+	void foo(const int);
+	\endcode
+	Will return a type representing \c int, removing the \c const
+	qualifier.
+	Sugar over array types is not desugared.
+	A type can be checked for qualifiers with \c
+	clang_isConstQualifiedType(), \c clang_isVolatileQualifiedType()
+	and \c clang_isRestrictQualifiedType().
+	A type that resulted from a call to \c clang_getUnqualifiedType
+	will return \c false for all of the above calls.
+*>
 extern fn CXType getUnqualifiedType(
-  CXType ct)
+	CXType ct)
 @cname("clang_getUnqualifiedType");
 
+<*
+	For reference types (e.g., "const int&"), returns the type that the
+	reference refers to (e.g "const int").
+	Otherwise, returns the type itself.
+	A type that has kind \c CXType_LValueReference or
+	\c CXType_RValueReference is a reference type.
+*>
 extern fn CXType getNonReferenceType(
-  CXType ct)
+	CXType ct)
 @cname("clang_getNonReferenceType");
 
+<*
+	Return the cursor for the declaration of the given type.
+*>
 extern fn CXCursor getTypeDeclaration(
-  CXType t)
+	CXType t)
 @cname("clang_getTypeDeclaration");
 
+<*
+	Returns the Objective-C type encoding for the specified declaration.
+*>
 extern fn CXString getDeclObjCTypeEncoding(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getDeclObjCTypeEncoding");
 
+<*
+	Returns the Objective-C type encoding for the specified CXType.
+*>
 extern fn CXString type_getObjCEncoding(
-  CXType type)
+	CXType type)
 @cname("clang_Type_getObjCEncoding");
 
+<*
+	Retrieve the spelling of a given CXTypeKind.
+*>
 extern fn CXString getTypeKindSpelling(
-  CXTypeKind k)
+	CXTypeKind k)
 @cname("clang_getTypeKindSpelling");
 
+<*
+	Retrieve the calling convention associated with a function type.
+	If a non-function type is passed in, CXCallingConv_Invalid is returned.
+*>
 extern fn CXCallingConv getFunctionTypeCallingConv(
-  CXType t)
+	CXType t)
 @cname("clang_getFunctionTypeCallingConv");
 
+<*
+	Retrieve the return type associated with a function type.
+	If a non-function type is passed in, an invalid type is returned.
+*>
 extern fn CXType getResultType(
-  CXType t)
+	CXType t)
 @cname("clang_getResultType");
 
+<*
+	Retrieve the exception specification type associated with a function type.
+	This is a value of type CXCursor_ExceptionSpecificationKind.
+	If a non-function type is passed in, an error code of -1 is returned.
+*>
 extern fn CInt getExceptionSpecificationType(
-  CXType t)
+	CXType t)
 @cname("clang_getExceptionSpecificationType");
 
+<*
+	Retrieve the number of non-variadic parameters associated with a
+	function type.
+	If a non-function type is passed in, -1 is returned.
+*>
 extern fn CInt getNumArgTypes(
-  CXType t)
+	CXType t)
 @cname("clang_getNumArgTypes");
 
+<*
+	Retrieve the type of a parameter of a function type.
+	If a non-function type is passed in or the function does not have enough
+	parameters, an invalid type is returned.
+*>
 extern fn CXType getArgType(
-  CXType t,
-  CUInt i)
+	CXType t,
+	CUInt i)
 @cname("clang_getArgType");
 
+<*
+	Retrieves the base type of the ObjCObjectType.
+	If the type is not an ObjC object, an invalid type is returned.
+*>
 extern fn CXType type_getObjCObjectBaseType(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getObjCObjectBaseType");
 
+<*
+	Retrieve the number of protocol references associated with an ObjC object/id.
+	If the type is not an ObjC object, 0 is returned.
+*>
 extern fn CUInt type_getNumObjCProtocolRefs(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getNumObjCProtocolRefs");
 
+<*
+	Retrieve the decl for a protocol reference for an ObjC object/id.
+	If the type is not an ObjC object or there are not enough protocol
+	references, an invalid cursor is returned.
+*>
 extern fn CXCursor type_getObjCProtocolDecl(
-  CXType t,
-  CUInt i)
+	CXType t,
+	CUInt i)
 @cname("clang_Type_getObjCProtocolDecl");
 
+<*
+	Retrieve the number of type arguments associated with an ObjC object.
+	If the type is not an ObjC object, 0 is returned.
+*>
 extern fn CUInt type_getNumObjCTypeArgs(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getNumObjCTypeArgs");
 
+<*
+	Retrieve a type argument associated with an ObjC object.
+	If the type is not an ObjC or the index is not valid,
+	an invalid type is returned.
+*>
 extern fn CXType type_getObjCTypeArg(
-  CXType t,
-  CUInt i)
+	CXType t,
+	CUInt i)
 @cname("clang_Type_getObjCTypeArg");
 
+<*
+	Return 1 if the CXType is a variadic function type, and 0 otherwise.
+*>
 extern fn CUInt isFunctionTypeVariadic(
-  CXType t)
+	CXType t)
 @cname("clang_isFunctionTypeVariadic");
 
+<*
+	Retrieve the return type associated with a given cursor.
+	This only returns a valid type if the cursor refers to a function or method.
+*>
 extern fn CXType getCursorResultType(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getCursorResultType");
 
+<*
+	Retrieve the exception specification type associated with a given cursor.
+	This is a value of type CXCursor_ExceptionSpecificationKind.
+	This only returns a valid result if the cursor refers to a function or
+	method.
+*>
 extern fn CInt getCursorExceptionSpecificationType(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getCursorExceptionSpecificationType");
 
+<*
+	Return 1 if the CXType is a POD (plain old data) type, and 0
+	otherwise.
+*>
 extern fn CUInt isPODType(
-  CXType t)
+	CXType t)
 @cname("clang_isPODType");
 
+<*
+	Return the element type of an array, complex, or vector type.
+	If a type is passed in that is not an array, complex, or vector type,
+	an invalid type is returned.
+*>
 extern fn CXType getElementType(
-  CXType t)
+	CXType t)
 @cname("clang_getElementType");
 
+<*
+	Return the number of elements of an array or vector type.
+	If a type is passed in that is not an array or vector type,
+	-1 is returned.
+*>
 extern fn CLongLong getNumElements(
-  CXType t)
+	CXType t)
 @cname("clang_getNumElements");
 
+<*
+	Return the element type of an array type.
+	If a non-array type is passed in, an invalid type is returned.
+*>
 extern fn CXType getArrayElementType(
-  CXType t)
+	CXType t)
 @cname("clang_getArrayElementType");
 
+<*
+	Return the array size of a constant array.
+	If a non-array type is passed in, -1 is returned.
+*>
 extern fn CLongLong getArraySize(
-  CXType t)
+	CXType t)
 @cname("clang_getArraySize");
 
+<*
+	Retrieve the type named by the qualified-id.
+	If a non-elaborated type is passed in, an invalid type is returned.
+*>
 extern fn CXType type_getNamedType(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getNamedType");
 
+<*
+	Determine if a typedef is 'transparent' tag.
+	A typedef is considered 'transparent' if it shares a name and spelling
+	location with its underlying tag type, as is the case with the NS_ENUM macro.
+	\returns non-zero if transparent and zero otherwise.
+*>
 extern fn CUInt type_isTransparentTagTypedef(
-  CXType t)
+	CXType t)
 @cname("clang_Type_isTransparentTagTypedef");
 
+
 constdef CXTypeNullabilityKind : CInt {
-  TYPE_NULLABILITY_NON_NULL = 0,
-  TYPE_NULLABILITY_NULLABLE = 1,
-  TYPE_NULLABILITY_UNSPECIFIED = 2,
-  TYPE_NULLABILITY_INVALID = 3,
-  TYPE_NULLABILITY_NULLABLE_RESULT = 4
+
+	<*
+		Values of this type can never be null.
+	*>
+	TYPE_NULLABILITY_NON_NULL = 0,
+
+	<*
+		Values of this type can be null.
+	*>
+	TYPE_NULLABILITY_NULLABLE = 1,
+
+	<*
+		Whether values of this type can be null is (explicitly)
+		unspecified. This captures a (fairly rare) case where we
+		can't conclude anything about the nullability of the type even
+		though it has been considered.
+	*>
+	TYPE_NULLABILITY_UNSPECIFIED = 2,
+
+	<*
+		Nullability is not applicable to this type.
+	*>
+	TYPE_NULLABILITY_INVALID = 3,
+
+	<*
+		Generally behaves like Nullable, except when used in a block parameter that
+		was imported into a swift async method. There, swift will assume that the
+		parameter can get null even if no error occurred. _Nullable parameters are
+		assumed to only get null on error.
+	*>
+	TYPE_NULLABILITY_NULLABLE_RESULT = 4
 }
 
+<*
+	Retrieve the nullability kind of a pointer type.
+*>
 extern fn CXTypeNullabilityKind type_getNullability(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getNullability");
 
+<*
+	List the possible error codes for \c clang_Type_getSizeOf,
+	\c clang_Type_getAlignOf, \c clang_Type_getOffsetOf,
+	\c clang_Cursor_getOffsetOf, and \c clang_getOffsetOfBase.
+	A value of this enumeration type can be returned if the target type is not
+	a valid argument to sizeof, alignof or offsetof.
+*>
 constdef CXTypeLayoutError : CInt {
-  TYPE_LAYOUT_ERROR_INVALID = -1,
-  TYPE_LAYOUT_ERROR_INCOMPLETE = -2,
-  TYPE_LAYOUT_ERROR_DEPENDENT = -3,
-  TYPE_LAYOUT_ERROR_NOT_CONSTANT_SIZE = -4,
-  TYPE_LAYOUT_ERROR_INVALID_FIELD_NAME = -5,
-  TYPE_LAYOUT_ERROR_UNDEDUCED = -6
+
+	<*
+		Type is of kind CXType_Invalid.
+	*>
+	TYPE_LAYOUT_ERROR_INVALID = -1,
+
+	<*
+		The type is an incomplete Type.
+	*>
+	TYPE_LAYOUT_ERROR_INCOMPLETE = -2,
+
+	<*
+		The type is a dependent Type.
+	*>
+	TYPE_LAYOUT_ERROR_DEPENDENT = -3,
+
+	<*
+		The type is not a constant size type.
+	*>
+	TYPE_LAYOUT_ERROR_NOT_CONSTANT_SIZE = -4,
+
+	<*
+		The Field name is not valid for this record.
+	*>
+	TYPE_LAYOUT_ERROR_INVALID_FIELD_NAME = -5,
+
+	<*
+		The type is undeduced.
+	*>
+	TYPE_LAYOUT_ERROR_UNDEDUCED = -6
 }
 
+<*
+	Return the alignment of a type in bytes as per C++[expr.alignof]
+	standard.
+	If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
+	If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
+	is returned.
+	If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
+	returned.
+	If the type declaration is not a constant size type,
+	CXTypeLayoutError_NotConstantSize is returned.
+*>
 extern fn CLongLong type_getAlignOf(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getAlignOf");
 
+<*
+	Return the class type of an member pointer type.
+	If a non-member-pointer type is passed in, an invalid type is returned.
+*>
 extern fn CXType type_getClassType(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getClassType");
 
+<*
+	Return the size of a type in bytes as per C++[expr.sizeof] standard.
+	If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
+	If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
+	is returned.
+	If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
+	returned.
+*>
 extern fn CLongLong type_getSizeOf(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getSizeOf");
 
+<*
+	Return the offset of a field named S in a record of type T in bits
+	as it would be returned by __offsetof__ as per C++11[18.2p4]
+	If the cursor is not a record field declaration, CXTypeLayoutError_Invalid
+	is returned.
+	If the field's type declaration is an incomplete type,
+	CXTypeLayoutError_Incomplete is returned.
+	If the field's type declaration is a dependent type,
+	CXTypeLayoutError_Dependent is returned.
+	If the field's name S is not found,
+	CXTypeLayoutError_InvalidFieldName is returned.
+*>
 extern fn CLongLong type_getOffsetOf(
-  CXType t,
-  ZString s)
+	CXType t,
+	ZString s)
 @cname("clang_Type_getOffsetOf");
 
+<*
+	Return the type that was modified by this attributed type.
+	If the type is not an attributed type, an invalid type is returned.
+*>
 extern fn CXType type_getModifiedType(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getModifiedType");
 
+<*
+	Gets the type contained by this atomic type.
+	If a non-atomic type is passed in, an invalid type is returned.
+*>
 extern fn CXType type_getValueType(
-  CXType ct)
+	CXType ct)
 @cname("clang_Type_getValueType");
 
+<*
+	Return the offset of the field represented by the Cursor.
+	If the cursor is not a field declaration, -1 is returned.
+	If the cursor semantic parent is not a record field declaration,
+	CXTypeLayoutError_Invalid is returned.
+	If the field's type declaration is an incomplete type,
+	CXTypeLayoutError_Incomplete is returned.
+	If the field's type declaration is a dependent type,
+	CXTypeLayoutError_Dependent is returned.
+	If the field's name S is not found,
+	CXTypeLayoutError_InvalidFieldName is returned.
+*>
 extern fn CLongLong cursor_getOffsetOfField(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getOffsetOfField");
 
+<*
+	Determine whether the given cursor represents an anonymous
+	tag or namespace
+*>
 extern fn CUInt cursor_isAnonymous(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isAnonymous");
 
+<*
+	Determine whether the given cursor represents an anonymous record
+	declaration.
+*>
 extern fn CUInt cursor_isAnonymousRecordDecl(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isAnonymousRecordDecl");
 
+<*
+	Determine whether the given cursor represents an inline namespace
+	declaration.
+*>
 extern fn CUInt cursor_isInlineNamespace(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isInlineNamespace");
 
+
 constdef CXRefQualifierKind : CInt {
-  REF_QUALIFIER_NONE = 0,
-  REF_QUALIFIER_L_VALUE = 1,
-  REF_QUALIFIER_R_VALUE = 2
+
+	<*
+		No ref-qualifier was provided. *
+	*>
+	REF_QUALIFIER_NONE = 0,
+
+	<*
+		An lvalue ref-qualifier was provided (\c &). *
+	*>
+	REF_QUALIFIER_L_VALUE = 1,
+
+	<*
+		An rvalue ref-qualifier was provided (\c &&). *
+	*>
+	REF_QUALIFIER_R_VALUE = 2
 }
 
+<*
+	Returns the number of template arguments for given template
+	specialization, or -1 if type \c T is not a template specialization.
+*>
 extern fn CInt type_getNumTemplateArguments(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getNumTemplateArguments");
 
+<*
+	Returns the type template argument of a template class specialization
+	at given index.
+	This function only returns template type arguments and does not handle
+	template template arguments or variadic packs.
+*>
 extern fn CXType type_getTemplateArgumentAsType(
-  CXType t,
-  CUInt i)
+	CXType t,
+	CUInt i)
 @cname("clang_Type_getTemplateArgumentAsType");
 
+<*
+	Retrieve the ref-qualifier kind of a function or method.
+	The ref-qualifier is returned for C++ functions or methods. For other types
+	or non-C++ declarations, CXRefQualifier_None is returned.
+*>
 extern fn CXRefQualifierKind type_getCXXRefQualifier(
-  CXType t)
+	CXType t)
 @cname("clang_Type_getCXXRefQualifier");
 
+<*
+	Returns 1 if the base class specified by the cursor with kind
+	CX_CXXBaseSpecifier is virtual.
+*>
 extern fn CUInt isVirtualBase(
-  CXCursor)
+	CXCursor)
 @cname("clang_isVirtualBase");
 
+<*
+	Returns the offset in bits of a CX_CXXBaseSpecifier relative to the parent
+	class.
+	Returns a small negative number if the offset cannot be computed. See
+	CXTypeLayoutError for error codes.
+*>
 extern fn CLongLong getOffsetOfBase(
-  CXCursor parent,
-  CXCursor base)
+	CXCursor parent,
+	CXCursor base)
 @cname("clang_getOffsetOfBase");
 
+<*
+	Represents the C++ access control level to a base class for a
+	cursor with kind CX_CXXBaseSpecifier.
+*>
 constdef CX_CXXAccessSpecifier : CInt {
-  _CXX_INVALID_ACCESS_SPECIFIER = 0,
-  _CXX_PUBLIC = 1,
-  _CXX_PROTECTED = 2,
-  _CXX_PRIVATE = 3
+	_CXX_INVALID_ACCESS_SPECIFIER = 0,
+	_CXX_PUBLIC = 1,
+	_CXX_PROTECTED = 2,
+	_CXX_PRIVATE = 3
 }
 
+<*
+	Returns the access control level for the referenced object.
+	If the cursor refers to a C++ declaration, its access control level within
+	its parent scope is returned. Otherwise, if the cursor refers to a base
+	specifier or access specifier, the specifier itself is returned.
+*>
 extern fn CX_CXXAccessSpecifier getCXXAccessSpecifier(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCXXAccessSpecifier");
 
+<*
+	Represents the storage classes as declared in the source. CX_SC_Invalid
+	was added for the case that the passed cursor in not a declaration.
+*>
 constdef CX_StorageClass : CInt {
-  _SC_INVALID = 0,
-  _SC_NONE = 1,
-  _SC_EXTERN = 2,
-  _SC_STATIC = 3,
-  _SC_PRIVATE_EXTERN = 4,
-  _SC_OPEN_CL_WORK_GROUP_LOCAL = 5,
-  _SC_AUTO = 6,
-  _SC_REGISTER = 7
+	_SC_INVALID = 0,
+	_SC_NONE = 1,
+	_SC_EXTERN = 2,
+	_SC_STATIC = 3,
+	_SC_PRIVATE_EXTERN = 4,
+	_SC_OPEN_CL_WORK_GROUP_LOCAL = 5,
+	_SC_AUTO = 6,
+	_SC_REGISTER = 7
 }
 
+<*
+	Represents a specific kind of binary operator which can appear at a cursor.
+*>
 constdef CX_BinaryOperatorKind : CInt {
-  _BO_INVALID = 0,
-  _BO_PTR_MEM_D = 1,
-  _BO_PTR_MEM_I = 2,
-  _BO_MUL = 3,
-  _BO_DIV = 4,
-  _BO_REM = 5,
-  _BO_ADD = 6,
-  _BO_SUB = 7,
-  _BO_SHL = 8,
-  _BO_SHR = 9,
-  _BO_CMP = 10,
-  _BO_LT = 11,
-  _BO_GT = 12,
-  _BO_LE = 13,
-  _BO_GE = 14,
-  _BO_EQ = 15,
-  _BO_NE = 16,
-  _BO_AND = 17,
-  _BO_XOR = 18,
-  _BO_OR = 19,
-  _BO_L_AND = 20,
-  _BO_L_OR = 21,
-  _BO_ASSIGN = 22,
-  _BO_MUL_ASSIGN = 23,
-  _BO_DIV_ASSIGN = 24,
-  _BO_REM_ASSIGN = 25,
-  _BO_ADD_ASSIGN = 26,
-  _BO_SUB_ASSIGN = 27,
-  _BO_SHL_ASSIGN = 28,
-  _BO_SHR_ASSIGN = 29,
-  _BO_AND_ASSIGN = 30,
-  _BO_XOR_ASSIGN = 31,
-  _BO_OR_ASSIGN = 32,
-  _BO_COMMA = 33,
-  _BO_LAST = 33
+	_BO_INVALID = 0,
+	_BO_PTR_MEM_D = 1,
+	_BO_PTR_MEM_I = 2,
+	_BO_MUL = 3,
+	_BO_DIV = 4,
+	_BO_REM = 5,
+	_BO_ADD = 6,
+	_BO_SUB = 7,
+	_BO_SHL = 8,
+	_BO_SHR = 9,
+	_BO_CMP = 10,
+	_BO_LT = 11,
+	_BO_GT = 12,
+	_BO_LE = 13,
+	_BO_GE = 14,
+	_BO_EQ = 15,
+	_BO_NE = 16,
+	_BO_AND = 17,
+	_BO_XOR = 18,
+	_BO_OR = 19,
+	_BO_L_AND = 20,
+	_BO_L_OR = 21,
+	_BO_ASSIGN = 22,
+	_BO_MUL_ASSIGN = 23,
+	_BO_DIV_ASSIGN = 24,
+	_BO_REM_ASSIGN = 25,
+	_BO_ADD_ASSIGN = 26,
+	_BO_SUB_ASSIGN = 27,
+	_BO_SHL_ASSIGN = 28,
+	_BO_SHR_ASSIGN = 29,
+	_BO_AND_ASSIGN = 30,
+	_BO_XOR_ASSIGN = 31,
+	_BO_OR_ASSIGN = 32,
+	_BO_COMMA = 33,
+	_BO_LAST = 33
 }
 
+<*
+	\brief Returns the operator code for the binary operator.
+	@deprecated "use clang_getCursorBinaryOperatorKind instead."
+*>
 extern fn CX_BinaryOperatorKind cursor_getBinaryOpcode(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getBinaryOpcode");
 
+<*
+	\brief Returns a string containing the spelling of the binary operator.
+	@deprecated "use clang_getBinaryOperatorKindSpelling instead"
+*>
 extern fn CXString cursor_getBinaryOpcodeStr(
-  CX_BinaryOperatorKind op)
+	CX_BinaryOperatorKind op)
 @cname("clang_Cursor_getBinaryOpcodeStr");
 
+<*
+	Returns the storage class for a function or variable declaration.
+	If the passed in Cursor is not a function or variable declaration,
+	CX_SC_Invalid is returned else the storage class.
+*>
 extern fn CX_StorageClass cursor_getStorageClass(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_getStorageClass");
 
+<*
+	Determine the number of overloaded declarations referenced by a
+	\c CXCursor_OverloadedDeclRef cursor.
+	\param cursor The cursor whose overloaded declarations are being queried.
+	\returns The number of overloaded declarations referenced by \c cursor. If it
+	is not a \c CXCursor_OverloadedDeclRef cursor, returns 0.
+*>
 extern fn CUInt getNumOverloadedDecls(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getNumOverloadedDecls");
 
+<*
+	Retrieve a cursor for one of the overloaded declarations referenced
+	by a \c CXCursor_OverloadedDeclRef cursor.
+	\param cursor The cursor whose overloaded declarations are being queried.
+	\param index The zero-based index into the set of overloaded declarations in
+	the cursor.
+	\returns A cursor representing the declaration referenced by the given
+	\c cursor at the specified \c index. If the cursor does not have an
+	associated set of overloaded declarations, or if the index is out of bounds,
+	returns \c clang_getNullCursor();
+*>
 extern fn CXCursor getOverloadedDecl(
-  CXCursor cursor,
-  CUInt index)
+	CXCursor cursor,
+	CUInt index)
 @cname("clang_getOverloadedDecl");
 
+<*
+	For cursors representing an iboutletcollection attribute,
+	this function returns the collection element type.
+*>
 extern fn CXType getIBOutletCollectionType(
-  CXCursor)
+	CXCursor)
 @cname("clang_getIBOutletCollectionType");
 
+<*
+	Describes how the traversal of the children of a particular
+	cursor should proceed after visiting a particular child cursor.
+	A value of this enumeration type should be returned by each
+	\c CXCursorVisitor to indicate how clang_visitChildren() proceed.
+*>
 constdef CXChildVisitResult : CInt {
-  CHILD_VISIT_BREAK = 0,
-  CHILD_VISIT_CONTINUE = 1,
-  CHILD_VISIT_RECURSE = 2
+
+	<*
+		Terminates the cursor traversal.
+	*>
+	CHILD_VISIT_BREAK = 0,
+
+	<*
+		Continues the cursor traversal with the next sibling of
+		the cursor just visited, without visiting its children.
+	*>
+	CHILD_VISIT_CONTINUE = 1,
+
+	<*
+		Recursively traverse the children of this cursor, using
+		the same visitor and client data.
+	*>
+	CHILD_VISIT_RECURSE = 2
 }
 
 alias CXCursorVisitor = fn CXChildVisitResult(
-  CXCursor cursor,
-  CXCursor parent,
-  CXClientData client_data);
+	CXCursor cursor,
+	CXCursor parent,
+	CXClientData client_data);
 
+<*
+	Visit the children of a particular cursor.
+	This function visits all the direct children of the given cursor,
+	invoking the given \p visitor function with the cursors of each
+	visited child. The traversal may be recursive, if the visitor returns
+	\c CXChildVisit_Recurse. The traversal may also be ended prematurely, if
+	the visitor returns \c CXChildVisit_Break.
+	\param parent the cursor whose child may be visited. All kinds of
+	cursors can be visited, including invalid cursors (which, by
+	definition, have no children).
+	\param visitor the visitor function that will be invoked for each
+	child of \p parent.
+	\param client_data pointer data supplied by the client, which will
+	be passed to the visitor each time it is invoked.
+	\returns a non-zero value if the traversal was terminated
+	prematurely by the visitor returning \c CXChildVisit_Break.
+*>
 extern fn CUInt visitChildren(
-  CXCursor parent,
-  CXCursorVisitor visitor,
-  CXClientData client_data)
+	CXCursor parent,
+	CXCursorVisitor visitor,
+	CXClientData client_data)
 @cname("clang_visitChildren");
 
 alias CXCursorVisitorBlock = void*;
 
+<*
+	Visits the children of a cursor using the specified block.  Behaves
+	identically to clang_visitChildren() in all other respects.
+*>
 extern fn CUInt visitChildrenWithBlock(
-  CXCursor parent,
-  CXCursorVisitorBlock block)
+	CXCursor parent,
+	CXCursorVisitorBlock block)
 @cname("clang_visitChildrenWithBlock");
 
+<*
+	Retrieve a Unified Symbol Resolution (USR) for the entity referenced
+	by the given cursor.
+	A Unified Symbol Resolution (USR) is a string that identifies a particular
+	entity (function, class, variable, etc.) within a program. USRs can be
+	compared across translation units to determine, e.g., when references in
+	one translation refer to an entity defined in another translation unit.
+*>
 extern fn CXString getCursorUSR(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCursorUSR");
 
+<*
+	Construct a USR for a specified Objective-C class.
+*>
 extern fn CXString constructUSR_ObjCClass(
-  ZString class_name)
+	ZString class_name)
 @cname("clang_constructUSR_ObjCClass");
 
+<*
+	Construct a USR for a specified Objective-C category.
+*>
 extern fn CXString constructUSR_ObjCCategory(
-  ZString class_name,
-  ZString category_name)
+	ZString class_name,
+	ZString category_name)
 @cname("clang_constructUSR_ObjCCategory");
 
+<*
+	Construct a USR for a specified Objective-C protocol.
+*>
 extern fn CXString constructUSR_ObjCProtocol(
-  ZString protocol_name)
+	ZString protocol_name)
 @cname("clang_constructUSR_ObjCProtocol");
 
+<*
+	Construct a USR for a specified Objective-C instance variable and
+	the USR for its containing class.
+*>
 extern fn CXString constructUSR_ObjCIvar(
-  ZString name,
-  CXString class_usr)
+	ZString name,
+	CXString class_usr)
 @cname("clang_constructUSR_ObjCIvar");
 
+<*
+	Construct a USR for a specified Objective-C method and
+	the USR for its containing class.
+*>
 extern fn CXString constructUSR_ObjCMethod(
-  ZString name,
-  CUInt is_instance_method,
-  CXString class_usr)
+	ZString name,
+	CUInt is_instance_method,
+	CXString class_usr)
 @cname("clang_constructUSR_ObjCMethod");
 
+<*
+	Construct a USR for a specified Objective-C property and the USR
+	for its containing class.
+*>
 extern fn CXString constructUSR_ObjCProperty(
-  ZString property,
-  CXString class_usr)
+	ZString property,
+	CXString class_usr)
 @cname("clang_constructUSR_ObjCProperty");
 
+<*
+	Retrieve a name for the entity referenced by this cursor.
+*>
 extern fn CXString getCursorSpelling(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCursorSpelling");
 
+<*
+	Retrieve a range for a piece that forms the cursors spelling name.
+	Most of the times there is only one range for the complete spelling but for
+	Objective-C methods and Objective-C message expressions, there are multiple
+	pieces for each selector identifier.
+	\param pieceIndex the index of the spelling name piece. If this is greater
+	than the actual number of pieces, it will return a NULL (invalid) range.
+	\param options Reserved.
+*>
 extern fn CXSourceRange cursor_getSpellingNameRange(
-  CXCursor,
-  CUInt piece_index,
-  CUInt options)
+	CXCursor,
+	CUInt piece_index,
+	CUInt options)
 @cname("clang_Cursor_getSpellingNameRange");
 
 alias CXPrintingPolicy = void*;
 
+<*
+	Properties for the printing policy.
+	See \c clang::PrintingPolicy for more information.
+*>
 constdef CXPrintingPolicyProperty : CInt {
-  PRINTING_POLICY_INDENTATION = 0,
-  PRINTING_POLICY_SUPPRESS_SPECIFIERS = 1,
-  PRINTING_POLICY_SUPPRESS_TAG_KEYWORD = 2,
-  PRINTING_POLICY_INCLUDE_TAG_DEFINITION = 3,
-  PRINTING_POLICY_SUPPRESS_SCOPE = 4,
-  PRINTING_POLICY_SUPPRESS_UNWRITTEN_SCOPE = 5,
-  PRINTING_POLICY_SUPPRESS_INITIALIZERS = 6,
-  PRINTING_POLICY_CONSTANT_ARRAY_SIZE_AS_WRITTEN = 7,
-  PRINTING_POLICY_ANONYMOUS_TAG_LOCATIONS = 8,
-  PRINTING_POLICY_SUPPRESS_STRONG_LIFETIME = 9,
-  PRINTING_POLICY_SUPPRESS_LIFETIME_QUALIFIERS = 10,
-  PRINTING_POLICY_SUPPRESS_TEMPLATE_ARGS_IN_CXX_CONSTRUCTORS = 11,
-  PRINTING_POLICY_BOOL = 12,
-  PRINTING_POLICY_RESTRICT = 13,
-  PRINTING_POLICY_ALIGNOF = 14,
-  PRINTING_POLICY_UNDERSCORE_ALIGNOF = 15,
-  PRINTING_POLICY_USE_VOID_FOR_ZERO_PARAMS = 16,
-  PRINTING_POLICY_TERSE_OUTPUT = 17,
-  PRINTING_POLICY_POLISH_FOR_DECLARATION = 18,
-  PRINTING_POLICY_HALF = 19,
-  PRINTING_POLICY_MSW_CHAR = 20,
-  PRINTING_POLICY_INCLUDE_NEWLINES = 21,
-  PRINTING_POLICY_MSVC_FORMATTING = 22,
-  PRINTING_POLICY_CONSTANTS_AS_WRITTEN = 23,
-  PRINTING_POLICY_SUPPRESS_IMPLICIT_BASE = 24,
-  PRINTING_POLICY_FULLY_QUALIFIED_NAME = 25,
-  PRINTING_POLICY_LAST_PROPERTY = 25
+	PRINTING_POLICY_INDENTATION = 0,
+	PRINTING_POLICY_SUPPRESS_SPECIFIERS = 1,
+	PRINTING_POLICY_SUPPRESS_TAG_KEYWORD = 2,
+	PRINTING_POLICY_INCLUDE_TAG_DEFINITION = 3,
+	PRINTING_POLICY_SUPPRESS_SCOPE = 4,
+	PRINTING_POLICY_SUPPRESS_UNWRITTEN_SCOPE = 5,
+	PRINTING_POLICY_SUPPRESS_INITIALIZERS = 6,
+	PRINTING_POLICY_CONSTANT_ARRAY_SIZE_AS_WRITTEN = 7,
+	PRINTING_POLICY_ANONYMOUS_TAG_LOCATIONS = 8,
+	PRINTING_POLICY_SUPPRESS_STRONG_LIFETIME = 9,
+	PRINTING_POLICY_SUPPRESS_LIFETIME_QUALIFIERS = 10,
+	PRINTING_POLICY_SUPPRESS_TEMPLATE_ARGS_IN_CXX_CONSTRUCTORS = 11,
+	PRINTING_POLICY_BOOL = 12,
+	PRINTING_POLICY_RESTRICT = 13,
+	PRINTING_POLICY_ALIGNOF = 14,
+	PRINTING_POLICY_UNDERSCORE_ALIGNOF = 15,
+	PRINTING_POLICY_USE_VOID_FOR_ZERO_PARAMS = 16,
+	PRINTING_POLICY_TERSE_OUTPUT = 17,
+	PRINTING_POLICY_POLISH_FOR_DECLARATION = 18,
+	PRINTING_POLICY_HALF = 19,
+	PRINTING_POLICY_MSW_CHAR = 20,
+	PRINTING_POLICY_INCLUDE_NEWLINES = 21,
+	PRINTING_POLICY_MSVC_FORMATTING = 22,
+	PRINTING_POLICY_CONSTANTS_AS_WRITTEN = 23,
+	PRINTING_POLICY_SUPPRESS_IMPLICIT_BASE = 24,
+	PRINTING_POLICY_FULLY_QUALIFIED_NAME = 25,
+	PRINTING_POLICY_LAST_PROPERTY = 25
 }
 
+<*
+	Get a property value for the given printing policy.
+*>
 extern fn CUInt printingPolicy_getProperty(
-  CXPrintingPolicy policy,
-  CXPrintingPolicyProperty property)
+	CXPrintingPolicy policy,
+	CXPrintingPolicyProperty property)
 @cname("clang_PrintingPolicy_getProperty");
 
+<*
+	Set a property value for the given printing policy.
+*>
 extern fn void printingPolicy_setProperty(
-  CXPrintingPolicy policy,
-  CXPrintingPolicyProperty property,
-  CUInt value)
+	CXPrintingPolicy policy,
+	CXPrintingPolicyProperty property,
+	CUInt value)
 @cname("clang_PrintingPolicy_setProperty");
 
+<*
+	Retrieve the default policy for the cursor.
+	The policy should be released after use with \c
+	clang_PrintingPolicy_dispose.
+*>
 extern fn CXPrintingPolicy getCursorPrintingPolicy(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCursorPrintingPolicy");
 
+<*
+	Release a printing policy.
+*>
 extern fn void printingPolicy_dispose(
-  CXPrintingPolicy policy)
+	CXPrintingPolicy policy)
 @cname("clang_PrintingPolicy_dispose");
 
+<*
+	Pretty print declarations.
+	\param Cursor The cursor representing a declaration.
+	\param Policy The policy to control the entities being printed. If
+	NULL, a default policy is used.
+	\returns The pretty printed declaration or the empty string for
+	other cursors.
+*>
 extern fn CXString getCursorPrettyPrinted(
-  CXCursor cursor,
-  CXPrintingPolicy policy)
+	CXCursor cursor,
+	CXPrintingPolicy policy)
 @cname("clang_getCursorPrettyPrinted");
 
+<*
+	Pretty-print the underlying type using a custom printing policy.
+	If the type is invalid, an empty string is returned.
+*>
 extern fn CXString getTypePrettyPrinted(
-  CXType ct,
-  CXPrintingPolicy cx_policy)
+	CXType ct,
+	CXPrintingPolicy cx_policy)
 @cname("clang_getTypePrettyPrinted");
 
+<*
+	Get the fully qualified name for a type.
+	This includes full qualification of all template parameters.
+	Policy - Further refine the type formatting
+	WithGlobalNsPrefix - If non-zero, function will prepend a '::' to qualified
+	names
+*>
 extern fn CXString getFullyQualifiedName(
-  CXType ct,
-  CXPrintingPolicy policy,
-  CUInt with_global_ns_prefix)
+	CXType ct,
+	CXPrintingPolicy policy,
+	CUInt with_global_ns_prefix)
 @cname("clang_getFullyQualifiedName");
 
+<*
+	Retrieve the display name for the entity referenced by this cursor.
+	The display name contains extra information that helps identify the cursor,
+	such as the parameters of a function or template or the arguments of a
+	class template specialization.
+*>
 extern fn CXString getCursorDisplayName(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCursorDisplayName");
 
+<*
+	For a cursor that is a reference, retrieve a cursor representing the
+	entity that it references.
+	Reference cursors refer to other entities in the AST. For example, an
+	Objective-C superclass reference cursor refers to an Objective-C class.
+	This function produces the cursor for the Objective-C class from the
+	cursor for the superclass reference. If the input cursor is a declaration or
+	definition, it returns that declaration or definition unchanged.
+	Otherwise, returns the NULL cursor.
+*>
 extern fn CXCursor getCursorReferenced(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCursorReferenced");
 
+<*
+	For a cursor that is either a reference to or a declaration
+	of some entity, retrieve a cursor that describes the definition of
+	that entity.
+	Some entities can be declared multiple times within a translation
+	unit, but only one of those declarations can also be a
+	definition. For example, given:
+	\code
+	int f(int, int);
+	int g(int x, int y) { return f(x, y); }
+	int f(int a, int b) { return a + b; }
+	int f(int, int);
+	\endcode
+	there are three declarations of the function "f", but only the
+	second one is a definition. The clang_getCursorDefinition()
+	function will take any cursor pointing to a declaration of "f"
+	(the first or fourth lines of the example) or a cursor referenced
+	that uses "f" (the call to "f' inside "g") and will return a
+	declaration cursor pointing to the definition (the second "f"
+	declaration).
+	If given a cursor for which there is no corresponding definition,
+	e.g., because there is no definition of that entity within this
+	translation unit, returns a NULL cursor.
+*>
 extern fn CXCursor getCursorDefinition(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCursorDefinition");
 
+<*
+	Determine whether the declaration pointed to by this cursor
+	is also a definition of that entity.
+*>
 extern fn CUInt isCursorDefinition(
-  CXCursor)
+	CXCursor)
 @cname("clang_isCursorDefinition");
 
+<*
+	Retrieve the canonical cursor corresponding to the given cursor.
+	In the C family of languages, many kinds of entities can be declared several
+	times within a single translation unit. For example, a structure type can
+	be forward-declared (possibly multiple times) and later defined:
+	\code
+	struct X;
+	struct X;
+	struct X {
+	int member;
+	};
+	\endcode
+	The declarations and the definition of \c X are represented by three
+	different cursors, all of which are declarations of the same underlying
+	entity. One of these cursor is considered the "canonical" cursor, which
+	is effectively the representative for the underlying entity. One can
+	determine if two cursors are declarations of the same underlying entity by
+	comparing their canonical cursors.
+	\returns The canonical cursor for the entity referred to by the given cursor.
+*>
 extern fn CXCursor getCanonicalCursor(
-  CXCursor)
+	CXCursor)
 @cname("clang_getCanonicalCursor");
 
+<*
+	If the cursor points to a selector identifier in an Objective-C
+	method or message expression, this returns the selector index.
+	After getting a cursor with #clang_getCursor, this can be called to
+	determine if the location points to a selector identifier.
+	\returns The selector index if the cursor is an Objective-C method or message
+	expression and the cursor is pointing to a selector identifier, or -1
+	otherwise.
+*>
 extern fn CInt cursor_getObjCSelectorIndex(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_getObjCSelectorIndex");
 
+<*
+	Given a cursor pointing to a C++ method call or an Objective-C
+	message, returns non-zero if the method/message is "dynamic", meaning:
+	For a C++ method: the call is virtual.
+	For an Objective-C message: the receiver is an object instance, not 'super'
+	or a specific class.
+	If the method/message is "static" or the cursor does not point to a
+	method/message, it will return zero.
+*>
 extern fn CInt cursor_isDynamicCall(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isDynamicCall");
 
+<*
+	Given a cursor pointing to an Objective-C message or property
+	reference, or C++ method call, returns the CXType of the receiver.
+*>
 extern fn CXType cursor_getReceiverType(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getReceiverType");
 
+<*
+	Property attributes for a \c CXCursor_ObjCPropertyDecl.
+*>
 constdef CXObjCPropertyAttrKind : CInt {
-  OBJ_C_PROPERTY_ATTR_NOATTR = 0,
-  OBJ_C_PROPERTY_ATTR_READONLY = 1,
-  OBJ_C_PROPERTY_ATTR_GETTER = 2,
-  OBJ_C_PROPERTY_ATTR_ASSIGN = 4,
-  OBJ_C_PROPERTY_ATTR_READWRITE = 8,
-  OBJ_C_PROPERTY_ATTR_RETAIN = 16,
-  OBJ_C_PROPERTY_ATTR_COPY = 32,
-  OBJ_C_PROPERTY_ATTR_NONATOMIC = 64,
-  OBJ_C_PROPERTY_ATTR_SETTER = 128,
-  OBJ_C_PROPERTY_ATTR_ATOMIC = 256,
-  OBJ_C_PROPERTY_ATTR_WEAK = 512,
-  OBJ_C_PROPERTY_ATTR_STRONG = 1024,
-  OBJ_C_PROPERTY_ATTR_UNSAFE_UNRETAINED = 2048,
-  OBJ_C_PROPERTY_ATTR_CLASS = 4096
+	OBJ_C_PROPERTY_ATTR_NOATTR = 0,
+	OBJ_C_PROPERTY_ATTR_READONLY = 1,
+	OBJ_C_PROPERTY_ATTR_GETTER = 2,
+	OBJ_C_PROPERTY_ATTR_ASSIGN = 4,
+	OBJ_C_PROPERTY_ATTR_READWRITE = 8,
+	OBJ_C_PROPERTY_ATTR_RETAIN = 16,
+	OBJ_C_PROPERTY_ATTR_COPY = 32,
+	OBJ_C_PROPERTY_ATTR_NONATOMIC = 64,
+	OBJ_C_PROPERTY_ATTR_SETTER = 128,
+	OBJ_C_PROPERTY_ATTR_ATOMIC = 256,
+	OBJ_C_PROPERTY_ATTR_WEAK = 512,
+	OBJ_C_PROPERTY_ATTR_STRONG = 1024,
+	OBJ_C_PROPERTY_ATTR_UNSAFE_UNRETAINED = 2048,
+	OBJ_C_PROPERTY_ATTR_CLASS = 4096
 }
 
+<*
+	Given a cursor that represents a property declaration, return the
+	associated property attributes. The bits are formed from
+	\c CXObjCPropertyAttrKind.
+	\param reserved Reserved for future use, pass 0.
+*>
 extern fn CUInt cursor_getObjCPropertyAttributes(
-  CXCursor c,
-  CUInt reserved)
+	CXCursor c,
+	CUInt reserved)
 @cname("clang_Cursor_getObjCPropertyAttributes");
 
+<*
+	Given a cursor that represents a property declaration, return the
+	name of the method that implements the getter.
+*>
 extern fn CXString cursor_getObjCPropertyGetterName(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getObjCPropertyGetterName");
 
+<*
+	Given a cursor that represents a property declaration, return the
+	name of the method that implements the setter, if any.
+*>
 extern fn CXString cursor_getObjCPropertySetterName(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getObjCPropertySetterName");
 
+<*
+	'Qualifiers' written next to the return and parameter types in
+	Objective-C method declarations.
+*>
 constdef CXObjCDeclQualifierKind : CInt {
-  OBJ_C_DECL_QUALIFIER_NONE = 0,
-  OBJ_C_DECL_QUALIFIER_IN = 1,
-  OBJ_C_DECL_QUALIFIER_INOUT = 2,
-  OBJ_C_DECL_QUALIFIER_OUT = 4,
-  OBJ_C_DECL_QUALIFIER_BYCOPY = 8,
-  OBJ_C_DECL_QUALIFIER_BYREF = 16,
-  OBJ_C_DECL_QUALIFIER_ONEWAY = 32
+	OBJ_C_DECL_QUALIFIER_NONE = 0,
+	OBJ_C_DECL_QUALIFIER_IN = 1,
+	OBJ_C_DECL_QUALIFIER_INOUT = 2,
+	OBJ_C_DECL_QUALIFIER_OUT = 4,
+	OBJ_C_DECL_QUALIFIER_BYCOPY = 8,
+	OBJ_C_DECL_QUALIFIER_BYREF = 16,
+	OBJ_C_DECL_QUALIFIER_ONEWAY = 32
 }
 
+<*
+	Given a cursor that represents an Objective-C method or parameter
+	declaration, return the associated Objective-C qualifiers for the return
+	type or the parameter respectively. The bits are formed from
+	CXObjCDeclQualifierKind.
+*>
 extern fn CUInt cursor_getObjCDeclQualifiers(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getObjCDeclQualifiers");
 
+<*
+	Given a cursor that represents an Objective-C method or property
+	declaration, return non-zero if the declaration was affected by "\@optional".
+	Returns zero if the cursor is not such a declaration or it is "\@required".
+*>
 extern fn CUInt cursor_isObjCOptional(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isObjCOptional");
 
+<*
+	Returns non-zero if the given cursor is a variadic function or method.
+*>
 extern fn CUInt cursor_isVariadic(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_isVariadic");
 
+<*
+	Returns non-zero if the given cursor points to a symbol marked with
+	external_source_symbol attribute.
+	\param language If non-NULL, and the attribute is present, will be set to
+	the 'language' string from the attribute.
+	\param definedIn If non-NULL, and the attribute is present, will be set to
+	the 'definedIn' string from the attribute.
+	\param isGenerated If non-NULL, and the attribute is present, will be set to
+	non-zero if the 'generated_declaration' is set in the attribute.
+*>
 extern fn CUInt cursor_isExternalSymbol(
-  CXCursor c,
-  CXString* language,
-  CXString* defined_in,
-  CUInt* is_generated)
+	CXCursor c,
+	CXString* language,
+	CXString* defined_in,
+	CUInt* is_generated)
 @cname("clang_Cursor_isExternalSymbol");
 
+<*
+	Given a cursor that represents a declaration, return the associated
+	comment's source range.  The range may include multiple consecutive comments
+	with whitespace in between.
+*>
 extern fn CXSourceRange cursor_getCommentRange(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getCommentRange");
 
+<*
+	Given a cursor that represents a declaration, return the associated
+	comment text, including comment markers.
+*>
 extern fn CXString cursor_getRawCommentText(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getRawCommentText");
 
+<*
+	Given a cursor that represents a documentable entity (e.g.,
+	declaration), return the associated \paragraph; otherwise return the
+	first paragraph.
+*>
 extern fn CXString cursor_getBriefCommentText(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getBriefCommentText");
 
+<*
+	Retrieve the CXString representing the mangled name of the cursor.
+*>
 extern fn CXString cursor_getMangling(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_getMangling");
 
+<*
+	Retrieve the CXStrings representing the mangled symbols of the C++
+	constructor or destructor at the cursor.
+*>
 extern fn CXStringSet* cursor_getCXXManglings(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_getCXXManglings");
 
+<*
+	Retrieve the CXStrings representing the mangled symbols of the ObjC
+	class interface or implementation at the cursor.
+*>
 extern fn CXStringSet* cursor_getObjCManglings(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_getObjCManglings");
 
+<*
+	Given a CXCursor_GCCAsmStmt cursor, return the assembly template string.
+	As per LLVM IR Assembly Template language, template placeholders for
+	inputs and outputs are either of the form $N where N is a decimal number
+	as an index into the input-output specification,
+	or ${N:M} where N is a decimal number also as an index into the
+	input-output specification and M is the template argument modifier.
+	The index N in both cases points into the the total inputs and outputs,
+	or more specifically, into the list of outputs followed by the inputs,
+	starting from index 0 as the first available template argument.
+	This function also returns a valid empty string if the cursor does not point
+	at a GCC inline assembly block.
+	Users are responsible for releasing the allocation of returned string via
+	\c clang_disposeString.
+*>
 extern fn CXString cursor_getGCCAssemblyTemplate(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_getGCCAssemblyTemplate");
 
+<*
+	Given a CXCursor_GCCAsmStmt cursor, check if the assembly block has goto
+	labels.
+	This function also returns 0 if the cursor does not point at a GCC inline
+	assembly block.
+*>
 extern fn CUInt cursor_isGCCAssemblyHasGoto(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_isGCCAssemblyHasGoto");
 
+<*
+	Given a CXCursor_GCCAsmStmt cursor, count the number of outputs.
+	This function also returns 0 if the cursor does not point at a GCC inline
+	assembly block.
+*>
 extern fn CUInt cursor_getGCCAssemblyNumOutputs(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_getGCCAssemblyNumOutputs");
 
+<*
+	Given a CXCursor_GCCAsmStmt cursor, count the number of inputs.
+	This function also returns 0 if the cursor does not point at a GCC inline
+	assembly block.
+*>
 extern fn CUInt cursor_getGCCAssemblyNumInputs(
-  CXCursor)
+	CXCursor)
 @cname("clang_Cursor_getGCCAssemblyNumInputs");
 
+<*
+	Given a CXCursor_GCCAsmStmt cursor, get the constraint and expression cursor
+	to the Index-th input.
+	This function returns 1 when the cursor points at a GCC inline assembly
+	statement, `Index` is within bounds and both the `Constraint` and `Expr` are
+	not NULL.
+	Otherwise, this function returns 0 but leaves `Constraint` and `Expr`
+	intact.
+	Users are responsible for releasing the allocation of `Constraint` via
+	\c clang_disposeString.
+*>
 extern fn CUInt cursor_getGCCAssemblyInput(
-  CXCursor cursor,
-  CUInt index,
-  CXString* constraint,
-  CXCursor* expr)
+	CXCursor cursor,
+	CUInt index,
+	CXString* constraint,
+	CXCursor* expr)
 @cname("clang_Cursor_getGCCAssemblyInput");
 
+<*
+	Given a CXCursor_GCCAsmStmt cursor, get the constraint and expression cursor
+	to the Index-th output.
+	This function returns 1 when the cursor points at a GCC inline assembly
+	statement, `Index` is within bounds and both the `Constraint` and `Expr` are
+	not NULL.
+	Otherwise, this function returns 0 but leaves `Constraint` and `Expr`
+	intact.
+	Users are responsible for releasing the allocation of `Constraint` via
+	\c clang_disposeString.
+*>
 extern fn CUInt cursor_getGCCAssemblyOutput(
-  CXCursor cursor,
-  CUInt index,
-  CXString* constraint,
-  CXCursor* expr)
+	CXCursor cursor,
+	CUInt index,
+	CXString* constraint,
+	CXCursor* expr)
 @cname("clang_Cursor_getGCCAssemblyOutput");
 
+<*
+	Given a CXCursor_GCCAsmStmt cursor, count the clobbers in it.
+	This function also returns 0 if the cursor does not point at a GCC inline
+	assembly block.
+*>
 extern fn CUInt cursor_getGCCAssemblyNumClobbers(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_Cursor_getGCCAssemblyNumClobbers");
 
+<*
+	Given a CXCursor_GCCAsmStmt cursor, get the Index-th clobber of it.
+	This function returns a valid empty string if the cursor does not point
+	at a GCC inline assembly block or `Index` is out of bounds.
+	Users are responsible for releasing the allocation of returned string via
+	\c clang_disposeString.
+*>
 extern fn CXString cursor_getGCCAssemblyClobber(
-  CXCursor cursor,
-  CUInt index)
+	CXCursor cursor,
+	CUInt index)
 @cname("clang_Cursor_getGCCAssemblyClobber");
 
+<*
+	Given a CXCursor_GCCAsmStmt cursor, check if the inline assembly is
+	`volatile`.
+	This function returns 0 if the cursor does not point at a GCC inline
+	assembly block.
+*>
 extern fn CUInt cursor_isGCCAssemblyVolatile(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_Cursor_isGCCAssemblyVolatile");
 
 alias CXModule = void*;
 
+<*
+	Given a CXCursor_ModuleImportDecl cursor, return the associated module.
+*>
 extern fn CXModule cursor_getModule(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getModule");
 
+<*
+	Given a CXFile header file, return the module that contains it, if one
+	exists.
+*>
 extern fn CXModule getModuleForFile(
-  CXTranslationUnit,
-  CXFile)
+	CXTranslationUnit,
+	CXFile)
 @cname("clang_getModuleForFile");
 
+<*
+	\param Module a module object.
+	\returns the module file where the provided module object came from.
+*>
 extern fn CXFile module_getASTFile(
-  CXModule mod)
+	CXModule mod)
 @cname("clang_Module_getASTFile");
 
+<*
+	\param Module a module object.
+	\returns the parent of a sub-module or NULL if the given module is top-level,
+	e.g. for 'std.vector' it will return the 'std' module.
+*>
 extern fn CXModule module_getParent(
-  CXModule mod)
+	CXModule mod)
 @cname("clang_Module_getParent");
 
+<*
+	\param Module a module object.
+	\returns the name of the module, e.g. for the 'std.vector' sub-module it
+	will return "vector".
+*>
 extern fn CXString module_getName(
-  CXModule mod)
+	CXModule mod)
 @cname("clang_Module_getName");
 
+<*
+	\param Module a module object.
+	\returns the full name of the module, e.g. "std.vector".
+*>
 extern fn CXString module_getFullName(
-  CXModule mod)
+	CXModule mod)
 @cname("clang_Module_getFullName");
 
+<*
+	\param Module a module object.
+	\returns non-zero if the module is a system one.
+*>
 extern fn CInt module_isSystem(
-  CXModule mod)
+	CXModule mod)
 @cname("clang_Module_isSystem");
 
+<*
+	\param Module a module object.
+	\returns the number of top level headers associated with this module.
+*>
 extern fn CUInt module_getNumTopLevelHeaders(
-  CXTranslationUnit,
-  CXModule mod)
+	CXTranslationUnit,
+	CXModule mod)
 @cname("clang_Module_getNumTopLevelHeaders");
 
+<*
+	\param Module a module object.
+	\param Index top level header index (zero-based).
+	\returns the specified top level header associated with the module.
+*>
 extern fn CXFile module_getTopLevelHeader(
-  CXTranslationUnit,
-  CXModule mod,
-  CUInt index)
+	CXTranslationUnit,
+	CXModule mod,
+	CUInt index)
 @cname("clang_Module_getTopLevelHeader");
 
+<*
+	Determine if a C++ constructor is a converting constructor.
+*>
 extern fn CUInt cXXConstructor_isConvertingConstructor(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXConstructor_isConvertingConstructor");
 
+<*
+	Determine if a C++ constructor is a copy constructor.
+*>
 extern fn CUInt cXXConstructor_isCopyConstructor(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXConstructor_isCopyConstructor");
 
+<*
+	Determine if a C++ constructor is the default constructor.
+*>
 extern fn CUInt cXXConstructor_isDefaultConstructor(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXConstructor_isDefaultConstructor");
 
+<*
+	Determine if a C++ constructor is a move constructor.
+*>
 extern fn CUInt cXXConstructor_isMoveConstructor(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXConstructor_isMoveConstructor");
 
+<*
+	Determine if a C++ field is declared 'mutable'.
+*>
 extern fn CUInt cXXField_isMutable(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXField_isMutable");
 
+<*
+	Determine if a C++ method is declared '= default'.
+*>
 extern fn CUInt cXXMethod_isDefaulted(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXMethod_isDefaulted");
 
+<*
+	Determine if a C++ method is declared '= delete'.
+*>
 extern fn CUInt cXXMethod_isDeleted(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXMethod_isDeleted");
 
+<*
+	Determine if a C++ member function or member function template is
+	pure virtual.
+*>
 extern fn CUInt cXXMethod_isPureVirtual(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXMethod_isPureVirtual");
 
+<*
+	Determine if a C++ member function or member function template is
+	declared 'static'.
+*>
 extern fn CUInt cXXMethod_isStatic(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXMethod_isStatic");
 
+<*
+	Determine if a C++ member function or member function template is
+	explicitly declared 'virtual' or if it overrides a virtual method from
+	one of the base classes.
+*>
 extern fn CUInt cXXMethod_isVirtual(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXMethod_isVirtual");
 
+<*
+	Determine if a C++ member function is a copy-assignment operator,
+	returning 1 if such is the case and 0 otherwise.
+	> A copy-assignment operator `X::operator=` is a non-static,
+	> non-template member function of _class_ `X` with exactly one
+	> parameter of type `X`, `X&`, `const X&`, `volatile X&` or `const
+	> volatile X&`.
+	That is, for example, the `operator=` in:
+	class Foo {
+	bool operator=(const volatile Foo&);
+	};
+	Is a copy-assignment operator, while the `operator=` in:
+	class Bar {
+	bool operator=(const int&);
+	};
+	Is not.
+*>
 extern fn CUInt cXXMethod_isCopyAssignmentOperator(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXMethod_isCopyAssignmentOperator");
 
+<*
+	Determine if a C++ member function is a move-assignment operator,
+	returning 1 if such is the case and 0 otherwise.
+	> A move-assignment operator `X::operator=` is a non-static,
+	> non-template member function of _class_ `X` with exactly one
+	> parameter of type `X&&`, `const X&&`, `volatile X&&` or `const
+	> volatile X&&`.
+	That is, for example, the `operator=` in:
+	class Foo {
+	bool operator=(const volatile Foo&&);
+	};
+	Is a move-assignment operator, while the `operator=` in:
+	class Bar {
+	bool operator=(const int&&);
+	};
+	Is not.
+*>
 extern fn CUInt cXXMethod_isMoveAssignmentOperator(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXMethod_isMoveAssignmentOperator");
 
+<*
+	Determines if a C++ constructor or conversion function was declared
+	explicit, returning 1 if such is the case and 0 otherwise.
+	Constructors or conversion functions are declared explicit through
+	the use of the explicit specifier.
+	For example, the following constructor and conversion function are
+	not explicit as they lack the explicit specifier:
+	class Foo {
+	Foo();
+	operator int();
+	};
+	While the following constructor and conversion function are
+	explicit as they are declared with the explicit specifier.
+	class Foo {
+	explicit Foo();
+	explicit operator int();
+	};
+	This function will return 0 when given a cursor pointing to one of
+	the former declarations and it will return 1 for a cursor pointing
+	to the latter declarations.
+	The explicit specifier allows the user to specify a
+	conditional compile-time expression whose value decides
+	whether the marked element is explicit or not.
+	For example:
+	constexpr bool foo(int i) { return i % 2 == 0; }
+	class Foo {
+	explicit(foo(1)) Foo();
+	explicit(foo(2)) operator int();
+	}
+	This function will return 0 for the constructor and 1 for
+	the conversion function.
+*>
 extern fn CUInt cXXMethod_isExplicit(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXMethod_isExplicit");
 
+<*
+	Determine if a C++ record is abstract, i.e. whether a class or struct
+	has a pure virtual member function.
+*>
 extern fn CUInt cXXRecord_isAbstract(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXRecord_isAbstract");
 
+<*
+	Determine if an enum declaration refers to a scoped enum.
+*>
 extern fn CUInt enumDecl_isScoped(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_EnumDecl_isScoped");
 
+<*
+	Determine if a C++ member function or member function template is
+	declared 'const'.
+*>
 extern fn CUInt cXXMethod_isConst(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_CXXMethod_isConst");
 
+<*
+	Given a cursor that represents a template, determine
+	the cursor kind of the specializations would be generated by instantiating
+	the template.
+	This routine can be used to determine what flavor of function template,
+	class template, or class template partial specialization is stored in the
+	cursor. For example, it can describe whether a class template cursor is
+	declared with "struct", "class" or "union".
+	\param C The cursor to query. This cursor should represent a template
+	declaration.
+	\returns The cursor kind of the specializations that would be generated
+	by instantiating the template \p C. If \p C is not a template, returns
+	\c CXCursor_NoDeclFound.
+*>
 extern fn CXCursorKind getTemplateCursorKind(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getTemplateCursorKind");
 
+<*
+	Given a cursor that may represent a specialization or instantiation
+	of a template, retrieve the cursor that represents the template that it
+	specializes or from which it was instantiated.
+	This routine determines the template involved both for explicit
+	specializations of templates and for implicit instantiations of the template,
+	both of which are referred to as "specializations". For a class template
+	specialization (e.g., \c std::vector<bool>), this routine will return
+	either the primary template (\c std::vector) or, if the specialization was
+	instantiated from a class template partial specialization, the class template
+	partial specialization. For a class template partial specialization and a
+	function template specialization (including instantiations), this
+	this routine will return the specialized template.
+	For members of a class template (e.g., member functions, member classes, or
+	static data members), returns the specialized or instantiated member.
+	Although not strictly "templates" in the C++ language, members of class
+	templates have the same notions of specializations and instantiations that
+	templates do, so this routine treats them similarly.
+	\param C A cursor that may be a specialization of a template or a member
+	of a template.
+	\returns If the given cursor is a specialization or instantiation of a
+	template or a member thereof, the template or member that it specializes or
+	from which it was instantiated. Otherwise, returns a NULL cursor.
+*>
 extern fn CXCursor getSpecializedCursorTemplate(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_getSpecializedCursorTemplate");
 
+<*
+	Given a cursor that references something else, return the source range
+	covering that reference.
+	\param C A cursor pointing to a member reference, a declaration reference, or
+	an operator call.
+	\param NameFlags A bitset with three independent flags:
+	CXNameRange_WantQualifier, CXNameRange_WantTemplateArgs, and
+	CXNameRange_WantSinglePiece.
+	\param PieceIndex For contiguous names or when passing the flag
+	CXNameRange_WantSinglePiece, only one piece with index 0 is
+	available. When the CXNameRange_WantSinglePiece flag is not passed for a
+	non-contiguous names, this index can be used to retrieve the individual
+	pieces of the name. See also CXNameRange_WantSinglePiece.
+	\returns The piece of the name pointed to by the given cursor. If there is no
+	name, or if the PieceIndex is out-of-range, a null-cursor will be returned.
+*>
 extern fn CXSourceRange getCursorReferenceNameRange(
-  CXCursor c,
-  CUInt name_flags,
-  CUInt piece_index)
+	CXCursor c,
+	CUInt name_flags,
+	CUInt piece_index)
 @cname("clang_getCursorReferenceNameRange");
 
+
 constdef CXNameRefFlags : CInt {
-  NAME_RANGE_WANT_QUALIFIER = 1,
-  NAME_RANGE_WANT_TEMPLATE_ARGS = 2,
-  NAME_RANGE_WANT_SINGLE_PIECE = 4
+
+	<*
+		Include the nested-name-specifier, e.g. Foo:: in x.Foo::y, in the
+		range.
+	*>
+	NAME_RANGE_WANT_QUALIFIER = 1,
+
+	<*
+		Include the explicit template arguments, e.g. \<int> in x.f<int>,
+		in the range.
+	*>
+	NAME_RANGE_WANT_TEMPLATE_ARGS = 2,
+
+	<*
+		If the name is non-contiguous, return the full spanning range.
+		Non-contiguous names occur in Objective-C when a selector with two or more
+		parameters is used, or in C++ when using an operator:
+		\code
+		[object doSomething:here withValue:there]; // Objective-C
+		return some_vector[1]; // C++
+		\endcode
+	*>
+	NAME_RANGE_WANT_SINGLE_PIECE = 4
 }
 
+<*
+	Describes a kind of token.
+*>
 constdef CXTokenKind : CInt {
-  TOKEN_PUNCTUATION = 0,
-  TOKEN_KEYWORD = 1,
-  TOKEN_IDENTIFIER = 2,
-  TOKEN_LITERAL = 3,
-  TOKEN_COMMENT = 4
+
+	<*
+		A token that contains some kind of punctuation.
+	*>
+	TOKEN_PUNCTUATION = 0,
+
+	<*
+		A language keyword.
+	*>
+	TOKEN_KEYWORD = 1,
+
+	<*
+		An identifier (that is not a keyword).
+	*>
+	TOKEN_IDENTIFIER = 2,
+
+	<*
+		A numeric, string, or character literal.
+	*>
+	TOKEN_LITERAL = 3,
+
+	<*
+		A comment.
+	*>
+	TOKEN_COMMENT = 4
 }
 
+<*
+	Describes a single preprocessing token.
+*>
 struct CXToken {
-  CUInt[4] int_data;
-  void* ptr_data;
+	CUInt[4] int_data;
+	void* ptr_data;
 }
 
+<*
+	Get the raw lexical token starting with the given location.
+	\param TU the translation unit whose text is being tokenized.
+	\param Location the source location with which the token starts.
+	\returns The token starting with the given location or NULL if no such token
+	exist. The returned pointer must be freed with clang_disposeTokens before the
+	translation unit is destroyed.
+*>
 extern fn CXToken* getToken(
-  CXTranslationUnit tu,
-  CXSourceLocation location)
+	CXTranslationUnit tu,
+	CXSourceLocation location)
 @cname("clang_getToken");
 
+<*
+	Determine the kind of the given token.
+*>
 extern fn CXTokenKind getTokenKind(
-  CXToken)
+	CXToken)
 @cname("clang_getTokenKind");
 
+<*
+	Determine the spelling of the given token.
+	The spelling of a token is the textual representation of that token, e.g.,
+	the text of an identifier or keyword.
+*>
 extern fn CXString getTokenSpelling(
-  CXTranslationUnit,
-  CXToken)
+	CXTranslationUnit,
+	CXToken)
 @cname("clang_getTokenSpelling");
 
+<*
+	Retrieve the source location of the given token.
+*>
 extern fn CXSourceLocation getTokenLocation(
-  CXTranslationUnit,
-  CXToken)
+	CXTranslationUnit,
+	CXToken)
 @cname("clang_getTokenLocation");
 
+<*
+	Retrieve a source range that covers the given token.
+*>
 extern fn CXSourceRange getTokenExtent(
-  CXTranslationUnit,
-  CXToken)
+	CXTranslationUnit,
+	CXToken)
 @cname("clang_getTokenExtent");
 
+<*
+	Tokenize the source code described by the given range into raw
+	lexical tokens.
+	\param TU the translation unit whose text is being tokenized.
+	\param Range the source range in which text should be tokenized. All of the
+	tokens produced by tokenization will fall within this source range,
+	\param Tokens this pointer will be set to point to the array of tokens
+	that occur within the given source range. The returned pointer must be
+	freed with clang_disposeTokens() before the translation unit is destroyed.
+	\param NumTokens will be set to the number of tokens in the \c *Tokens
+	array.
+*>
 extern fn void tokenize(
-  CXTranslationUnit tu,
-  CXSourceRange range,
-  CXToken** tokens,
-  CUInt* num_tokens)
+	CXTranslationUnit tu,
+	CXSourceRange range,
+	CXToken** tokens,
+	CUInt* num_tokens)
 @cname("clang_tokenize");
 
+<*
+	Annotate the given set of tokens by providing cursors for each token
+	that can be mapped to a specific entity within the abstract syntax tree.
+	This token-annotation routine is equivalent to invoking
+	clang_getCursor() for the source locations of each of the
+	tokens. The cursors provided are filtered, so that only those
+	cursors that have a direct correspondence to the token are
+	accepted. For example, given a function call \c f(x),
+	clang_getCursor() would provide the following cursors:
+	* when the cursor is over the 'f', a DeclRefExpr cursor referring to 'f'.
+	* when the cursor is over the '(' or the ')', a CallExpr referring to 'f'.
+	* when the cursor is over the 'x', a DeclRefExpr cursor referring to 'x'.
+	Only the first and last of these cursors will occur within the
+	annotate, since the tokens "f" and "x' directly refer to a function
+	and a variable, respectively, but the parentheses are just a small
+	part of the full syntax of the function call expression, which is
+	not provided as an annotation.
+	\param TU the translation unit that owns the given tokens.
+	\param Tokens the set of tokens to annotate.
+	\param NumTokens the number of tokens in \p Tokens.
+	\param Cursors an array of \p NumTokens cursors, whose contents will be
+	replaced with the cursors corresponding to each token.
+*>
 extern fn void annotateTokens(
-  CXTranslationUnit tu,
-  CXToken* tokens,
-  CUInt num_tokens,
-  CXCursor* cursors)
+	CXTranslationUnit tu,
+	CXToken* tokens,
+	CUInt num_tokens,
+	CXCursor* cursors)
 @cname("clang_annotateTokens");
 
+<*
+	Free the given set of tokens.
+*>
 extern fn void disposeTokens(
-  CXTranslationUnit tu,
-  CXToken* tokens,
-  CUInt num_tokens)
+	CXTranslationUnit tu,
+	CXToken* tokens,
+	CUInt num_tokens)
 @cname("clang_disposeTokens");
 
+<*
+	\defgroup CINDEX_DEBUG Debugging facilities
+	These routines are used for testing and debugging, only, and should not
+	be relied upon.
+	@{
+*>
 extern fn CXString getCursorKindSpelling(
-  CXCursorKind kind)
+	CXCursorKind kind)
 @cname("clang_getCursorKindSpelling");
 
+
 extern fn void getDefinitionSpellingAndExtent(
-  CXCursor,
-  CChar** start_buf,
-  CChar** end_buf,
-  CUInt* start_line,
-  CUInt* start_column,
-  CUInt* end_line,
-  CUInt* end_column)
+	CXCursor,
+	ZString* start_buf,
+	ZString* end_buf,
+	CUInt* start_line,
+	CUInt* start_column,
+	CUInt* end_line,
+	CUInt* end_column)
 @cname("clang_getDefinitionSpellingAndExtent");
+
 
 extern fn void enableStackTraces()
 @cname("clang_enableStackTraces");
 
 alias UnnamedPFN1 @private = fn void(
-  void*);
+	void*);
+
 
 extern fn void executeOnThread(
-  UnnamedPFN1 func,
-  void* user_data,
-  CUInt stack_size)
+	UnnamedPFN1 func,
+	void* user_data,
+	CUInt stack_size)
 @cname("clang_executeOnThread");
 
 alias CXCompletionString = void*;
 
+<*
+	A single result of code completion.
+*>
 struct CXCompletionResult {
-  CXCursorKind cursor_kind;
-  CXCompletionString completion_string;
+	CXCursorKind cursor_kind;
+	CXCompletionString completion_string;
 }
 
+<*
+	Describes a single piece of text within a code-completion string.
+	Each "chunk" within a code-completion string (\c CXCompletionString) is
+	either a piece of text with a specific "kind" that describes how that text
+	should be interpreted by the client or is another completion string.
+*>
 constdef CXCompletionChunkKind : CInt {
-  COMPLETION_CHUNK_OPTIONAL = 0,
-  COMPLETION_CHUNK_TYPED_TEXT = 1,
-  COMPLETION_CHUNK_TEXT = 2,
-  COMPLETION_CHUNK_PLACEHOLDER = 3,
-  COMPLETION_CHUNK_INFORMATIVE = 4,
-  COMPLETION_CHUNK_CURRENT_PARAMETER = 5,
-  COMPLETION_CHUNK_LEFT_PAREN = 6,
-  COMPLETION_CHUNK_RIGHT_PAREN = 7,
-  COMPLETION_CHUNK_LEFT_BRACKET = 8,
-  COMPLETION_CHUNK_RIGHT_BRACKET = 9,
-  COMPLETION_CHUNK_LEFT_BRACE = 10,
-  COMPLETION_CHUNK_RIGHT_BRACE = 11,
-  COMPLETION_CHUNK_LEFT_ANGLE = 12,
-  COMPLETION_CHUNK_RIGHT_ANGLE = 13,
-  COMPLETION_CHUNK_COMMA = 14,
-  COMPLETION_CHUNK_RESULT_TYPE = 15,
-  COMPLETION_CHUNK_COLON = 16,
-  COMPLETION_CHUNK_SEMI_COLON = 17,
-  COMPLETION_CHUNK_EQUAL = 18,
-  COMPLETION_CHUNK_HORIZONTAL_SPACE = 19,
-  COMPLETION_CHUNK_VERTICAL_SPACE = 20
+
+	<*
+		A code-completion string that describes "optional" text that
+		could be a part of the template (but is not required).
+		The Optional chunk is the only kind of chunk that has a code-completion
+		string for its representation, which is accessible via
+		\c clang_getCompletionChunkCompletionString(). The code-completion string
+		describes an additional part of the template that is completely optional.
+		For example, optional chunks can be used to describe the placeholders for
+		arguments that match up with defaulted function parameters, e.g. given:
+		\code
+		void f(int x, float y = 3.14, double z = 2.71828);
+		\endcode
+		The code-completion string for this function would contain:
+		- a TypedText chunk for "f".
+		- a LeftParen chunk for "(".
+		- a Placeholder chunk for "int x"
+		- an Optional chunk containing the remaining defaulted arguments, e.g.,
+		- a Comma chunk for ","
+		- a Placeholder chunk for "float y"
+		- an Optional chunk containing the last defaulted argument:
+		- a Comma chunk for ","
+		- a Placeholder chunk for "double z"
+		- a RightParen chunk for ")"
+		There are many ways to handle Optional chunks. Two simple approaches are:
+		- Completely ignore optional chunks, in which case the template for the
+		function "f" would only include the first parameter ("int x").
+		- Fully expand all optional chunks, in which case the template for the
+		function "f" would have all of the parameters.
+	*>
+	COMPLETION_CHUNK_OPTIONAL = 0,
+
+	<*
+		Text that a user would be expected to type to get this
+		code-completion result.
+		There will be exactly one "typed text" chunk in a semantic string, which
+		will typically provide the spelling of a keyword or the name of a
+		declaration that could be used at the current code point. Clients are
+		expected to filter the code-completion results based on the text in this
+		chunk.
+	*>
+	COMPLETION_CHUNK_TYPED_TEXT = 1,
+
+	<*
+		Text that should be inserted as part of a code-completion result.
+		A "text" chunk represents text that is part of the template to be
+		inserted into user code should this particular code-completion result
+		be selected.
+	*>
+	COMPLETION_CHUNK_TEXT = 2,
+
+	<*
+		Placeholder text that should be replaced by the user.
+		A "placeholder" chunk marks a place where the user should insert text
+		into the code-completion template. For example, placeholders might mark
+		the function parameters for a function declaration, to indicate that the
+		user should provide arguments for each of those parameters. The actual
+		text in a placeholder is a suggestion for the text to display before
+		the user replaces the placeholder with real code.
+	*>
+	COMPLETION_CHUNK_PLACEHOLDER = 3,
+
+	<*
+		Informative text that should be displayed but never inserted as
+		part of the template.
+		An "informative" chunk contains annotations that can be displayed to
+		help the user decide whether a particular code-completion result is the
+		right option, but which is not part of the actual template to be inserted
+		by code completion.
+	*>
+	COMPLETION_CHUNK_INFORMATIVE = 4,
+
+	<*
+		Text that describes the current parameter when code-completion is
+		referring to function call, message send, or template specialization.
+		A "current parameter" chunk occurs when code-completion is providing
+		information about a parameter corresponding to the argument at the
+		code-completion point. For example, given a function
+		\code
+		int add(int x, int y);
+		\endcode
+		and the source code \c add(, where the code-completion point is after the
+		"(", the code-completion string will contain a "current parameter" chunk
+		for "int x", indicating that the current argument will initialize that
+		parameter. After typing further, to \c add(17, (where the code-completion
+		point is after the ","), the code-completion string will contain a
+		"current parameter" chunk to "int y".
+	*>
+	COMPLETION_CHUNK_CURRENT_PARAMETER = 5,
+
+	<*
+		A left parenthesis ('('), used to initiate a function call or
+		signal the beginning of a function parameter list.
+	*>
+	COMPLETION_CHUNK_LEFT_PAREN = 6,
+
+	<*
+		A right parenthesis (')'), used to finish a function call or
+		signal the end of a function parameter list.
+	*>
+	COMPLETION_CHUNK_RIGHT_PAREN = 7,
+
+	<*
+		A left bracket ('[').
+	*>
+	COMPLETION_CHUNK_LEFT_BRACKET = 8,
+
+	<*
+		A right bracket (']').
+	*>
+	COMPLETION_CHUNK_RIGHT_BRACKET = 9,
+
+	<*
+		A left brace ('{').
+	*>
+	COMPLETION_CHUNK_LEFT_BRACE = 10,
+
+	<*
+		A right brace ('}').
+	*>
+	COMPLETION_CHUNK_RIGHT_BRACE = 11,
+
+	<*
+		A left angle bracket ('<').
+	*>
+	COMPLETION_CHUNK_LEFT_ANGLE = 12,
+
+	<*
+		A right angle bracket ('>').
+	*>
+	COMPLETION_CHUNK_RIGHT_ANGLE = 13,
+
+	<*
+		A comma separator (',').
+	*>
+	COMPLETION_CHUNK_COMMA = 14,
+
+	<*
+		Text that specifies the result type of a given result.
+		This special kind of informative chunk is not meant to be inserted into
+		the text buffer. Rather, it is meant to illustrate the type that an
+		expression using the given completion string would have.
+	*>
+	COMPLETION_CHUNK_RESULT_TYPE = 15,
+
+	<*
+		A colon (':').
+	*>
+	COMPLETION_CHUNK_COLON = 16,
+
+	<*
+		A semicolon (';').
+	*>
+	COMPLETION_CHUNK_SEMI_COLON = 17,
+
+	<*
+		An '=' sign.
+	*>
+	COMPLETION_CHUNK_EQUAL = 18,
+
+	<*
+		Horizontal space (' ').
+	*>
+	COMPLETION_CHUNK_HORIZONTAL_SPACE = 19,
+
+	<*
+		Vertical space ('\\n'), after which it is generally a good idea to
+		perform indentation.
+	*>
+	COMPLETION_CHUNK_VERTICAL_SPACE = 20
 }
 
+<*
+	Determine the kind of a particular chunk within a completion string.
+	\param completion_string the completion string to query.
+	\param chunk_number the 0-based index of the chunk in the completion string.
+	\returns the kind of the chunk at the index \c chunk_number.
+*>
 extern fn CXCompletionChunkKind getCompletionChunkKind(
-  CXCompletionString completion_string,
-  CUInt chunk_number)
+	CXCompletionString completion_string,
+	CUInt chunk_number)
 @cname("clang_getCompletionChunkKind");
 
+<*
+	Retrieve the text associated with a particular chunk within a
+	completion string.
+	\param completion_string the completion string to query.
+	\param chunk_number the 0-based index of the chunk in the completion string.
+	\returns the text associated with the chunk at index \c chunk_number.
+*>
 extern fn CXString getCompletionChunkText(
-  CXCompletionString completion_string,
-  CUInt chunk_number)
+	CXCompletionString completion_string,
+	CUInt chunk_number)
 @cname("clang_getCompletionChunkText");
 
+<*
+	Retrieve the completion string associated with a particular chunk
+	within a completion string.
+	\param completion_string the completion string to query.
+	\param chunk_number the 0-based index of the chunk in the completion string.
+	\returns the completion string associated with the chunk at index
+	\c chunk_number.
+*>
 extern fn CXCompletionString getCompletionChunkCompletionString(
-  CXCompletionString completion_string,
-  CUInt chunk_number)
+	CXCompletionString completion_string,
+	CUInt chunk_number)
 @cname("clang_getCompletionChunkCompletionString");
 
+<*
+	Retrieve the number of chunks in the given code-completion string.
+*>
 extern fn CUInt getNumCompletionChunks(
-  CXCompletionString completion_string)
+	CXCompletionString completion_string)
 @cname("clang_getNumCompletionChunks");
 
+<*
+	Determine the priority of this code completion.
+	The priority of a code completion indicates how likely it is that this
+	particular completion is the completion that the user will select. The
+	priority is selected by various internal heuristics.
+	\param completion_string The completion string to query.
+	\returns The priority of this completion string. Smaller values indicate
+	higher-priority (more likely) completions.
+*>
 extern fn CUInt getCompletionPriority(
-  CXCompletionString completion_string)
+	CXCompletionString completion_string)
 @cname("clang_getCompletionPriority");
 
+<*
+	Determine the availability of the entity that this code-completion
+	string refers to.
+	\param completion_string The completion string to query.
+	\returns The availability of the completion string.
+*>
 extern fn CXAvailabilityKind getCompletionAvailability(
-  CXCompletionString completion_string)
+	CXCompletionString completion_string)
 @cname("clang_getCompletionAvailability");
 
+<*
+	Retrieve the number of annotations associated with the given
+	completion string.
+	\param completion_string the completion string to query.
+	\returns the number of annotations associated with the given completion
+	string.
+*>
 extern fn CUInt getCompletionNumAnnotations(
-  CXCompletionString completion_string)
+	CXCompletionString completion_string)
 @cname("clang_getCompletionNumAnnotations");
 
+<*
+	Retrieve the annotation associated with the given completion string.
+	\param completion_string the completion string to query.
+	\param annotation_number the 0-based index of the annotation of the
+	completion string.
+	\returns annotation string associated with the completion at index
+	\c annotation_number, or a NULL string if that annotation is not available.
+*>
 extern fn CXString getCompletionAnnotation(
-  CXCompletionString completion_string,
-  CUInt annotation_number)
+	CXCompletionString completion_string,
+	CUInt annotation_number)
 @cname("clang_getCompletionAnnotation");
 
+<*
+	Retrieve the parent context of the given completion string.
+	The parent context of a completion string is the semantic parent of
+	the declaration (if any) that the code completion represents. For example,
+	a code completion for an Objective-C method would have the method's class
+	or protocol as its context.
+	\param completion_string The code completion string whose parent is
+	being queried.
+	\param kind DEPRECATED: always set to CXCursor_NotImplemented if non-NULL.
+	\returns The name of the completion parent, e.g., "NSObject" if
+	the completion string represents a method in the NSObject class.
+*>
 extern fn CXString getCompletionParent(
-  CXCompletionString completion_string,
-  CXCursorKind* kind)
+	CXCompletionString completion_string,
+	CXCursorKind* kind)
 @cname("clang_getCompletionParent");
 
+<*
+	Retrieve the brief documentation comment attached to the declaration
+	that corresponds to the given completion string.
+*>
 extern fn CXString getCompletionBriefComment(
-  CXCompletionString completion_string)
+	CXCompletionString completion_string)
 @cname("clang_getCompletionBriefComment");
 
+<*
+	Retrieve a completion string for an arbitrary declaration or macro
+	definition cursor.
+	\param cursor The cursor to query.
+	\returns A non-context-sensitive completion string for declaration and macro
+	definition cursors, or NULL for other kinds of cursors.
+*>
 extern fn CXCompletionString getCursorCompletionString(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorCompletionString");
 
+<*
+	Contains the results of code-completion.
+	This data structure contains the results of code completion, as
+	produced by \c clang_codeCompleteAt(). Its contents must be freed by
+	\c clang_disposeCodeCompleteResults.
+*>
 struct CXCodeCompleteResults {
-  CXCompletionResult* results;
-  CUInt num_results;
+	CXCompletionResult* results;
+	CUInt num_results;
 }
 
+<*
+	Retrieve the number of fix-its for the given completion index.
+	Calling this makes sense only if CXCodeComplete_IncludeCompletionsWithFixIts
+	option was set.
+	\param results The structure keeping all completion results
+	\param completion_index The index of the completion
+	\return The number of fix-its which must be applied before the completion at
+	completion_index can be applied
+*>
 extern fn CUInt getCompletionNumFixIts(
-  CXCodeCompleteResults* results,
-  CUInt completion_index)
+	CXCodeCompleteResults* results,
+	CUInt completion_index)
 @cname("clang_getCompletionNumFixIts");
 
+<*
+	Fix-its that *must* be applied before inserting the text for the
+	corresponding completion.
+	By default, clang_codeCompleteAt() only returns completions with empty
+	fix-its. Extra completions with non-empty fix-its should be explicitly
+	requested by setting CXCodeComplete_IncludeCompletionsWithFixIts.
+	For the clients to be able to compute position of the cursor after applying
+	fix-its, the following conditions are guaranteed to hold for
+	replacement_range of the stored fix-its:
+	- Ranges in the fix-its are guaranteed to never contain the completion
+	point (or identifier under completion point, if any) inside them, except
+	at the start or at the end of the range.
+	- If a fix-it range starts or ends with completion point (or starts or
+	ends after the identifier under completion point), it will contain at
+	least one character. It allows to unambiguously recompute completion
+	point after applying the fix-it.
+	The intuition is that provided fix-its change code around the identifier we
+	complete, but are not allowed to touch the identifier itself or the
+	completion point. One example of completions with corrections are the ones
+	replacing '.' with '->' and vice versa:
+	std::unique_ptr<std::vector<int>> vec_ptr;
+	In 'vec_ptr.^', one of the completions is 'push_back', it requires
+	replacing '.' with '->'.
+	In 'vec_ptr->^', one of the completions is 'release', it requires
+	replacing '->' with '.'.
+	\param results The structure keeping all completion results
+	\param completion_index The index of the completion
+	\param fixit_index The index of the fix-it for the completion at
+	completion_index
+	\param replacement_range The fix-it range that must be replaced before the
+	completion at completion_index can be applied
+	\returns The fix-it string that must replace the code at replacement_range
+	before the completion at completion_index can be applied
+*>
 extern fn CXString getCompletionFixIt(
-  CXCodeCompleteResults* results,
-  CUInt completion_index,
-  CUInt fixit_index,
-  CXSourceRange* replacement_range)
+	CXCodeCompleteResults* results,
+	CUInt completion_index,
+	CUInt fixit_index,
+	CXSourceRange* replacement_range)
 @cname("clang_getCompletionFixIt");
 
+<*
+	Flags that can be passed to \c clang_codeCompleteAt() to
+	modify its behavior.
+	The enumerators in this enumeration can be bitwise-OR'd together to
+	provide multiple options to \c clang_codeCompleteAt().
+*>
 constdef CXCodeComplete_Flags : CInt {
-  CODE_COMPLETE_INCLUDE_MACROS = 1,
-  CODE_COMPLETE_INCLUDE_CODE_PATTERNS = 2,
-  CODE_COMPLETE_INCLUDE_BRIEF_COMMENTS = 4,
-  CODE_COMPLETE_SKIP_PREAMBLE = 8,
-  CODE_COMPLETE_INCLUDE_COMPLETIONS_WITH_FIX_ITS = 16
+
+	<*
+		Whether to include macros within the set of code
+		completions returned.
+	*>
+	CODE_COMPLETE_INCLUDE_MACROS = 1,
+
+	<*
+		Whether to include code patterns for language constructs
+		within the set of code completions, e.g., for loops.
+	*>
+	CODE_COMPLETE_INCLUDE_CODE_PATTERNS = 2,
+
+	<*
+		Whether to include brief documentation within the set of code
+		completions returned.
+	*>
+	CODE_COMPLETE_INCLUDE_BRIEF_COMMENTS = 4,
+
+	<*
+		Whether to speed up completion by omitting top- or namespace-level entities
+		defined in the preamble. There's no guarantee any particular entity is
+		omitted. This may be useful if the headers are indexed externally.
+	*>
+	CODE_COMPLETE_SKIP_PREAMBLE = 8,
+
+	<*
+		Whether to include completions with small
+		fix-its, e.g. change '.' to '->' on member access, etc.
+	*>
+	CODE_COMPLETE_INCLUDE_COMPLETIONS_WITH_FIX_ITS = 16
 }
 
+<*
+	Bits that represent the context under which completion is occurring.
+	The enumerators in this enumeration may be bitwise-OR'd together if multiple
+	contexts are occurring simultaneously.
+*>
 constdef CXCompletionContext : CInt {
-  COMPLETION_CONTEXT_UNEXPOSED = 0,
-  COMPLETION_CONTEXT_ANY_TYPE = 1,
-  COMPLETION_CONTEXT_ANY_VALUE = 2,
-  COMPLETION_CONTEXT_OBJ_C_OBJECT_VALUE = 4,
-  COMPLETION_CONTEXT_OBJ_C_SELECTOR_VALUE = 8,
-  COMPLETION_CONTEXT_CXX_CLASS_TYPE_VALUE = 16,
-  COMPLETION_CONTEXT_DOT_MEMBER_ACCESS = 32,
-  COMPLETION_CONTEXT_ARROW_MEMBER_ACCESS = 64,
-  COMPLETION_CONTEXT_OBJ_C_PROPERTY_ACCESS = 128,
-  COMPLETION_CONTEXT_ENUM_TAG = 256,
-  COMPLETION_CONTEXT_UNION_TAG = 512,
-  COMPLETION_CONTEXT_STRUCT_TAG = 1024,
-  COMPLETION_CONTEXT_CLASS_TAG = 2048,
-  COMPLETION_CONTEXT_NAMESPACE = 4096,
-  COMPLETION_CONTEXT_NESTED_NAME_SPECIFIER = 8192,
-  COMPLETION_CONTEXT_OBJ_C_INTERFACE = 16384,
-  COMPLETION_CONTEXT_OBJ_C_PROTOCOL = 32768,
-  COMPLETION_CONTEXT_OBJ_C_CATEGORY = 65536,
-  COMPLETION_CONTEXT_OBJ_C_INSTANCE_MESSAGE = 131072,
-  COMPLETION_CONTEXT_OBJ_C_CLASS_MESSAGE = 262144,
-  COMPLETION_CONTEXT_OBJ_C_SELECTOR_NAME = 524288,
-  COMPLETION_CONTEXT_MACRO_NAME = 1048576,
-  COMPLETION_CONTEXT_NATURAL_LANGUAGE = 2097152,
-  COMPLETION_CONTEXT_INCLUDED_FILE = 4194304,
-  COMPLETION_CONTEXT_UNKNOWN = 8388607
+
+	<*
+		The context for completions is unexposed, as only Clang results
+		should be included. (This is equivalent to having no context bits set.)
+	*>
+	COMPLETION_CONTEXT_UNEXPOSED = 0,
+
+	<*
+		Completions for any possible type should be included in the results.
+	*>
+	COMPLETION_CONTEXT_ANY_TYPE = 1,
+
+	<*
+		Completions for any possible value (variables, function calls, etc.)
+		should be included in the results.
+	*>
+	COMPLETION_CONTEXT_ANY_VALUE = 2,
+
+	<*
+		Completions for values that resolve to an Objective-C object should
+		be included in the results.
+	*>
+	COMPLETION_CONTEXT_OBJ_C_OBJECT_VALUE = 4,
+
+	<*
+		Completions for values that resolve to an Objective-C selector
+		should be included in the results.
+	*>
+	COMPLETION_CONTEXT_OBJ_C_SELECTOR_VALUE = 8,
+
+	<*
+		Completions for values that resolve to a C++ class type should be
+		included in the results.
+	*>
+	COMPLETION_CONTEXT_CXX_CLASS_TYPE_VALUE = 16,
+
+	<*
+		Completions for fields of the member being accessed using the dot
+		operator should be included in the results.
+	*>
+	COMPLETION_CONTEXT_DOT_MEMBER_ACCESS = 32,
+
+	<*
+		Completions for fields of the member being accessed using the arrow
+		operator should be included in the results.
+	*>
+	COMPLETION_CONTEXT_ARROW_MEMBER_ACCESS = 64,
+
+	<*
+		Completions for properties of the Objective-C object being accessed
+		using the dot operator should be included in the results.
+	*>
+	COMPLETION_CONTEXT_OBJ_C_PROPERTY_ACCESS = 128,
+
+	<*
+		Completions for enum tags should be included in the results.
+	*>
+	COMPLETION_CONTEXT_ENUM_TAG = 256,
+
+	<*
+		Completions for union tags should be included in the results.
+	*>
+	COMPLETION_CONTEXT_UNION_TAG = 512,
+
+	<*
+		Completions for struct tags should be included in the results.
+	*>
+	COMPLETION_CONTEXT_STRUCT_TAG = 1024,
+
+	<*
+		Completions for C++ class names should be included in the results.
+	*>
+	COMPLETION_CONTEXT_CLASS_TAG = 2048,
+
+	<*
+		Completions for C++ namespaces and namespace aliases should be
+		included in the results.
+	*>
+	COMPLETION_CONTEXT_NAMESPACE = 4096,
+
+	<*
+		Completions for C++ nested name specifiers should be included in
+		the results.
+	*>
+	COMPLETION_CONTEXT_NESTED_NAME_SPECIFIER = 8192,
+
+	<*
+		Completions for Objective-C interfaces (classes) should be included
+		in the results.
+	*>
+	COMPLETION_CONTEXT_OBJ_C_INTERFACE = 16384,
+
+	<*
+		Completions for Objective-C protocols should be included in
+		the results.
+	*>
+	COMPLETION_CONTEXT_OBJ_C_PROTOCOL = 32768,
+
+	<*
+		Completions for Objective-C categories should be included in
+		the results.
+	*>
+	COMPLETION_CONTEXT_OBJ_C_CATEGORY = 65536,
+
+	<*
+		Completions for Objective-C instance messages should be included
+		in the results.
+	*>
+	COMPLETION_CONTEXT_OBJ_C_INSTANCE_MESSAGE = 131072,
+
+	<*
+		Completions for Objective-C class messages should be included in
+		the results.
+	*>
+	COMPLETION_CONTEXT_OBJ_C_CLASS_MESSAGE = 262144,
+
+	<*
+		Completions for Objective-C selector names should be included in
+		the results.
+	*>
+	COMPLETION_CONTEXT_OBJ_C_SELECTOR_NAME = 524288,
+
+	<*
+		Completions for preprocessor macro names should be included in
+		the results.
+	*>
+	COMPLETION_CONTEXT_MACRO_NAME = 1048576,
+
+	<*
+		Natural language completions should be included in the results.
+	*>
+	COMPLETION_CONTEXT_NATURAL_LANGUAGE = 2097152,
+
+	<*
+		#include file completions should be included in the results.
+	*>
+	COMPLETION_CONTEXT_INCLUDED_FILE = 4194304,
+
+	<*
+		The current context is unknown, so set all contexts.
+	*>
+	COMPLETION_CONTEXT_UNKNOWN = 8388607
 }
 
+<*
+	Returns a default set of code-completion options that can be
+	passed to\c clang_codeCompleteAt().
+*>
 extern fn CUInt defaultCodeCompleteOptions()
 @cname("clang_defaultCodeCompleteOptions");
 
+<*
+	Perform code completion at a given location in a translation unit.
+	This function performs code completion at a particular file, line, and
+	column within source code, providing results that suggest potential
+	code snippets based on the context of the completion. The basic model
+	for code completion is that Clang will parse a complete source file,
+	performing syntax checking up to the location where code-completion has
+	been requested. At that point, a special code-completion token is passed
+	to the parser, which recognizes this token and determines, based on the
+	current location in the C/Objective-C/C++ grammar and the state of
+	semantic analysis, what completions to provide. These completions are
+	returned via a new \c CXCodeCompleteResults structure.
+	Code completion itself is meant to be triggered by the client when the
+	user types punctuation characters or whitespace, at which point the
+	code-completion location will coincide with the cursor. For example, if \c p
+	is a pointer, code-completion might be triggered after the "-" and then
+	after the ">" in \c p->. When the code-completion location is after the ">",
+	the completion results will provide, e.g., the members of the struct that
+	"p" points to. The client is responsible for placing the cursor at the
+	beginning of the token currently being typed, then filtering the results
+	based on the contents of the token. For example, when code-completing for
+	the expression \c p->get, the client should provide the location just after
+	the ">" (e.g., pointing at the "g") to this code-completion hook. Then, the
+	client can filter the results based on the current token text ("get"), only
+	showing those results that start with "get". The intent of this interface
+	is to separate the relatively high-latency acquisition of code-completion
+	results from the filtering of results on a per-character basis, which must
+	have a lower latency.
+	\param TU The translation unit in which code-completion should
+	occur. The source files for this translation unit need not be
+	completely up-to-date (and the contents of those source files may
+	be overridden via \p unsaved_files). Cursors referring into the
+	translation unit may be invalidated by this invocation.
+	\param complete_filename The name of the source file where code
+	completion should be performed. This filename may be any file
+	included in the translation unit.
+	\param complete_line The line at which code-completion should occur.
+	\param complete_column The column at which code-completion should occur.
+	Note that the column should point just after the syntactic construct that
+	initiated code completion, and not in the middle of a lexical token.
+	\param unsaved_files the Files that have not yet been saved to disk
+	but may be required for parsing or code completion, including the
+	contents of those files.  The contents and name of these files (as
+	specified by CXUnsavedFile) are copied when necessary, so the
+	client only needs to guarantee their validity until the call to
+	this function returns.
+	\param num_unsaved_files The number of unsaved file entries in \p
+	unsaved_files.
+	\param options Extra options that control the behavior of code
+	completion, expressed as a bitwise OR of the enumerators of the
+	CXCodeComplete_Flags enumeration. The
+	\c clang_defaultCodeCompleteOptions() function returns a default set
+	of code-completion options.
+	\returns If successful, a new \c CXCodeCompleteResults structure
+	containing code-completion results, which should eventually be
+	freed with \c clang_disposeCodeCompleteResults(). If code
+	completion fails, returns NULL.
+*>
 extern fn CXCodeCompleteResults* codeCompleteAt(
-  CXTranslationUnit tu,
-  ZString complete_filename,
-  CUInt complete_line,
-  CUInt complete_column,
-  CXUnsavedFile* unsaved_files,
-  CUInt num_unsaved_files,
-  CUInt options)
+	CXTranslationUnit tu,
+	ZString complete_filename,
+	CUInt complete_line,
+	CUInt complete_column,
+	CXUnsavedFile* unsaved_files,
+	CUInt num_unsaved_files,
+	CUInt options)
 @cname("clang_codeCompleteAt");
 
+<*
+	Sort the code-completion results in case-insensitive alphabetical
+	order.
+	\param Results The set of results to sort.
+	\param NumResults The number of results in \p Results.
+*>
 extern fn void sortCodeCompletionResults(
-  CXCompletionResult* results,
-  CUInt num_results)
+	CXCompletionResult* results,
+	CUInt num_results)
 @cname("clang_sortCodeCompletionResults");
 
+<*
+	Free the given set of code-completion results.
+*>
 extern fn void disposeCodeCompleteResults(
-  CXCodeCompleteResults* results)
+	CXCodeCompleteResults* results)
 @cname("clang_disposeCodeCompleteResults");
 
+<*
+	Determine the number of diagnostics produced prior to the
+	location where code completion was performed.
+*>
 extern fn CUInt codeCompleteGetNumDiagnostics(
-  CXCodeCompleteResults* results)
+	CXCodeCompleteResults* results)
 @cname("clang_codeCompleteGetNumDiagnostics");
 
+<*
+	Retrieve a diagnostic associated with the given code completion.
+	\param Results the code completion results to query.
+	\param Index the zero-based diagnostic number to retrieve.
+	\returns the requested diagnostic. This diagnostic must be freed
+	via a call to \c clang_disposeDiagnostic().
+*>
 extern fn CXDiagnostic codeCompleteGetDiagnostic(
-  CXCodeCompleteResults* results,
-  CUInt index)
+	CXCodeCompleteResults* results,
+	CUInt index)
 @cname("clang_codeCompleteGetDiagnostic");
 
+<*
+	Determines what completions are appropriate for the context
+	the given code completion.
+	\param Results the code completion results to query
+	\returns the kinds of completions that are appropriate for use
+	along with the given code completion results.
+*>
 extern fn CULongLong codeCompleteGetContexts(
-  CXCodeCompleteResults* results)
+	CXCodeCompleteResults* results)
 @cname("clang_codeCompleteGetContexts");
 
+<*
+	Returns the cursor kind for the container for the current code
+	completion context. The container is only guaranteed to be set for
+	contexts where a container exists (i.e. member accesses or Objective-C
+	message sends); if there is not a container, this function will return
+	CXCursor_InvalidCode.
+	\param Results the code completion results to query
+	\param IsIncomplete on return, this value will be false if Clang has complete
+	information about the container. If Clang does not have complete
+	information, this value will be true.
+	\returns the container kind, or CXCursor_InvalidCode if there is not a
+	container
+*>
 extern fn CXCursorKind codeCompleteGetContainerKind(
-  CXCodeCompleteResults* results,
-  CUInt* is_incomplete)
+	CXCodeCompleteResults* results,
+	CUInt* is_incomplete)
 @cname("clang_codeCompleteGetContainerKind");
 
+<*
+	Returns the USR for the container for the current code completion
+	context. If there is not a container for the current context, this
+	function will return the empty string.
+	\param Results the code completion results to query
+	\returns the USR for the container
+*>
 extern fn CXString codeCompleteGetContainerUSR(
-  CXCodeCompleteResults* results)
+	CXCodeCompleteResults* results)
 @cname("clang_codeCompleteGetContainerUSR");
 
+<*
+	Returns the currently-entered selector for an Objective-C message
+	send, formatted like "initWithFoo:bar:". Only guaranteed to return a
+	non-empty string for CXCompletionContext_ObjCInstanceMessage and
+	CXCompletionContext_ObjCClassMessage.
+	\param Results the code completion results to query
+	\returns the selector (or partial selector) that has been entered thus far
+	for an Objective-C message send.
+*>
 extern fn CXString codeCompleteGetObjCSelector(
-  CXCodeCompleteResults* results)
+	CXCodeCompleteResults* results)
 @cname("clang_codeCompleteGetObjCSelector");
 
+<*
+	Return a version string, suitable for showing to a user, but not
+	intended to be parsed (the format is not guaranteed to be stable).
+*>
 extern fn CXString getClangVersion()
 @cname("clang_getClangVersion");
 
+<*
+	Enable/disable crash recovery.
+	\param isEnabled Flag to indicate if crash recovery is enabled.  A non-zero
+	value enables crash recovery, while 0 disables it.
+*>
 extern fn void toggleCrashRecovery(
-  CUInt is_enabled)
+	CUInt is_enabled)
 @cname("clang_toggleCrashRecovery");
 
 alias CXInclusionVisitor = fn void(
-  CXFile included_file,
-  CXSourceLocation* inclusion_stack,
-  CUInt include_len,
-  CXClientData client_data);
+	CXFile included_file,
+	CXSourceLocation* inclusion_stack,
+	CUInt include_len,
+	CXClientData client_data);
 
+<*
+	Visit the set of preprocessor inclusions in a translation unit.
+	The visitor function is called with the provided data for every included
+	file.  This does not include headers included by the PCH file (unless one
+	is inspecting the inclusions in the PCH file itself).
+*>
 extern fn void getInclusions(
-  CXTranslationUnit tu,
-  CXInclusionVisitor visitor,
-  CXClientData client_data)
+	CXTranslationUnit tu,
+	CXInclusionVisitor visitor,
+	CXClientData client_data)
 @cname("clang_getInclusions");
 
+
 constdef CXEvalResultKind : CInt {
-  EVAL_INT = 1,
-  EVAL_FLOAT = 2,
-  EVAL_OBJ_C_STR_LITERAL = 3,
-  EVAL_STR_LITERAL = 4,
-  EVAL_CF_STR = 5,
-  EVAL_OTHER = 6,
-  EVAL_UN_EXPOSED = 0
+	EVAL_INT = 1,
+	EVAL_FLOAT = 2,
+	EVAL_OBJ_C_STR_LITERAL = 3,
+	EVAL_STR_LITERAL = 4,
+	EVAL_CF_STR = 5,
+	EVAL_OTHER = 6,
+	EVAL_UN_EXPOSED = 0
 }
 
 alias CXEvalResult = void*;
 
+<*
+	If cursor is a statement declaration tries to evaluate the
+	statement and if its variable, tries to evaluate its initializer,
+	into its corresponding type.
+	If it's an expression, tries to evaluate the expression.
+*>
 extern fn CXEvalResult cursor_Evaluate(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_Evaluate");
 
+<*
+	Returns the kind of the evaluated result.
+*>
 extern fn CXEvalResultKind evalResult_getKind(
-  CXEvalResult e)
+	CXEvalResult e)
 @cname("clang_EvalResult_getKind");
 
+<*
+	Returns the evaluation result as integer if the
+	kind is Int.
+*>
 extern fn CInt evalResult_getAsInt(
-  CXEvalResult e)
+	CXEvalResult e)
 @cname("clang_EvalResult_getAsInt");
 
+<*
+	Returns the evaluation result as a long long integer if the
+	kind is Int. This prevents overflows that may happen if the result is
+	returned with clang_EvalResult_getAsInt.
+*>
 extern fn CLongLong evalResult_getAsLongLong(
-  CXEvalResult e)
+	CXEvalResult e)
 @cname("clang_EvalResult_getAsLongLong");
 
+<*
+	Returns a non-zero value if the kind is Int and the evaluation
+	result resulted in an unsigned integer.
+*>
 extern fn CUInt evalResult_isUnsignedInt(
-  CXEvalResult e)
+	CXEvalResult e)
 @cname("clang_EvalResult_isUnsignedInt");
 
+<*
+	Returns the evaluation result as an unsigned integer if
+	the kind is Int and clang_EvalResult_isUnsignedInt is non-zero.
+*>
 extern fn CULongLong evalResult_getAsUnsigned(
-  CXEvalResult e)
+	CXEvalResult e)
 @cname("clang_EvalResult_getAsUnsigned");
 
+<*
+	Returns the evaluation result as double if the
+	kind is double.
+*>
 extern fn double evalResult_getAsDouble(
-  CXEvalResult e)
+	CXEvalResult e)
 @cname("clang_EvalResult_getAsDouble");
 
+<*
+	Returns the evaluation result as a constant string if the
+	kind is other than Int or float. User must not free this pointer,
+	instead call clang_EvalResult_dispose on the CXEvalResult returned
+	by clang_Cursor_Evaluate.
+*>
 extern fn ZString evalResult_getAsStr(
-  CXEvalResult e)
+	CXEvalResult e)
 @cname("clang_EvalResult_getAsStr");
 
+<*
+	Disposes the created Eval memory.
+*>
 extern fn void evalResult_dispose(
-  CXEvalResult e)
+	CXEvalResult e)
 @cname("clang_EvalResult_dispose");
 
+<*
+	\defgroup CINDEX_HIGH Higher level API functions
+	@{
+*>
 constdef CXVisitorResult : CInt {
-  VISIT_BREAK = 0,
-  VISIT_CONTINUE = 1
+	VISIT_BREAK = 0,
+	VISIT_CONTINUE = 1
 }
 
 alias UnnamedPFN2 @private = fn CXVisitorResult(
-  void* context,
-  CXCursor,
-  CXSourceRange);
+	void* context,
+	CXCursor,
+	CXSourceRange);
+
 
 struct CXCursorAndRangeVisitor {
-  void* context;
-  UnnamedPFN2 visit;
+	void* context;
+	UnnamedPFN2 visit;
 }
+
 
 constdef CXResult : CInt {
-  RESULT_SUCCESS = 0,
-  RESULT_INVALID = 1,
-  RESULT_VISIT_BREAK = 2
+
+	<*
+		Function returned successfully.
+	*>
+	RESULT_SUCCESS = 0,
+
+	<*
+		One of the parameters was invalid for the function.
+	*>
+	RESULT_INVALID = 1,
+
+	<*
+		The function was terminated by a callback (e.g. it returned
+		CXVisit_Break)
+	*>
+	RESULT_VISIT_BREAK = 2
 }
 
+<*
+	Find references of a declaration in a specific file.
+	\param cursor pointing to a declaration or a reference of one.
+	\param file to search for references.
+	\param visitor callback that will receive pairs of CXCursor/CXSourceRange for
+	each reference found.
+	The CXSourceRange will point inside the file; if the reference is inside
+	a macro (and not a macro argument) the CXSourceRange will be invalid.
+	\returns one of the CXResult enumerators.
+*>
 extern fn CXResult findReferencesInFile(
-  CXCursor cursor,
-  CXFile file,
-  CXCursorAndRangeVisitor visitor)
+	CXCursor cursor,
+	CXFile file,
+	CXCursorAndRangeVisitor visitor)
 @cname("clang_findReferencesInFile");
 
+<*
+	Find #import/#include directives in a specific file.
+	\param TU translation unit containing the file to query.
+	\param file to search for #import/#include directives.
+	\param visitor callback that will receive pairs of CXCursor/CXSourceRange for
+	each directive found.
+	\returns one of the CXResult enumerators.
+*>
 extern fn CXResult findIncludesInFile(
-  CXTranslationUnit tu,
-  CXFile file,
-  CXCursorAndRangeVisitor visitor)
+	CXTranslationUnit tu,
+	CXFile file,
+	CXCursorAndRangeVisitor visitor)
 @cname("clang_findIncludesInFile");
 
 alias CXCursorAndRangeVisitorBlock = void*;
 
+
 extern fn CXResult findReferencesInFileWithBlock(
-  CXCursor,
-  CXFile,
-  CXCursorAndRangeVisitorBlock)
+	CXCursor,
+	CXFile,
+	CXCursorAndRangeVisitorBlock)
 @cname("clang_findReferencesInFileWithBlock");
 
+
 extern fn CXResult findIncludesInFileWithBlock(
-  CXTranslationUnit,
-  CXFile,
-  CXCursorAndRangeVisitorBlock)
+	CXTranslationUnit,
+	CXFile,
+	CXCursorAndRangeVisitorBlock)
 @cname("clang_findIncludesInFileWithBlock");
 
 alias CXIdxClientFile = void*;
@@ -2578,494 +8035,932 @@ alias CXIdxClientContainer = void*;
 
 alias CXIdxClientASTFile = void*;
 
+<*
+	Source location passed to index callbacks.
+*>
 struct CXIdxLoc {
-  void*[2] ptr_data;
-  CUInt int_data;
+	void*[2] ptr_data;
+	CUInt int_data;
 }
 
+<*
+	Data for ppIncludedFile callback.
+*>
 struct CXIdxIncludedFileInfo {
-  CXIdxLoc hash_loc;
-  ZString filename;
-  CXFile file;
-  CInt is_import;
-  CInt is_angled;
-  CInt is_module_import;
+	CXIdxLoc hash_loc;
+	ZString filename;
+	CXFile file;
+	CInt is_import;
+	CInt is_angled;
+	CInt is_module_import;
 }
 
+<*
+	Data for IndexerCallbacks#importedASTFile.
+*>
 struct CXIdxImportedASTFileInfo {
-  CXFile file;
-  CXModule mod;
-  CXIdxLoc loc;
-  CInt is_implicit;
+	CXFile file;
+	CXModule mod;
+	CXIdxLoc loc;
+	CInt is_implicit;
 }
+
 
 constdef CXIdxEntityKind : CInt {
-  IDX_ENTITY_UNEXPOSED = 0,
-  IDX_ENTITY_TYPEDEF = 1,
-  IDX_ENTITY_FUNCTION = 2,
-  IDX_ENTITY_VARIABLE = 3,
-  IDX_ENTITY_FIELD = 4,
-  IDX_ENTITY_ENUM_CONSTANT = 5,
-  IDX_ENTITY_OBJ_C_CLASS = 6,
-  IDX_ENTITY_OBJ_C_PROTOCOL = 7,
-  IDX_ENTITY_OBJ_C_CATEGORY = 8,
-  IDX_ENTITY_OBJ_C_INSTANCE_METHOD = 9,
-  IDX_ENTITY_OBJ_C_CLASS_METHOD = 10,
-  IDX_ENTITY_OBJ_C_PROPERTY = 11,
-  IDX_ENTITY_OBJ_C_IVAR = 12,
-  IDX_ENTITY_ENUM = 13,
-  IDX_ENTITY_STRUCT = 14,
-  IDX_ENTITY_UNION = 15,
-  IDX_ENTITY_CXX_CLASS = 16,
-  IDX_ENTITY_CXX_NAMESPACE = 17,
-  IDX_ENTITY_CXX_NAMESPACE_ALIAS = 18,
-  IDX_ENTITY_CXX_STATIC_VARIABLE = 19,
-  IDX_ENTITY_CXX_STATIC_METHOD = 20,
-  IDX_ENTITY_CXX_INSTANCE_METHOD = 21,
-  IDX_ENTITY_CXX_CONSTRUCTOR = 22,
-  IDX_ENTITY_CXX_DESTRUCTOR = 23,
-  IDX_ENTITY_CXX_CONVERSION_FUNCTION = 24,
-  IDX_ENTITY_CXX_TYPE_ALIAS = 25,
-  IDX_ENTITY_CXX_INTERFACE = 26,
-  IDX_ENTITY_CXX_CONCEPT = 27
+	IDX_ENTITY_UNEXPOSED = 0,
+	IDX_ENTITY_TYPEDEF = 1,
+	IDX_ENTITY_FUNCTION = 2,
+	IDX_ENTITY_VARIABLE = 3,
+	IDX_ENTITY_FIELD = 4,
+	IDX_ENTITY_ENUM_CONSTANT = 5,
+	IDX_ENTITY_OBJ_C_CLASS = 6,
+	IDX_ENTITY_OBJ_C_PROTOCOL = 7,
+	IDX_ENTITY_OBJ_C_CATEGORY = 8,
+	IDX_ENTITY_OBJ_C_INSTANCE_METHOD = 9,
+	IDX_ENTITY_OBJ_C_CLASS_METHOD = 10,
+	IDX_ENTITY_OBJ_C_PROPERTY = 11,
+	IDX_ENTITY_OBJ_C_IVAR = 12,
+	IDX_ENTITY_ENUM = 13,
+	IDX_ENTITY_STRUCT = 14,
+	IDX_ENTITY_UNION = 15,
+	IDX_ENTITY_CXX_CLASS = 16,
+	IDX_ENTITY_CXX_NAMESPACE = 17,
+	IDX_ENTITY_CXX_NAMESPACE_ALIAS = 18,
+	IDX_ENTITY_CXX_STATIC_VARIABLE = 19,
+	IDX_ENTITY_CXX_STATIC_METHOD = 20,
+	IDX_ENTITY_CXX_INSTANCE_METHOD = 21,
+	IDX_ENTITY_CXX_CONSTRUCTOR = 22,
+	IDX_ENTITY_CXX_DESTRUCTOR = 23,
+	IDX_ENTITY_CXX_CONVERSION_FUNCTION = 24,
+	IDX_ENTITY_CXX_TYPE_ALIAS = 25,
+	IDX_ENTITY_CXX_INTERFACE = 26,
+	IDX_ENTITY_CXX_CONCEPT = 27
 }
+
 
 constdef CXIdxEntityLanguage : CInt {
-  IDX_ENTITY_LANG_NONE = 0,
-  IDX_ENTITY_LANG_C = 1,
-  IDX_ENTITY_LANG_OBJ_C = 2,
-  IDX_ENTITY_LANG_CXX = 3,
-  IDX_ENTITY_LANG_SWIFT = 4
+	IDX_ENTITY_LANG_NONE = 0,
+	IDX_ENTITY_LANG_C = 1,
+	IDX_ENTITY_LANG_OBJ_C = 2,
+	IDX_ENTITY_LANG_CXX = 3,
+	IDX_ENTITY_LANG_SWIFT = 4
 }
 
+<*
+	Extra C++ template information for an entity. This can apply to:
+	CXIdxEntity_Function
+	CXIdxEntity_CXXClass
+	CXIdxEntity_CXXStaticMethod
+	CXIdxEntity_CXXInstanceMethod
+	CXIdxEntity_CXXConstructor
+	CXIdxEntity_CXXConversionFunction
+	CXIdxEntity_CXXTypeAlias
+*>
 constdef CXIdxEntityCXXTemplateKind : CInt {
-  IDX_ENTITY_NON_TEMPLATE = 0,
-  IDX_ENTITY_TEMPLATE = 1,
-  IDX_ENTITY_TEMPLATE_PARTIAL_SPECIALIZATION = 2,
-  IDX_ENTITY_TEMPLATE_SPECIALIZATION = 3
+	IDX_ENTITY_NON_TEMPLATE = 0,
+	IDX_ENTITY_TEMPLATE = 1,
+	IDX_ENTITY_TEMPLATE_PARTIAL_SPECIALIZATION = 2,
+	IDX_ENTITY_TEMPLATE_SPECIALIZATION = 3
 }
+
 
 constdef CXIdxAttrKind : CInt {
-  IDX_ATTR_UNEXPOSED = 0,
-  IDX_ATTR_IB_ACTION = 1,
-  IDX_ATTR_IB_OUTLET = 2,
-  IDX_ATTR_IB_OUTLET_COLLECTION = 3
+	IDX_ATTR_UNEXPOSED = 0,
+	IDX_ATTR_IB_ACTION = 1,
+	IDX_ATTR_IB_OUTLET = 2,
+	IDX_ATTR_IB_OUTLET_COLLECTION = 3
 }
+
 
 struct CXIdxAttrInfo {
-  CXIdxAttrKind kind;
-  CXCursor cursor;
-  CXIdxLoc loc;
+	CXIdxAttrKind kind;
+	CXCursor cursor;
+	CXIdxLoc loc;
 }
+
 
 struct CXIdxEntityInfo {
-  CXIdxEntityKind kind;
-  CXIdxEntityCXXTemplateKind template_kind;
-  CXIdxEntityLanguage lang;
-  ZString name;
-  ZString usr;
-  CXCursor cursor;
-  CXIdxAttrInfo** attributes;
-  CUInt num_attributes;
+	CXIdxEntityKind kind;
+	CXIdxEntityCXXTemplateKind template_kind;
+	CXIdxEntityLanguage lang;
+	ZString name;
+	ZString usr;
+	CXCursor cursor;
+	CXIdxAttrInfo** attributes;
+	CUInt num_attributes;
 }
+
 
 struct CXIdxContainerInfo {
-  CXCursor cursor;
+	CXCursor cursor;
 }
+
 
 struct CXIdxIBOutletCollectionAttrInfo {
-  CXIdxAttrInfo* attr_info;
-  CXIdxEntityInfo* objc_class;
-  CXCursor class_cursor;
-  CXIdxLoc class_loc;
+	CXIdxAttrInfo* attr_info;
+	CXIdxEntityInfo* objc_class;
+	CXCursor class_cursor;
+	CXIdxLoc class_loc;
 }
+
 
 constdef CXIdxDeclInfoFlags : CInt {
-  IDX_DECL_FLAG_SKIPPED = 1
+	IDX_DECL_FLAG_SKIPPED = 1
 }
+
 
 struct CXIdxDeclInfo {
-  CXIdxEntityInfo* entity_info;
-  CXCursor cursor;
-  CXIdxLoc loc;
-  CXIdxContainerInfo* semantic_container;
-  CXIdxContainerInfo* lexical_container;
-  CInt is_redeclaration;
-  CInt is_definition;
-  CInt is_container;
-  CXIdxContainerInfo* decl_as_container;
-  CInt is_implicit;
-  CXIdxAttrInfo** attributes;
-  CUInt num_attributes;
-  CUInt flags;
+	CXIdxEntityInfo* entity_info;
+	CXCursor cursor;
+	CXIdxLoc loc;
+	CXIdxContainerInfo* semantic_container;
+	CXIdxContainerInfo* lexical_container;
+	CInt is_redeclaration;
+	CInt is_definition;
+	CInt is_container;
+	CXIdxContainerInfo* decl_as_container;
+	CInt is_implicit;
+	CXIdxAttrInfo** attributes;
+	CUInt num_attributes;
+	CUInt flags;
 }
+
 
 constdef CXIdxObjCContainerKind : CInt {
-  IDX_OBJ_C_CONTAINER_FORWARD_REF = 0,
-  IDX_OBJ_C_CONTAINER_INTERFACE = 1,
-  IDX_OBJ_C_CONTAINER_IMPLEMENTATION = 2
+	IDX_OBJ_C_CONTAINER_FORWARD_REF = 0,
+	IDX_OBJ_C_CONTAINER_INTERFACE = 1,
+	IDX_OBJ_C_CONTAINER_IMPLEMENTATION = 2
 }
+
 
 struct CXIdxObjCContainerDeclInfo {
-  CXIdxDeclInfo* decl_info;
-  CXIdxObjCContainerKind kind;
+	CXIdxDeclInfo* decl_info;
+	CXIdxObjCContainerKind kind;
 }
+
 
 struct CXIdxBaseClassInfo {
-  CXIdxEntityInfo* base;
-  CXCursor cursor;
-  CXIdxLoc loc;
+	CXIdxEntityInfo* base;
+	CXCursor cursor;
+	CXIdxLoc loc;
 }
+
 
 struct CXIdxObjCProtocolRefInfo {
-  CXIdxEntityInfo* protocol;
-  CXCursor cursor;
-  CXIdxLoc loc;
+	CXIdxEntityInfo* protocol;
+	CXCursor cursor;
+	CXIdxLoc loc;
 }
+
 
 struct CXIdxObjCProtocolRefListInfo {
-  CXIdxObjCProtocolRefInfo** protocols;
-  CUInt num_protocols;
+	CXIdxObjCProtocolRefInfo** protocols;
+	CUInt num_protocols;
 }
+
 
 struct CXIdxObjCInterfaceDeclInfo {
-  CXIdxObjCContainerDeclInfo* container_info;
-  CXIdxBaseClassInfo* super_info;
-  CXIdxObjCProtocolRefListInfo* protocols;
+	CXIdxObjCContainerDeclInfo* container_info;
+	CXIdxBaseClassInfo* super_info;
+	CXIdxObjCProtocolRefListInfo* protocols;
 }
+
 
 struct CXIdxObjCCategoryDeclInfo {
-  CXIdxObjCContainerDeclInfo* container_info;
-  CXIdxEntityInfo* objc_class;
-  CXCursor class_cursor;
-  CXIdxLoc class_loc;
-  CXIdxObjCProtocolRefListInfo* protocols;
+	CXIdxObjCContainerDeclInfo* container_info;
+	CXIdxEntityInfo* objc_class;
+	CXCursor class_cursor;
+	CXIdxLoc class_loc;
+	CXIdxObjCProtocolRefListInfo* protocols;
 }
+
 
 struct CXIdxObjCPropertyDeclInfo {
-  CXIdxDeclInfo* decl_info;
-  CXIdxEntityInfo* getter;
-  CXIdxEntityInfo* setter;
+	CXIdxDeclInfo* decl_info;
+	CXIdxEntityInfo* getter;
+	CXIdxEntityInfo* setter;
 }
+
 
 struct CXIdxCXXClassDeclInfo {
-  CXIdxDeclInfo* decl_info;
-  CXIdxBaseClassInfo** bases;
-  CUInt num_bases;
+	CXIdxDeclInfo* decl_info;
+	CXIdxBaseClassInfo** bases;
+	CUInt num_bases;
 }
 
+<*
+	Data for IndexerCallbacks#indexEntityReference.
+	This may be deprecated in a future version as this duplicates
+	the \c CXSymbolRole_Implicit bit in \c CXSymbolRole.
+*>
 constdef CXIdxEntityRefKind : CInt {
-  IDX_ENTITY_REF_DIRECT = 1,
-  IDX_ENTITY_REF_IMPLICIT = 2
+
+	<*
+		The entity is referenced directly in user's code.
+	*>
+	IDX_ENTITY_REF_DIRECT = 1,
+
+	<*
+		An implicit reference, e.g. a reference of an Objective-C method
+		via the dot syntax.
+	*>
+	IDX_ENTITY_REF_IMPLICIT = 2
 }
 
+<*
+	Roles that are attributed to symbol occurrences.
+	Internal: this currently mirrors low 9 bits of clang::index::SymbolRole with
+	higher bits zeroed. These high bits may be exposed in the future.
+*>
 constdef CXSymbolRole : CInt {
-  SYMBOL_ROLE_NONE = 0,
-  SYMBOL_ROLE_DECLARATION = 1,
-  SYMBOL_ROLE_DEFINITION = 2,
-  SYMBOL_ROLE_REFERENCE = 4,
-  SYMBOL_ROLE_READ = 8,
-  SYMBOL_ROLE_WRITE = 16,
-  SYMBOL_ROLE_CALL = 32,
-  SYMBOL_ROLE_DYNAMIC = 64,
-  SYMBOL_ROLE_ADDRESS_OF = 128,
-  SYMBOL_ROLE_IMPLICIT = 256
+	SYMBOL_ROLE_NONE = 0,
+	SYMBOL_ROLE_DECLARATION = 1,
+	SYMBOL_ROLE_DEFINITION = 2,
+	SYMBOL_ROLE_REFERENCE = 4,
+	SYMBOL_ROLE_READ = 8,
+	SYMBOL_ROLE_WRITE = 16,
+	SYMBOL_ROLE_CALL = 32,
+	SYMBOL_ROLE_DYNAMIC = 64,
+	SYMBOL_ROLE_ADDRESS_OF = 128,
+	SYMBOL_ROLE_IMPLICIT = 256
 }
 
+<*
+	Data for IndexerCallbacks#indexEntityReference.
+*>
 struct CXIdxEntityRefInfo {
-  CXIdxEntityRefKind kind;
-  CXCursor cursor;
-  CXIdxLoc loc;
-  CXIdxEntityInfo* referenced_entity;
-  CXIdxEntityInfo* parent_entity;
-  CXIdxContainerInfo* container;
-  CXSymbolRole role;
+	CXIdxEntityRefKind kind;
+	CXCursor cursor;
+	CXIdxLoc loc;
+	CXIdxEntityInfo* referenced_entity;
+	CXIdxEntityInfo* parent_entity;
+	CXIdxContainerInfo* container;
+	CXSymbolRole role;
 }
 
 alias UnnamedPFN3 @private = fn CInt(
-  CXClientData client_data,
-  void* reserved);
+	CXClientData client_data,
+	void* reserved);
 
 alias UnnamedPFN4 @private = fn void(
-  CXClientData client_data,
-  CXDiagnosticSet,
-  void* reserved);
+	CXClientData client_data,
+	CXDiagnosticSet,
+	void* reserved);
 
 alias UnnamedPFN5 @private = fn CXIdxClientFile(
-  CXClientData client_data,
-  CXFile main_file,
-  void* reserved);
+	CXClientData client_data,
+	CXFile main_file,
+	void* reserved);
 
 alias UnnamedPFN6 @private = fn CXIdxClientFile(
-  CXClientData client_data,
-  CXIdxIncludedFileInfo*);
+	CXClientData client_data,
+	CXIdxIncludedFileInfo*);
 
 alias UnnamedPFN7 @private = fn CXIdxClientASTFile(
-  CXClientData client_data,
-  CXIdxImportedASTFileInfo*);
+	CXClientData client_data,
+	CXIdxImportedASTFileInfo*);
 
 alias UnnamedPFN8 @private = fn CXIdxClientContainer(
-  CXClientData client_data,
-  void* reserved);
+	CXClientData client_data,
+	void* reserved);
 
 alias UnnamedPFN9 @private = fn void(
-  CXClientData client_data,
-  CXIdxDeclInfo*);
+	CXClientData client_data,
+	CXIdxDeclInfo*);
 
 alias UnnamedPFN10 @private = fn void(
-  CXClientData client_data,
-  CXIdxEntityRefInfo*);
+	CXClientData client_data,
+	CXIdxEntityRefInfo*);
 
+<*
+	A group of callbacks used by #clang_indexSourceFile and
+	#clang_indexTranslationUnit.
+*>
 struct IndexerCallbacks {
-  UnnamedPFN3 abort_query;
-  UnnamedPFN4 diagnostic;
-  UnnamedPFN5 entered_main_file;
-  UnnamedPFN6 pp_included_file;
-  UnnamedPFN7 imported_ast_file;
-  UnnamedPFN8 started_translation_unit;
-  UnnamedPFN9 index_declaration;
-  UnnamedPFN10 index_entity_reference;
+	UnnamedPFN3 abort_query;
+	UnnamedPFN4 diagnostic;
+	UnnamedPFN5 entered_main_file;
+	UnnamedPFN6 pp_included_file;
+	UnnamedPFN7 imported_ast_file;
+	UnnamedPFN8 started_translation_unit;
+	UnnamedPFN9 index_declaration;
+	UnnamedPFN10 index_entity_reference;
 }
 
+
 extern fn CInt index_isEntityObjCContainerKind(
-  CXIdxEntityKind)
+	CXIdxEntityKind)
 @cname("clang_index_isEntityObjCContainerKind");
 
+
 extern fn CXIdxObjCContainerDeclInfo* index_getObjCContainerDeclInfo(
-  CXIdxDeclInfo*)
+	CXIdxDeclInfo*)
 @cname("clang_index_getObjCContainerDeclInfo");
 
+
 extern fn CXIdxObjCInterfaceDeclInfo* index_getObjCInterfaceDeclInfo(
-  CXIdxDeclInfo*)
+	CXIdxDeclInfo*)
 @cname("clang_index_getObjCInterfaceDeclInfo");
 
+
 extern fn CXIdxObjCCategoryDeclInfo* index_getObjCCategoryDeclInfo(
-  CXIdxDeclInfo*)
+	CXIdxDeclInfo*)
 @cname("clang_index_getObjCCategoryDeclInfo");
 
+
 extern fn CXIdxObjCProtocolRefListInfo* index_getObjCProtocolRefListInfo(
-  CXIdxDeclInfo*)
+	CXIdxDeclInfo*)
 @cname("clang_index_getObjCProtocolRefListInfo");
 
+
 extern fn CXIdxObjCPropertyDeclInfo* index_getObjCPropertyDeclInfo(
-  CXIdxDeclInfo*)
+	CXIdxDeclInfo*)
 @cname("clang_index_getObjCPropertyDeclInfo");
 
+
 extern fn CXIdxIBOutletCollectionAttrInfo* index_getIBOutletCollectionAttrInfo(
-  CXIdxAttrInfo*)
+	CXIdxAttrInfo*)
 @cname("clang_index_getIBOutletCollectionAttrInfo");
 
+
 extern fn CXIdxCXXClassDeclInfo* index_getCXXClassDeclInfo(
-  CXIdxDeclInfo*)
+	CXIdxDeclInfo*)
 @cname("clang_index_getCXXClassDeclInfo");
 
+<*
+	For retrieving a custom CXIdxClientContainer attached to a
+	container.
+*>
 extern fn CXIdxClientContainer index_getClientContainer(
-  CXIdxContainerInfo*)
+	CXIdxContainerInfo*)
 @cname("clang_index_getClientContainer");
 
+<*
+	For setting a custom CXIdxClientContainer attached to a
+	container.
+*>
 extern fn void index_setClientContainer(
-  CXIdxContainerInfo*,
-  CXIdxClientContainer)
+	CXIdxContainerInfo*,
+	CXIdxClientContainer)
 @cname("clang_index_setClientContainer");
 
+<*
+	For retrieving a custom CXIdxClientEntity attached to an entity.
+*>
 extern fn CXIdxClientEntity index_getClientEntity(
-  CXIdxEntityInfo*)
+	CXIdxEntityInfo*)
 @cname("clang_index_getClientEntity");
 
+<*
+	For setting a custom CXIdxClientEntity attached to an entity.
+*>
 extern fn void index_setClientEntity(
-  CXIdxEntityInfo*,
-  CXIdxClientEntity)
+	CXIdxEntityInfo*,
+	CXIdxClientEntity)
 @cname("clang_index_setClientEntity");
 
 alias CXIndexAction = void*;
 
+<*
+	An indexing action/session, to be applied to one or multiple
+	translation units.
+	\param CIdx The index object with which the index action will be associated.
+*>
 extern fn CXIndexAction indexAction_create(
-  CXIndex c_idx)
+	CXIndex c_idx)
 @cname("clang_IndexAction_create");
 
+<*
+	Destroy the given index action.
+	The index action must not be destroyed until all of the translation units
+	created within that index action have been destroyed.
+*>
 extern fn void indexAction_dispose(
-  CXIndexAction)
+	CXIndexAction)
 @cname("clang_IndexAction_dispose");
 
+
 constdef CXIndexOptFlags : CInt {
-  INDEX_OPT_NONE = 0,
-  INDEX_OPT_SUPPRESS_REDUNDANT_REFS = 1,
-  INDEX_OPT_INDEX_FUNCTION_LOCAL_SYMBOLS = 2,
-  INDEX_OPT_INDEX_IMPLICIT_TEMPLATE_INSTANTIATIONS = 4,
-  INDEX_OPT_SUPPRESS_WARNINGS = 8,
-  INDEX_OPT_SKIP_PARSED_BODIES_IN_SESSION = 16
+
+	<*
+		Used to indicate that no special indexing options are needed.
+	*>
+	INDEX_OPT_NONE = 0,
+
+	<*
+		Used to indicate that IndexerCallbacks#indexEntityReference should
+		be invoked for only one reference of an entity per source file that does
+		not also include a declaration/definition of the entity.
+	*>
+	INDEX_OPT_SUPPRESS_REDUNDANT_REFS = 1,
+
+	<*
+		Function-local symbols should be indexed. If this is not set
+		function-local symbols will be ignored.
+	*>
+	INDEX_OPT_INDEX_FUNCTION_LOCAL_SYMBOLS = 2,
+
+	<*
+		Implicit function/class template instantiations should be indexed.
+		If this is not set, implicit instantiations will be ignored.
+	*>
+	INDEX_OPT_INDEX_IMPLICIT_TEMPLATE_INSTANTIATIONS = 4,
+
+	<*
+		Suppress all compiler warnings when parsing for indexing.
+	*>
+	INDEX_OPT_SUPPRESS_WARNINGS = 8,
+
+	<*
+		Skip a function/method body that was already parsed during an
+		indexing session associated with a \c CXIndexAction object.
+		Bodies in system headers are always skipped.
+	*>
+	INDEX_OPT_SKIP_PARSED_BODIES_IN_SESSION = 16
 }
 
+<*
+	Index the given source file and the translation unit corresponding
+	to that file via callbacks implemented through #IndexerCallbacks.
+	\param client_data pointer data supplied by the client, which will
+	be passed to the invoked callbacks.
+	\param index_callbacks Pointer to indexing callbacks that the client
+	implements.
+	\param index_callbacks_size Size of #IndexerCallbacks structure that gets
+	passed in index_callbacks.
+	\param index_options A bitmask of options that affects how indexing is
+	performed. This should be a bitwise OR of the CXIndexOpt_XXX flags.
+	\param[out] out_TU pointer to store a \c CXTranslationUnit that can be
+	reused after indexing is finished. Set to \c NULL if you do not require it.
+	\returns 0 on success or if there were errors from which the compiler could
+	recover.  If there is a failure from which there is no recovery, returns
+	a non-zero \c CXErrorCode.
+	The rest of the parameters are the same as #clang_parseTranslationUnit.
+*>
 extern fn CInt indexSourceFile(
-  CXIndexAction,
-  CXClientData client_data,
-  IndexerCallbacks* index_callbacks,
-  CUInt index_callbacks_size,
-  CUInt index_options,
-  ZString source_filename,
-  CChar** command_line_args,
-  CInt num_command_line_args,
-  CXUnsavedFile* unsaved_files,
-  CUInt num_unsaved_files,
-  CXTranslationUnit* out_tu,
-  CUInt tu_options)
+	CXIndexAction,
+	CXClientData client_data,
+	IndexerCallbacks* index_callbacks,
+	CUInt index_callbacks_size,
+	CUInt index_options,
+	ZString source_filename,
+	ZString* command_line_args,
+	CInt num_command_line_args,
+	CXUnsavedFile* unsaved_files,
+	CUInt num_unsaved_files,
+	CXTranslationUnit* out_tu,
+	CUInt tu_options)
 @cname("clang_indexSourceFile");
 
+<*
+	Same as clang_indexSourceFile but requires a full command line
+	for \c command_line_args including argv[0]. This is useful if the standard
+	library paths are relative to the binary.
+*>
 extern fn CInt indexSourceFileFullArgv(
-  CXIndexAction,
-  CXClientData client_data,
-  IndexerCallbacks* index_callbacks,
-  CUInt index_callbacks_size,
-  CUInt index_options,
-  ZString source_filename,
-  CChar** command_line_args,
-  CInt num_command_line_args,
-  CXUnsavedFile* unsaved_files,
-  CUInt num_unsaved_files,
-  CXTranslationUnit* out_tu,
-  CUInt tu_options)
+	CXIndexAction,
+	CXClientData client_data,
+	IndexerCallbacks* index_callbacks,
+	CUInt index_callbacks_size,
+	CUInt index_options,
+	ZString source_filename,
+	ZString* command_line_args,
+	CInt num_command_line_args,
+	CXUnsavedFile* unsaved_files,
+	CUInt num_unsaved_files,
+	CXTranslationUnit* out_tu,
+	CUInt tu_options)
 @cname("clang_indexSourceFileFullArgv");
 
+<*
+	Index the given translation unit via callbacks implemented through
+	#IndexerCallbacks.
+	The order of callback invocations is not guaranteed to be the same as
+	when indexing a source file. The high level order will be:
+	-Preprocessor callbacks invocations
+	-Declaration/reference callbacks invocations
+	-Diagnostic callback invocations
+	The parameters are the same as #clang_indexSourceFile.
+	\returns If there is a failure from which there is no recovery, returns
+	non-zero, otherwise returns 0.
+*>
 extern fn CInt indexTranslationUnit(
-  CXIndexAction,
-  CXClientData client_data,
-  IndexerCallbacks* index_callbacks,
-  CUInt index_callbacks_size,
-  CUInt index_options,
-  CXTranslationUnit)
+	CXIndexAction,
+	CXClientData client_data,
+	IndexerCallbacks* index_callbacks,
+	CUInt index_callbacks_size,
+	CUInt index_options,
+	CXTranslationUnit)
 @cname("clang_indexTranslationUnit");
 
+<*
+	Retrieve the CXIdxFile, file, line, column, and offset represented by
+	the given CXIdxLoc.
+	If the location refers into a macro expansion, retrieves the
+	location of the macro expansion and if it refers into a macro argument
+	retrieves the location of the argument.
+*>
 extern fn void indexLoc_getFileLocation(
-  CXIdxLoc loc,
-  CXIdxClientFile* index_file,
-  CXFile* file,
-  CUInt* line,
-  CUInt* column,
-  CUInt* offset)
+	CXIdxLoc loc,
+	CXIdxClientFile* index_file,
+	CXFile* file,
+	CUInt* line,
+	CUInt* column,
+	CUInt* offset)
 @cname("clang_indexLoc_getFileLocation");
 
+<*
+	Retrieve the CXSourceLocation represented by the given CXIdxLoc.
+*>
 extern fn CXSourceLocation indexLoc_getCXSourceLocation(
-  CXIdxLoc loc)
+	CXIdxLoc loc)
 @cname("clang_indexLoc_getCXSourceLocation");
 
 alias CXFieldVisitor = fn CXVisitorResult(
-  CXCursor c,
-  CXClientData client_data);
+	CXCursor c,
+	CXClientData client_data);
 
+<*
+	Visit the fields of a particular type.
+	This function visits all the direct fields of the given cursor,
+	invoking the given \p visitor function with the cursors of each
+	visited field. The traversal may be ended prematurely, if
+	the visitor returns \c CXFieldVisit_Break.
+	\param T the record type whose field may be visited.
+	\param visitor the visitor function that will be invoked for each
+	field of \p T.
+	\param client_data pointer data supplied by the client, which will
+	be passed to the visitor each time it is invoked.
+	\returns a non-zero value if the traversal was terminated
+	prematurely by the visitor returning \c CXFieldVisit_Break.
+*>
 extern fn CUInt type_visitFields(
-  CXType t,
-  CXFieldVisitor visitor,
-  CXClientData client_data)
+	CXType t,
+	CXFieldVisitor visitor,
+	CXClientData client_data)
 @cname("clang_Type_visitFields");
 
+<*
+	Visit the base classes of a type.
+	This function visits all the direct base classes of a the given cursor,
+	invoking the given \p visitor function with the cursors of each
+	visited base. The traversal may be ended prematurely, if
+	the visitor returns \c CXFieldVisit_Break.
+	\param T the record type whose field may be visited.
+	\param visitor the visitor function that will be invoked for each
+	field of \p T.
+	\param client_data pointer data supplied by the client, which will
+	be passed to the visitor each time it is invoked.
+	\returns a non-zero value if the traversal was terminated
+	prematurely by the visitor returning \c CXFieldVisit_Break.
+*>
 extern fn CUInt visitCXXBaseClasses(
-  CXType t,
-  CXFieldVisitor visitor,
-  CXClientData client_data)
+	CXType t,
+	CXFieldVisitor visitor,
+	CXClientData client_data)
 @cname("clang_visitCXXBaseClasses");
 
+<*
+	Visit the class methods of a type.
+	This function visits all the methods of the given cursor,
+	invoking the given \p visitor function with the cursors of each
+	visited method. The traversal may be ended prematurely, if
+	the visitor returns \c CXFieldVisit_Break.
+	\param T The record type whose field may be visited.
+	\param visitor The visitor function that will be invoked for each
+	field of \p T.
+	\param client_data Pointer data supplied by the client, which will
+	be passed to the visitor each time it is invoked.
+	\returns A non-zero value if the traversal was terminated
+	prematurely by the visitor returning \c CXFieldVisit_Break.
+*>
 extern fn CUInt visitCXXMethods(
-  CXType t,
-  CXFieldVisitor visitor,
-  CXClientData client_data)
+	CXType t,
+	CXFieldVisitor visitor,
+	CXClientData client_data)
 @cname("clang_visitCXXMethods");
 
+<*
+	Describes the kind of binary operators.
+*>
 constdef CXBinaryOperatorKind : CInt {
-  BINARY_OPERATOR_INVALID = 0,
-  BINARY_OPERATOR_PTR_MEM_D = 1,
-  BINARY_OPERATOR_PTR_MEM_I = 2,
-  BINARY_OPERATOR_MUL = 3,
-  BINARY_OPERATOR_DIV = 4,
-  BINARY_OPERATOR_REM = 5,
-  BINARY_OPERATOR_ADD = 6,
-  BINARY_OPERATOR_SUB = 7,
-  BINARY_OPERATOR_SHL = 8,
-  BINARY_OPERATOR_SHR = 9,
-  BINARY_OPERATOR_CMP = 10,
-  BINARY_OPERATOR_LT = 11,
-  BINARY_OPERATOR_GT = 12,
-  BINARY_OPERATOR_LE = 13,
-  BINARY_OPERATOR_GE = 14,
-  BINARY_OPERATOR_EQ = 15,
-  BINARY_OPERATOR_NE = 16,
-  BINARY_OPERATOR_AND = 17,
-  BINARY_OPERATOR_XOR = 18,
-  BINARY_OPERATOR_OR = 19,
-  BINARY_OPERATOR_L_AND = 20,
-  BINARY_OPERATOR_L_OR = 21,
-  BINARY_OPERATOR_ASSIGN = 22,
-  BINARY_OPERATOR_MUL_ASSIGN = 23,
-  BINARY_OPERATOR_DIV_ASSIGN = 24,
-  BINARY_OPERATOR_REM_ASSIGN = 25,
-  BINARY_OPERATOR_ADD_ASSIGN = 26,
-  BINARY_OPERATOR_SUB_ASSIGN = 27,
-  BINARY_OPERATOR_SHL_ASSIGN = 28,
-  BINARY_OPERATOR_SHR_ASSIGN = 29,
-  BINARY_OPERATOR_AND_ASSIGN = 30,
-  BINARY_OPERATOR_XOR_ASSIGN = 31,
-  BINARY_OPERATOR_OR_ASSIGN = 32,
-  BINARY_OPERATOR_COMMA = 33,
-  BINARY_OPERATOR_LAST = 33
+
+	<*
+		This value describes cursors which are not binary operators. *
+	*>
+	BINARY_OPERATOR_INVALID = 0,
+
+	<*
+		C++ Pointer - to - member operator. *
+	*>
+	BINARY_OPERATOR_PTR_MEM_D = 1,
+
+	<*
+		C++ Pointer - to - member operator. *
+	*>
+	BINARY_OPERATOR_PTR_MEM_I = 2,
+
+	<*
+		Multiplication operator. *
+	*>
+	BINARY_OPERATOR_MUL = 3,
+
+	<*
+		Division operator. *
+	*>
+	BINARY_OPERATOR_DIV = 4,
+
+	<*
+		Remainder operator. *
+	*>
+	BINARY_OPERATOR_REM = 5,
+
+	<*
+		Addition operator. *
+	*>
+	BINARY_OPERATOR_ADD = 6,
+
+	<*
+		Subtraction operator. *
+	*>
+	BINARY_OPERATOR_SUB = 7,
+
+	<*
+		Bitwise shift left operator. *
+	*>
+	BINARY_OPERATOR_SHL = 8,
+
+	<*
+		Bitwise shift right operator. *
+	*>
+	BINARY_OPERATOR_SHR = 9,
+
+	<*
+		C++ three-way comparison (spaceship) operator. *
+	*>
+	BINARY_OPERATOR_CMP = 10,
+
+	<*
+		Less than operator. *
+	*>
+	BINARY_OPERATOR_LT = 11,
+
+	<*
+		Greater than operator. *
+	*>
+	BINARY_OPERATOR_GT = 12,
+
+	<*
+		Less or equal operator. *
+	*>
+	BINARY_OPERATOR_LE = 13,
+
+	<*
+		Greater or equal operator. *
+	*>
+	BINARY_OPERATOR_GE = 14,
+
+	<*
+		Equal operator. *
+	*>
+	BINARY_OPERATOR_EQ = 15,
+
+	<*
+		Not equal operator. *
+	*>
+	BINARY_OPERATOR_NE = 16,
+
+	<*
+		Bitwise AND operator. *
+	*>
+	BINARY_OPERATOR_AND = 17,
+
+	<*
+		Bitwise XOR operator. *
+	*>
+	BINARY_OPERATOR_XOR = 18,
+
+	<*
+		Bitwise OR operator. *
+	*>
+	BINARY_OPERATOR_OR = 19,
+
+	<*
+		Logical AND operator. *
+	*>
+	BINARY_OPERATOR_L_AND = 20,
+
+	<*
+		Logical OR operator. *
+	*>
+	BINARY_OPERATOR_L_OR = 21,
+
+	<*
+		Assignment operator. *
+	*>
+	BINARY_OPERATOR_ASSIGN = 22,
+
+	<*
+		Multiplication assignment operator. *
+	*>
+	BINARY_OPERATOR_MUL_ASSIGN = 23,
+
+	<*
+		Division assignment operator. *
+	*>
+	BINARY_OPERATOR_DIV_ASSIGN = 24,
+
+	<*
+		Remainder assignment operator. *
+	*>
+	BINARY_OPERATOR_REM_ASSIGN = 25,
+
+	<*
+		Addition assignment operator. *
+	*>
+	BINARY_OPERATOR_ADD_ASSIGN = 26,
+
+	<*
+		Subtraction assignment operator. *
+	*>
+	BINARY_OPERATOR_SUB_ASSIGN = 27,
+
+	<*
+		Bitwise shift left assignment operator. *
+	*>
+	BINARY_OPERATOR_SHL_ASSIGN = 28,
+
+	<*
+		Bitwise shift right assignment operator. *
+	*>
+	BINARY_OPERATOR_SHR_ASSIGN = 29,
+
+	<*
+		Bitwise AND assignment operator. *
+	*>
+	BINARY_OPERATOR_AND_ASSIGN = 30,
+
+	<*
+		Bitwise XOR assignment operator. *
+	*>
+	BINARY_OPERATOR_XOR_ASSIGN = 31,
+
+	<*
+		Bitwise OR assignment operator. *
+	*>
+	BINARY_OPERATOR_OR_ASSIGN = 32,
+
+	<*
+		Comma operator. *
+	*>
+	BINARY_OPERATOR_COMMA = 33,
+
+	<*
+		Comma operator. *
+	*>
+	BINARY_OPERATOR_LAST = 33
 }
 
+<*
+	Retrieve the spelling of a given CXBinaryOperatorKind.
+*>
 extern fn CXString getBinaryOperatorKindSpelling(
-  CXBinaryOperatorKind kind)
+	CXBinaryOperatorKind kind)
 @cname("clang_getBinaryOperatorKindSpelling");
 
+<*
+	Retrieve the binary operator kind of this cursor.
+	If this cursor is not a binary operator then returns Invalid.
+*>
 extern fn CXBinaryOperatorKind getCursorBinaryOperatorKind(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorBinaryOperatorKind");
 
+<*
+	Describes the kind of unary operators.
+*>
 constdef CXUnaryOperatorKind : CInt {
-  UNARY_OPERATOR_INVALID = 0,
-  UNARY_OPERATOR_POST_INC = 1,
-  UNARY_OPERATOR_POST_DEC = 2,
-  UNARY_OPERATOR_PRE_INC = 3,
-  UNARY_OPERATOR_PRE_DEC = 4,
-  UNARY_OPERATOR_ADDR_OF = 5,
-  UNARY_OPERATOR_DEREF = 6,
-  UNARY_OPERATOR_PLUS = 7,
-  UNARY_OPERATOR_MINUS = 8,
-  UNARY_OPERATOR_NOT = 9,
-  UNARY_OPERATOR_L_NOT = 10,
-  UNARY_OPERATOR_REAL = 11,
-  UNARY_OPERATOR_IMAG = 12,
-  UNARY_OPERATOR_EXTENSION = 13,
-  UNARY_OPERATOR_COAWAIT = 14
+
+	<*
+		This value describes cursors which are not unary operators. *
+	*>
+	UNARY_OPERATOR_INVALID = 0,
+
+	<*
+		Postfix increment operator. *
+	*>
+	UNARY_OPERATOR_POST_INC = 1,
+
+	<*
+		Postfix decrement operator. *
+	*>
+	UNARY_OPERATOR_POST_DEC = 2,
+
+	<*
+		Prefix increment operator. *
+	*>
+	UNARY_OPERATOR_PRE_INC = 3,
+
+	<*
+		Prefix decrement operator. *
+	*>
+	UNARY_OPERATOR_PRE_DEC = 4,
+
+	<*
+		Address of operator. *
+	*>
+	UNARY_OPERATOR_ADDR_OF = 5,
+
+	<*
+		Dereference operator. *
+	*>
+	UNARY_OPERATOR_DEREF = 6,
+
+	<*
+		Plus operator. *
+	*>
+	UNARY_OPERATOR_PLUS = 7,
+
+	<*
+		Minus operator. *
+	*>
+	UNARY_OPERATOR_MINUS = 8,
+
+	<*
+		Not operator. *
+	*>
+	UNARY_OPERATOR_NOT = 9,
+
+	<*
+		LNot operator. *
+	*>
+	UNARY_OPERATOR_L_NOT = 10,
+
+	<*
+		"__real expr" operator. *
+	*>
+	UNARY_OPERATOR_REAL = 11,
+
+	<*
+		"__imag expr" operator. *
+	*>
+	UNARY_OPERATOR_IMAG = 12,
+
+	<*
+		__extension__ marker operator. *
+	*>
+	UNARY_OPERATOR_EXTENSION = 13,
+
+	<*
+		C++ co_await operator. *
+	*>
+	UNARY_OPERATOR_COAWAIT = 14
 }
 
+<*
+	Retrieve the spelling of a given CXUnaryOperatorKind.
+*>
 extern fn CXString getUnaryOperatorKindSpelling(
-  CXUnaryOperatorKind kind)
+	CXUnaryOperatorKind kind)
 @cname("clang_getUnaryOperatorKindSpelling");
 
+<*
+	Retrieve the unary operator kind of this cursor.
+	If this cursor is not a unary operator then returns Invalid.
+*>
 extern fn CXUnaryOperatorKind getCursorUnaryOperatorKind(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getCursorUnaryOperatorKind");
 
 alias CXRemapping = void*;
 
+
 extern fn CXRemapping getRemappings(
-  ZString)
+	ZString)
 @cname("clang_getRemappings");
 
+
 extern fn CXRemapping getRemappingsFromFileList(
-  CChar**,
-  CUInt)
+	ZString*,
+	CUInt)
 @cname("clang_getRemappingsFromFileList");
 
+
 extern fn CUInt remap_getNumFiles(
-  CXRemapping)
+	CXRemapping)
 @cname("clang_remap_getNumFiles");
 
+
 extern fn void remap_getFilenames(
-  CXRemapping,
-  CUInt,
-  CXString*,
-  CXString*)
+	CXRemapping,
+	CUInt,
+	CXString*,
+	CXString*)
 @cname("clang_remap_getFilenames");
 
+
 extern fn void remap_dispose(
-  CXRemapping)
+	CXRemapping)
 @cname("clang_remap_dispose");
 
 alias CXCompilationDatabase = void*;
@@ -3074,307 +8969,757 @@ alias CXCompileCommands = void*;
 
 alias CXCompileCommand = void*;
 
+<*
+	Error codes for Compilation Database
+*>
 constdef CXCompilationDatabase_Error : CInt {
-  COMPILATION_DATABASE_NO_ERROR = 0,
-  COMPILATION_DATABASE_CAN_NOT_LOAD_DATABASE = 1
+	COMPILATION_DATABASE_NO_ERROR = 0,
+	COMPILATION_DATABASE_CAN_NOT_LOAD_DATABASE = 1
 }
 
+<*
+	Creates a compilation database from the database found in directory
+	buildDir. For example, CMake can output a compile_commands.json which can
+	be used to build the database.
+	It must be freed by \c clang_CompilationDatabase_dispose.
+*>
 extern fn CXCompilationDatabase compilationDatabase_fromDirectory(
-  ZString build_dir,
-  CXCompilationDatabase_Error* error_code)
+	ZString build_dir,
+	CXCompilationDatabase_Error* error_code)
 @cname("clang_CompilationDatabase_fromDirectory");
 
+<*
+	Free the given compilation database
+*>
 extern fn void compilationDatabase_dispose(
-  CXCompilationDatabase)
+	CXCompilationDatabase)
 @cname("clang_CompilationDatabase_dispose");
 
+<*
+	Find the compile commands used for a file. The compile commands
+	must be freed by \c clang_CompileCommands_dispose.
+*>
 extern fn CXCompileCommands compilationDatabase_getCompileCommands(
-  CXCompilationDatabase,
-  ZString complete_file_name)
+	CXCompilationDatabase,
+	ZString complete_file_name)
 @cname("clang_CompilationDatabase_getCompileCommands");
 
+<*
+	Get all the compile commands in the given compilation database.
+*>
 extern fn CXCompileCommands compilationDatabase_getAllCompileCommands(
-  CXCompilationDatabase)
+	CXCompilationDatabase)
 @cname("clang_CompilationDatabase_getAllCompileCommands");
 
+<*
+	Free the given CompileCommands
+*>
 extern fn void compileCommands_dispose(
-  CXCompileCommands)
+	CXCompileCommands)
 @cname("clang_CompileCommands_dispose");
 
+<*
+	Get the number of CompileCommand we have for a file
+*>
 extern fn CUInt compileCommands_getSize(
-  CXCompileCommands)
+	CXCompileCommands)
 @cname("clang_CompileCommands_getSize");
 
+<*
+	Get the I'th CompileCommand for a file
+	Note : 0 <= i < clang_CompileCommands_getSize(CXCompileCommands)
+*>
 extern fn CXCompileCommand compileCommands_getCommand(
-  CXCompileCommands,
-  CUInt i)
+	CXCompileCommands,
+	CUInt i)
 @cname("clang_CompileCommands_getCommand");
 
+<*
+	Get the working directory where the CompileCommand was executed from
+*>
 extern fn CXString compileCommand_getDirectory(
-  CXCompileCommand)
+	CXCompileCommand)
 @cname("clang_CompileCommand_getDirectory");
 
+<*
+	Get the filename associated with the CompileCommand.
+*>
 extern fn CXString compileCommand_getFilename(
-  CXCompileCommand)
+	CXCompileCommand)
 @cname("clang_CompileCommand_getFilename");
 
+<*
+	Get the number of arguments in the compiler invocation.
+*>
 extern fn CUInt compileCommand_getNumArgs(
-  CXCompileCommand)
+	CXCompileCommand)
 @cname("clang_CompileCommand_getNumArgs");
 
+<*
+	Get the I'th argument value in the compiler invocations
+	Invariant :
+	- argument 0 is the compiler executable
+*>
 extern fn CXString compileCommand_getArg(
-  CXCompileCommand,
-  CUInt i)
+	CXCompileCommand,
+	CUInt i)
 @cname("clang_CompileCommand_getArg");
 
+<*
+	Get the number of source mappings for the compiler invocation.
+*>
 extern fn CUInt compileCommand_getNumMappedSources(
-  CXCompileCommand)
+	CXCompileCommand)
 @cname("clang_CompileCommand_getNumMappedSources");
 
+<*
+	Get the I'th mapped source path for the compiler invocation.
+*>
 extern fn CXString compileCommand_getMappedSourcePath(
-  CXCompileCommand,
-  CUInt i)
+	CXCompileCommand,
+	CUInt i)
 @cname("clang_CompileCommand_getMappedSourcePath");
 
+<*
+	Get the I'th mapped source content for the compiler invocation.
+*>
 extern fn CXString compileCommand_getMappedSourceContent(
-  CXCompileCommand,
-  CUInt i)
+	CXCompileCommand,
+	CUInt i)
 @cname("clang_CompileCommand_getMappedSourceContent");
 
+<*
+	A parsed comment.
+*>
 struct CXComment {
-  void* ast_node;
-  CXTranslationUnit translation_unit;
+	void* ast_node;
+	CXTranslationUnit translation_unit;
 }
 
+<*
+	Given a cursor that represents a documentable entity (e.g.,
+	declaration), return the associated parsed comment as a
+	\c CXComment_FullComment AST node.
+*>
 extern fn CXComment cursor_getParsedComment(
-  CXCursor c)
+	CXCursor c)
 @cname("clang_Cursor_getParsedComment");
 
+<*
+	Describes the type of the comment AST node (\c CXComment).  A comment
+	node can be considered block content (e. g., paragraph), inline content
+	(plain text) or neither (the root AST node).
+*>
 constdef CXCommentKind : CInt {
-  COMMENT_NULL = 0,
-  COMMENT_TEXT = 1,
-  COMMENT_INLINE_COMMAND = 2,
-  COMMENT_HTML_START_TAG = 3,
-  COMMENT_HTML_END_TAG = 4,
-  COMMENT_PARAGRAPH = 5,
-  COMMENT_BLOCK_COMMAND = 6,
-  COMMENT_PARAM_COMMAND = 7,
-  COMMENT_T_PARAM_COMMAND = 8,
-  COMMENT_VERBATIM_BLOCK_COMMAND = 9,
-  COMMENT_VERBATIM_BLOCK_LINE = 10,
-  COMMENT_VERBATIM_LINE = 11,
-  COMMENT_FULL_COMMENT = 12
+
+	<*
+		Null comment.  No AST node is constructed at the requested location
+		because there is no text or a syntax error.
+	*>
+	COMMENT_NULL = 0,
+
+	<*
+		Plain text.  Inline content.
+	*>
+	COMMENT_TEXT = 1,
+
+	<*
+		A command with word-like arguments that is considered inline content.
+		For example: \\c command.
+	*>
+	COMMENT_INLINE_COMMAND = 2,
+
+	<*
+		HTML start tag with attributes (name-value pairs).  Considered
+		inline content.
+		For example:
+		\verbatim
+		<br> <br /> <a href="http://example.org/">
+		\endverbatim
+	*>
+	COMMENT_HTML_START_TAG = 3,
+
+	<*
+		HTML end tag.  Considered inline content.
+		For example:
+		\verbatim
+		</a>
+		\endverbatim
+	*>
+	COMMENT_HTML_END_TAG = 4,
+
+	<*
+		A paragraph, contains inline comment.  The paragraph itself is
+		block content.
+	*>
+	COMMENT_PARAGRAPH = 5,
+
+	<*
+		A command that has zero or more word-like arguments (number of
+		word-like arguments depends on command name) and a paragraph as an
+		argument.  Block command is block content.
+		Paragraph argument is also a child of the block command.
+		For example: \has 0 word-like arguments and a paragraph argument.
+		AST nodes of special kinds that parser knows about (e. g., \\param
+		command) have their own node kinds.
+	*>
+	COMMENT_BLOCK_COMMAND = 6,
+
+	<*
+		A \\param or \\arg command that describes the function parameter
+		(name, passing direction, description).
+		For example: \\param [in] ParamName description.
+	*>
+	COMMENT_PARAM_COMMAND = 7,
+
+	<*
+		A \\tparam command that describes a template parameter (name and
+		description).
+		For example: \\tparam T description.
+	*>
+	COMMENT_T_PARAM_COMMAND = 8,
+
+	<*
+		A verbatim block command (e. g., preformatted code).  Verbatim
+		block has an opening and a closing command and contains multiple lines of
+		text (\c CXComment_VerbatimBlockLine child nodes).
+		For example:
+		\\verbatim
+		aaa
+		\\endverbatim
+	*>
+	COMMENT_VERBATIM_BLOCK_COMMAND = 9,
+
+	<*
+		A line of text that is contained within a
+		CXComment_VerbatimBlockCommand node.
+	*>
+	COMMENT_VERBATIM_BLOCK_LINE = 10,
+
+	<*
+		A verbatim line command.  Verbatim line has an opening command,
+		a single line of text (up to the newline after the opening command) and
+		has no closing command.
+	*>
+	COMMENT_VERBATIM_LINE = 11,
+
+	<*
+		A full comment attached to a declaration, contains block content.
+	*>
+	COMMENT_FULL_COMMENT = 12
 }
 
+<*
+	The most appropriate rendering mode for an inline command, chosen on
+	command semantics in Doxygen.
+*>
 constdef CXCommentInlineCommandRenderKind : CInt {
-  COMMENT_INLINE_COMMAND_RENDER_KIND_NORMAL = 0,
-  COMMENT_INLINE_COMMAND_RENDER_KIND_BOLD = 1,
-  COMMENT_INLINE_COMMAND_RENDER_KIND_MONOSPACED = 2,
-  COMMENT_INLINE_COMMAND_RENDER_KIND_EMPHASIZED = 3,
-  COMMENT_INLINE_COMMAND_RENDER_KIND_ANCHOR = 4
+
+	<*
+		Command argument should be rendered in a normal font.
+	*>
+	COMMENT_INLINE_COMMAND_RENDER_KIND_NORMAL = 0,
+
+	<*
+		Command argument should be rendered in a bold font.
+	*>
+	COMMENT_INLINE_COMMAND_RENDER_KIND_BOLD = 1,
+
+	<*
+		Command argument should be rendered in a monospaced font.
+	*>
+	COMMENT_INLINE_COMMAND_RENDER_KIND_MONOSPACED = 2,
+
+	<*
+		Command argument should be rendered emphasized (typically italic
+		font).
+	*>
+	COMMENT_INLINE_COMMAND_RENDER_KIND_EMPHASIZED = 3,
+
+	<*
+		Command argument should not be rendered (since it only defines an anchor).
+	*>
+	COMMENT_INLINE_COMMAND_RENDER_KIND_ANCHOR = 4
 }
 
+<*
+	Describes parameter passing direction for \\param or \\arg command.
+*>
 constdef CXCommentParamPassDirection : CInt {
-  COMMENT_PARAM_PASS_DIRECTION_IN = 0,
-  COMMENT_PARAM_PASS_DIRECTION_OUT = 1,
-  COMMENT_PARAM_PASS_DIRECTION_IN_OUT = 2
+
+	<*
+		The parameter is an input parameter.
+	*>
+	COMMENT_PARAM_PASS_DIRECTION_IN = 0,
+
+	<*
+		The parameter is an output parameter.
+	*>
+	COMMENT_PARAM_PASS_DIRECTION_OUT = 1,
+
+	<*
+		The parameter is an input and output parameter.
+	*>
+	COMMENT_PARAM_PASS_DIRECTION_IN_OUT = 2
 }
 
+<*
+	\param Comment AST node of any kind.
+	\returns the type of the AST node.
+*>
 extern fn CXCommentKind comment_getKind(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_Comment_getKind");
 
+<*
+	\param Comment AST node of any kind.
+	\returns number of children of the AST node.
+*>
 extern fn CUInt comment_getNumChildren(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_Comment_getNumChildren");
 
+<*
+	\param Comment AST node of any kind.
+	\param ChildIdx child index (zero-based).
+	\returns the specified child of the AST node.
+*>
 extern fn CXComment comment_getChild(
-  CXComment comment,
-  CUInt child_idx)
+	CXComment comment,
+	CUInt child_idx)
 @cname("clang_Comment_getChild");
 
+<*
+	A \c CXComment_Paragraph node is considered whitespace if it contains
+	only \c CXComment_Text nodes that are empty or whitespace.
+	Other AST nodes (except \c CXComment_Paragraph and \c CXComment_Text) are
+	never considered whitespace.
+	\returns non-zero if \c Comment is whitespace.
+*>
 extern fn CUInt comment_isWhitespace(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_Comment_isWhitespace");
 
+<*
+	\returns non-zero if \c Comment is inline content and has a newline
+	immediately following it in the comment text.  Newlines between paragraphs
+	do not count.
+*>
 extern fn CUInt inlineContentComment_hasTrailingNewline(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_InlineContentComment_hasTrailingNewline");
 
+<*
+	\param Comment a \c CXComment_Text AST node.
+	\returns text contained in the AST node.
+*>
 extern fn CXString textComment_getText(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_TextComment_getText");
 
+<*
+	\param Comment a \c CXComment_InlineCommand AST node.
+	\returns name of the inline command.
+*>
 extern fn CXString inlineCommandComment_getCommandName(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_InlineCommandComment_getCommandName");
 
+<*
+	\param Comment a \c CXComment_InlineCommand AST node.
+	\returns the most appropriate rendering mode, chosen on command
+	semantics in Doxygen.
+*>
 extern fn CXCommentInlineCommandRenderKind inlineCommandComment_getRenderKind(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_InlineCommandComment_getRenderKind");
 
+<*
+	\param Comment a \c CXComment_InlineCommand AST node.
+	\returns number of command arguments.
+*>
 extern fn CUInt inlineCommandComment_getNumArgs(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_InlineCommandComment_getNumArgs");
 
+<*
+	\param Comment a \c CXComment_InlineCommand AST node.
+	\param ArgIdx argument index (zero-based).
+	\returns text of the specified argument.
+*>
 extern fn CXString inlineCommandComment_getArgText(
-  CXComment comment,
-  CUInt arg_idx)
+	CXComment comment,
+	CUInt arg_idx)
 @cname("clang_InlineCommandComment_getArgText");
 
+<*
+	\param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
+	node.
+	\returns HTML tag name.
+*>
 extern fn CXString hTMLTagComment_getTagName(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_HTMLTagComment_getTagName");
 
+<*
+	\param Comment a \c CXComment_HTMLStartTag AST node.
+	\returns non-zero if tag is self-closing (for example, &lt;br /&gt;).
+*>
 extern fn CUInt hTMLStartTagComment_isSelfClosing(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_HTMLStartTagComment_isSelfClosing");
 
+<*
+	\param Comment a \c CXComment_HTMLStartTag AST node.
+	\returns number of attributes (name-value pairs) attached to the start tag.
+*>
 extern fn CUInt hTMLStartTag_getNumAttrs(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_HTMLStartTag_getNumAttrs");
 
+<*
+	\param Comment a \c CXComment_HTMLStartTag AST node.
+	\param AttrIdx attribute index (zero-based).
+	\returns name of the specified attribute.
+*>
 extern fn CXString hTMLStartTag_getAttrName(
-  CXComment comment,
-  CUInt attr_idx)
+	CXComment comment,
+	CUInt attr_idx)
 @cname("clang_HTMLStartTag_getAttrName");
 
+<*
+	\param Comment a \c CXComment_HTMLStartTag AST node.
+	\param AttrIdx attribute index (zero-based).
+	\returns value of the specified attribute.
+*>
 extern fn CXString hTMLStartTag_getAttrValue(
-  CXComment comment,
-  CUInt attr_idx)
+	CXComment comment,
+	CUInt attr_idx)
 @cname("clang_HTMLStartTag_getAttrValue");
 
+<*
+	\param Comment a \c CXComment_BlockCommand AST node.
+	\returns name of the block command.
+*>
 extern fn CXString blockCommandComment_getCommandName(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_BlockCommandComment_getCommandName");
 
+<*
+	\param Comment a \c CXComment_BlockCommand AST node.
+	\returns number of word-like arguments.
+*>
 extern fn CUInt blockCommandComment_getNumArgs(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_BlockCommandComment_getNumArgs");
 
+<*
+	\param Comment a \c CXComment_BlockCommand AST node.
+	\param ArgIdx argument index (zero-based).
+	\returns text of the specified word-like argument.
+*>
 extern fn CXString blockCommandComment_getArgText(
-  CXComment comment,
-  CUInt arg_idx)
+	CXComment comment,
+	CUInt arg_idx)
 @cname("clang_BlockCommandComment_getArgText");
 
+<*
+	\param Comment a \c CXComment_BlockCommand or
+	\c CXComment_VerbatimBlockCommand AST node.
+	\returns paragraph argument of the block command.
+*>
 extern fn CXComment blockCommandComment_getParagraph(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_BlockCommandComment_getParagraph");
 
+<*
+	\param Comment a \c CXComment_ParamCommand AST node.
+	\returns parameter name.
+*>
 extern fn CXString paramCommandComment_getParamName(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_ParamCommandComment_getParamName");
 
+<*
+	\param Comment a \c CXComment_ParamCommand AST node.
+	\returns non-zero if the parameter that this AST node represents was found
+	in the function prototype and \c clang_ParamCommandComment_getParamIndex
+	function will return a meaningful value.
+*>
 extern fn CUInt paramCommandComment_isParamIndexValid(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_ParamCommandComment_isParamIndexValid");
 
+<*
+	\param Comment a \c CXComment_ParamCommand AST node.
+	\returns zero-based parameter index in function prototype.
+*>
 extern fn CUInt paramCommandComment_getParamIndex(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_ParamCommandComment_getParamIndex");
 
+<*
+	\param Comment a \c CXComment_ParamCommand AST node.
+	\returns non-zero if parameter passing direction was specified explicitly in
+	the comment.
+*>
 extern fn CUInt paramCommandComment_isDirectionExplicit(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_ParamCommandComment_isDirectionExplicit");
 
+<*
+	\param Comment a \c CXComment_ParamCommand AST node.
+	\returns parameter passing direction.
+*>
 extern fn CXCommentParamPassDirection paramCommandComment_getDirection(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_ParamCommandComment_getDirection");
 
+<*
+	\param Comment a \c CXComment_TParamCommand AST node.
+	\returns template parameter name.
+*>
 extern fn CXString tParamCommandComment_getParamName(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_TParamCommandComment_getParamName");
 
+<*
+	\param Comment a \c CXComment_TParamCommand AST node.
+	\returns non-zero if the parameter that this AST node represents was found
+	in the template parameter list and
+	\c clang_TParamCommandComment_getDepth and
+	\c clang_TParamCommandComment_getIndex functions will return a meaningful
+	value.
+*>
 extern fn CUInt tParamCommandComment_isParamPositionValid(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_TParamCommandComment_isParamPositionValid");
 
+<*
+	\param Comment a \c CXComment_TParamCommand AST node.
+	\returns zero-based nesting depth of this parameter in the template parameter list.
+	For example,
+	\verbatim
+	template<typename C, template<typename T> class TT>
+	void test(TT<int> aaa);
+	\endverbatim
+	for C and TT nesting depth is 0,
+	for T nesting depth is 1.
+*>
 extern fn CUInt tParamCommandComment_getDepth(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_TParamCommandComment_getDepth");
 
+<*
+	\param Comment a \c CXComment_TParamCommand AST node.
+	\returns zero-based parameter index in the template parameter list at a
+	given nesting depth.
+	For example,
+	\verbatim
+	template<typename C, template<typename T> class TT>
+	void test(TT<int> aaa);
+	\endverbatim
+	for C and TT nesting depth is 0, so we can ask for index at depth 0:
+	at depth 0 C's index is 0, TT's index is 1.
+	For T nesting depth is 1, so we can ask for index at depth 0 and 1:
+	at depth 0 T's index is 1 (same as TT's),
+	at depth 1 T's index is 0.
+*>
 extern fn CUInt tParamCommandComment_getIndex(
-  CXComment comment,
-  CUInt depth)
+	CXComment comment,
+	CUInt depth)
 @cname("clang_TParamCommandComment_getIndex");
 
+<*
+	\param Comment a \c CXComment_VerbatimBlockLine AST node.
+	\returns text contained in the AST node.
+*>
 extern fn CXString verbatimBlockLineComment_getText(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_VerbatimBlockLineComment_getText");
 
+<*
+	\param Comment a \c CXComment_VerbatimLine AST node.
+	\returns text contained in the AST node.
+*>
 extern fn CXString verbatimLineComment_getText(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_VerbatimLineComment_getText");
 
+<*
+	Convert an HTML tag AST node to string.
+	\param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
+	node.
+	\returns string containing an HTML tag.
+*>
 extern fn CXString hTMLTagComment_getAsString(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_HTMLTagComment_getAsString");
 
+<*
+	Convert a given full parsed comment to an HTML fragment.
+	Specific details of HTML layout are subject to change.  Don't try to parse
+	this HTML back into an AST, use other APIs instead.
+	Currently the following CSS classes are used:
+	\li "para-brief" for \paragraph and equivalent commands;
+	\li "para-returns" for \\returns paragraph and equivalent commands;
+	\li "word-returns" for the "Returns" word in \\returns paragraph.
+	Function argument documentation is rendered as a \<dl\> list with arguments
+	sorted in function prototype order.  CSS classes used:
+	\li "param-name-index-NUMBER" for parameter name (\<dt\>);
+	\li "param-descr-index-NUMBER" for parameter description (\<dd\>);
+	\li "param-name-index-invalid" and "param-descr-index-invalid" are used if
+	parameter index is invalid.
+	Template parameter documentation is rendered as a \<dl\> list with
+	parameters sorted in template parameter list order.  CSS classes used:
+	\li "tparam-name-index-NUMBER" for parameter name (\<dt\>);
+	\li "tparam-descr-index-NUMBER" for parameter description (\<dd\>);
+	\li "tparam-name-index-other" and "tparam-descr-index-other" are used for
+	names inside template template parameters;
+	\li "tparam-name-index-invalid" and "tparam-descr-index-invalid" are used if
+	parameter position is invalid.
+	\param Comment a \c CXComment_FullComment AST node.
+	\returns string containing an HTML fragment.
+*>
 extern fn CXString fullComment_getAsHTML(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_FullComment_getAsHTML");
 
+<*
+	Convert a given full parsed comment to an XML document.
+	A Relax NG schema for the XML can be found in comment-xml-schema.rng file
+	inside clang source tree.
+	\param Comment a \c CXComment_FullComment AST node.
+	\returns string containing an XML document.
+*>
 extern fn CXString fullComment_getAsXML(
-  CXComment comment)
+	CXComment comment)
 @cname("clang_FullComment_getAsXML");
 
 alias CXAPISet = void*;
 
+<*
+	Traverses the translation unit to create a \c CXAPISet.
+	\param tu is the \c CXTranslationUnit to build the \c CXAPISet for.
+	\param out_api is a pointer to the output of this function. It is needs to be
+	disposed of by calling clang_disposeAPISet.
+	\returns Error code indicating success or failure of the APISet creation.
+*>
 extern fn CXErrorCode createAPISet(
-  CXTranslationUnit tu,
-  CXAPISet* out_api)
+	CXTranslationUnit tu,
+	CXAPISet* out_api)
 @cname("clang_createAPISet");
 
+<*
+	Dispose of an APISet.
+	The provided \c CXAPISet can not be used after this function is called.
+*>
 extern fn void disposeAPISet(
-  CXAPISet api)
+	CXAPISet api)
 @cname("clang_disposeAPISet");
 
+<*
+	Generate a single symbol symbol graph for the given USR. Returns a null
+	string if the associated symbol can not be found in the provided \c CXAPISet.
+	The output contains the symbol graph as well as some additional information
+	about related symbols.
+	\param usr is a string containing the USR of the symbol to generate the
+	symbol graph for.
+	\param api the \c CXAPISet to look for the symbol in.
+	\returns a string containing the serialized symbol graph representation for
+	the symbol being queried or a null string if it can not be found in the
+	APISet.
+*>
 extern fn CXString getSymbolGraphForUSR(
-  ZString usr,
-  CXAPISet api)
+	ZString usr,
+	CXAPISet api)
 @cname("clang_getSymbolGraphForUSR");
 
+<*
+	Generate a single symbol symbol graph for the declaration at the given
+	cursor. Returns a null string if the AST node for the cursor isn't a
+	declaration.
+	The output contains the symbol graph as well as some additional information
+	about related symbols.
+	\param cursor the declaration for which to generate the single symbol symbol
+	graph.
+	\returns a string containing the serialized symbol graph representation for
+	the symbol being queried or a null string if it can not be found in the
+	APISet.
+*>
 extern fn CXString getSymbolGraphForCursor(
-  CXCursor cursor)
+	CXCursor cursor)
 @cname("clang_getSymbolGraphForCursor");
 
+<*
+	Installs error handler that prints error message to stderr and calls abort().
+	Replaces currently installed error handler (if any).
+*>
 extern fn void install_aborting_llvm_fatal_error_handler()
 @cname("clang_install_aborting_llvm_fatal_error_handler");
 
+<*
+	Removes currently installed error handler (if any).
+	If no error handler is intalled, the default strategy is to print error
+	message to stderr and call exit(1).
+*>
 extern fn void uninstall_llvm_fatal_error_handler()
 @cname("clang_uninstall_llvm_fatal_error_handler");
 
 alias CXRewriter = void*;
 
+<*
+	Create CXRewriter.
+*>
 extern fn CXRewriter cXRewriter_create(
-  CXTranslationUnit tu)
+	CXTranslationUnit tu)
 @cname("clang_CXRewriter_create");
 
+<*
+	Insert the specified string at the specified location in the original buffer.
+*>
 extern fn void cXRewriter_insertTextBefore(
-  CXRewriter rew,
-  CXSourceLocation loc,
-  ZString insert)
+	CXRewriter rew,
+	CXSourceLocation loc,
+	ZString insert)
 @cname("clang_CXRewriter_insertTextBefore");
 
+<*
+	Replace the specified range of characters in the input with the specified
+	replacement.
+*>
 extern fn void cXRewriter_replaceText(
-  CXRewriter rew,
-  CXSourceRange to_be_replaced,
-  ZString replacement)
+	CXRewriter rew,
+	CXSourceRange to_be_replaced,
+	ZString replacement)
 @cname("clang_CXRewriter_replaceText");
 
+<*
+	Remove the specified range.
+*>
 extern fn void cXRewriter_removeText(
-  CXRewriter rew,
-  CXSourceRange to_be_removed)
+	CXRewriter rew,
+	CXSourceRange to_be_removed)
 @cname("clang_CXRewriter_removeText");
 
+<*
+	Save all changed files to disk.
+	Returns 1 if any files were not saved successfully, returns 0 otherwise.
+*>
 extern fn CInt cXRewriter_overwriteChangedFiles(
-  CXRewriter rew)
+	CXRewriter rew)
 @cname("clang_CXRewriter_overwriteChangedFiles");
 
+<*
+	Write out rewritten version of the main file to stdout.
+*>
 extern fn void cXRewriter_writeMainFileToStdOut(
-  CXRewriter rew)
+	CXRewriter rew)
 @cname("clang_CXRewriter_writeMainFileToStdOut");
 
+<*
+	Free the given CXRewriter.
+*>
 extern fn void cXRewriter_dispose(
-  CXRewriter rew)
+	CXRewriter rew)
 @cname("clang_CXRewriter_dispose");

--- a/bindgen.c3l/src/clang.c3i
+++ b/bindgen.c3l/src/clang.c3i
@@ -1,65 +1,15 @@
 
 module clang;
-import libc; // for Time_t
+import libc;
 
-/*-------------------------------*\
-|                                 |
-|       File CXErrorCode.h        |
-|                                 |
-\*-------------------------------*/
+constdef CXErrorCode : CInt {
+  ERROR_SUCCESS = 0,
+  ERROR_FAILURE = 1,
+  ERROR_CRASHED = 2,
+  ERROR_INVALID_ARGUMENTS = 3,
+  ERROR_AST_READ_ERROR = 4
+}
 
-/**
- * Error codes returned by libclang routines.
- *
- * Zero (\c CXError_Success) is the only error code indicating success.  Other
- * error codes, including not yet assigned non-zero values, indicate errors.
- */
-typedef CXErrorCode = inline CInt;
-
-/**
- * No error.
- */
-const CXErrorCode ERROR_SUCCESS = 0;
-
-/**
- * A generic error code, no further details are available.
- *
- * Errors of this kind can get their own specific error codes in future
- * libclang versions.
- */
-const CXErrorCode ERROR_FAILURE = 1;
-
-/**
- * libclang crashed while performing the requested operation.
- */
-const CXErrorCode ERROR_CRASHED = 2;
-
-/**
- * The function detected that the arguments violate the function
- * contract.
- */
-const CXErrorCode ERROR_INVALID_ARGUMENTS = 3;
-
-/**
- * An AST deserialization error has occurred.
- */
-const CXErrorCode ERROR_AST_READ_ERROR = 4;
-
-
-/*-------------------------------*\
-|                                 |
-|         File CXString.h         |
-|                                 |
-\*-------------------------------*/
-
-/**
- * A character string.
- *
- * The \c CXString type is used to return strings from the interface when
- * the ownership of that string might differ from one call to the next.
- * Use \c clang_getCString() to retrieve the string data and, once finished
- * with the string data, call \c clang_disposeString() to free the string.
- */
 struct CXString {
   void* data;
   CUInt private_flags;
@@ -70,8149 +20,2637 @@ struct CXStringSet {
   CUInt count;
 }
 
-/**
- * Retrieve the character data associated with the given string.
- */
-fn ZString getCString(
-  CXString string) 
-@extern("clang_getCString");
+extern fn ZString getCString(
+  CXString string)
+@cname("clang_getCString");
 
-/**
- * Free the given string.
- */
-fn void disposeString(
-  CXString string) 
-@extern("clang_disposeString");
+extern fn void disposeString(
+  CXString string)
+@cname("clang_disposeString");
 
-/**
- * Free the given string set.
- */
-fn void disposeStringSet(
-  CXStringSet* set) 
-@extern("clang_disposeStringSet");
+extern fn void disposeStringSet(
+  CXStringSet* set)
+@cname("clang_disposeStringSet");
 
+extern fn CULongLong getBuildSessionTimestamp()
+@cname("clang_getBuildSessionTimestamp");
 
-/*-------------------------------*\
-|                                 |
-|          File CXFile.h          |
-|                                 |
-\*-------------------------------*/
+alias CXVirtualFileOverlay = void*;
 
-/**
- * A particular source file that is part of a translation unit.
- */
-typedef CXFile = inline void*;
+extern fn CXVirtualFileOverlay virtualFileOverlay_create(
+  CUInt options)
+@cname("clang_VirtualFileOverlay_create");
 
-/**
- * Retrieve the complete file and path name of the given file.
- */
-fn CXString getFileName(
-  CXFile sfile) 
-@extern("clang_getFileName");
+extern fn CXErrorCode virtualFileOverlay_addFileMapping(
+  CXVirtualFileOverlay,
+  ZString virtual_path,
+  ZString real_path)
+@cname("clang_VirtualFileOverlay_addFileMapping");
 
-/**
- * Retrieve the last modification time of the given file.
- */
-fn Time_t getFileTime(
-  CXFile sfile) 
-@extern("clang_getFileTime");
+extern fn CXErrorCode virtualFileOverlay_setCaseSensitivity(
+  CXVirtualFileOverlay,
+  CInt case_sensitive)
+@cname("clang_VirtualFileOverlay_setCaseSensitivity");
 
-/**
- * Uniquely identifies a CXFile, that refers to the same underlying file,
- * across an indexing session.
- */
+extern fn CXErrorCode virtualFileOverlay_writeToBuffer(
+  CXVirtualFileOverlay,
+  CUInt options,
+  CChar** out_buffer_ptr,
+  CUInt* out_buffer_size)
+@cname("clang_VirtualFileOverlay_writeToBuffer");
+
+extern fn void free(
+  void* buffer)
+@cname("clang_free");
+
+extern fn void virtualFileOverlay_dispose(
+  CXVirtualFileOverlay)
+@cname("clang_VirtualFileOverlay_dispose");
+
+alias CXModuleMapDescriptor = void*;
+
+extern fn CXModuleMapDescriptor moduleMapDescriptor_create(
+  CUInt options)
+@cname("clang_ModuleMapDescriptor_create");
+
+extern fn CXErrorCode moduleMapDescriptor_setFrameworkModuleName(
+  CXModuleMapDescriptor,
+  ZString name)
+@cname("clang_ModuleMapDescriptor_setFrameworkModuleName");
+
+extern fn CXErrorCode moduleMapDescriptor_setUmbrellaHeader(
+  CXModuleMapDescriptor,
+  ZString name)
+@cname("clang_ModuleMapDescriptor_setUmbrellaHeader");
+
+extern fn CXErrorCode moduleMapDescriptor_writeToBuffer(
+  CXModuleMapDescriptor,
+  CUInt options,
+  CChar** out_buffer_ptr,
+  CUInt* out_buffer_size)
+@cname("clang_ModuleMapDescriptor_writeToBuffer");
+
+extern fn void moduleMapDescriptor_dispose(
+  CXModuleMapDescriptor)
+@cname("clang_ModuleMapDescriptor_dispose");
+
+alias CXFile = void*;
+
+extern fn CXString getFileName(
+  CXFile s_file)
+@cname("clang_getFileName");
+
+extern fn Time_t getFileTime(
+  CXFile s_file)
+@cname("clang_getFileTime");
+
 struct CXFileUniqueID {
-  CLongLong[3] data;
+  CULongLong[3] data;
 }
 
-/**
- * Retrieve the unique ID for the given \c file.
- *
- * \param file the file to get the ID for.
- * \param outID stores the returned CXFileUniqueID.
- * \returns If there was a failure getting the unique ID, returns non-zero,
- * otherwise returns 0.
- */
-fn CInt getFileUniqueID(
-  CXFile file, 
-  CXFileUniqueID* out_id) 
-@extern("clang_getFileUniqueID");
+extern fn CInt getFileUniqueID(
+  CXFile file,
+  CXFileUniqueID* out_id)
+@cname("clang_getFileUniqueID");
 
-/**
- * Returns non-zero if the \c file1 and \c file2 point to the same file,
- * or they are both NULL.
- */
-fn CInt isEqual_File(
-  CXFile file1, 
-  CXFile file2) 
-@extern("clang_File_isEqual");
+extern fn CInt file_isEqual(
+  CXFile file_1,
+  CXFile file_2)
+@cname("clang_File_isEqual");
 
-/**
- * Returns the real path name of \c file.
- *
- * An empty string may be returned. Use \c clang_getFileName() in that case.
- */
-fn CXString tryGetRealPathName_File(
-  CXFile file) 
-@extern("clang_File_tryGetRealPathName");
+extern fn CXString file_tryGetRealPathName(
+  CXFile file)
+@cname("clang_File_tryGetRealPathName");
 
-
-/*-------------------------------*\
-|                                 |
-|     File CXSourceLocation.h     |
-|                                 |
-\*-------------------------------*/
-
-/**
- * Identifies a specific source location within a translation
- * unit.
- *
- * Use clang_getExpansionLocation() or clang_getSpellingLocation()
- * to map a source location to a particular file, line, and column.
- */
 struct CXSourceLocation {
   void*[2] ptr_data;
   CUInt int_data;
 }
 
-/**
- * Identifies a half-open character range in the source code.
- *
- * Use clang_getRangeStart() and clang_getRangeEnd() to retrieve the
- * starting and end locations from a source range, respectively.
- */
 struct CXSourceRange {
   void*[2] ptr_data;
   CUInt begin_int_data;
   CUInt end_int_data;
 }
 
-/**
- * Retrieve a NULL (invalid) source location.
- */
-fn CXSourceLocation getNullLocation() 
-@extern("clang_getNullLocation");
+extern fn CXSourceLocation getNullLocation()
+@cname("clang_getNullLocation");
 
-/**
- * Determine whether two source locations, which must refer into
- * the same translation unit, refer to exactly the same point in the source
- * code.
- *
- * \returns non-zero if the source locations refer to the same location, zero
- * if they refer to different locations.
- */
-fn CUInt equalLocations(
-  CXSourceLocation loc1, 
-  CXSourceLocation loc2) 
-@extern("clang_equalLocations");
+extern fn CUInt equalLocations(
+  CXSourceLocation loc_1,
+  CXSourceLocation loc_2)
+@cname("clang_equalLocations");
 
-/**
- * Returns non-zero if the given source location is in a system header.
- */
-fn CInt isInSystemHeader_Location(
-  CXSourceLocation location) 
-@extern("clang_Location_isInSystemHeader");
+extern fn CUInt isBeforeInTranslationUnit(
+  CXSourceLocation loc_1,
+  CXSourceLocation loc_2)
+@cname("clang_isBeforeInTranslationUnit");
 
-/**
- * Returns non-zero if the given source location is in the main file of
- * the corresponding translation unit.
- */
-fn CInt isFromMainFile_Location(
-  CXSourceLocation location) 
-@extern("clang_Location_isFromMainFile");
+extern fn CInt location_isInSystemHeader(
+  CXSourceLocation location)
+@cname("clang_Location_isInSystemHeader");
 
-/**
- * Retrieve a NULL (invalid) source range.
- */
-fn CXSourceRange getNullRange() 
-@extern("clang_getNullRange");
+extern fn CInt location_isFromMainFile(
+  CXSourceLocation location)
+@cname("clang_Location_isFromMainFile");
 
-/**
- * Retrieve a source range given the beginning and ending source
- * locations.
- */
-fn CXSourceRange getRange(
-  CXSourceLocation begin, 
-  CXSourceLocation end) 
-@extern("clang_getRange");
+extern fn CXSourceRange getNullRange()
+@cname("clang_getNullRange");
 
-/**
- * Determine whether two ranges are equivalent.
- *
- * \returns non-zero if the ranges are the same, zero if they differ.
- */
-fn CUInt equalRanges(
-  CXSourceRange range1, 
-  CXSourceRange range2) 
-@extern("clang_equalRanges");
+extern fn CXSourceRange getRange(
+  CXSourceLocation begin,
+  CXSourceLocation end)
+@cname("clang_getRange");
 
-/**
- * Returns non-zero if \p range is null.
- */
-fn CInt isNull_Range(
-  CXSourceRange range) 
-@extern("clang_Range_isNull");
+extern fn CUInt equalRanges(
+  CXSourceRange range_1,
+  CXSourceRange range_2)
+@cname("clang_equalRanges");
 
-/**
- * Retrieve the file, line, column, and offset represented by
- * the given source location.
- *
- * If the location refers into a macro expansion, retrieves the
- * location of the macro expansion.
- *
- * \param location the location within a source file that will be decomposed
- * into its parts.
- *
- * \param file [out] if non-NULL, will be set to the file to which the given
- * source location points.
- *
- * \param line [out] if non-NULL, will be set to the line to which the given
- * source location points.
- *
- * \param column [out] if non-NULL, will be set to the column to which the given
- * source location points.
- *
- * \param offset [out] if non-NULL, will be set to the offset into the
- * buffer to which the given source location points.
- */
-fn void getExpansionLocation(
-  CXSourceLocation location, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_getExpansionLocation");
+extern fn CInt range_isNull(
+  CXSourceRange range)
+@cname("clang_Range_isNull");
 
-/**
- * Retrieve the file, line and column represented by the given source
- * location, as specified in a # line directive.
- *
- * Example: given the following source code in a file somefile.c
- *
- * \code
- * #123 "dummy.c" 1
- *
- * static CInt func(void)
- * {
- *     return 0;
- * }
- * \endcode
- *
- * the location information returned by this function would be
- *
- * File: dummy.c Line: 124 Column: 12
- *
- * whereas clang_getExpansionLocation would have returned
- *
- * File: somefile.c Line: 3 Column: 12
- *
- * \param location the location within a source file that will be decomposed
- * into its parts.
- *
- * \param filename [out] if non-NULL, will be set to the filename of the
- * source location. Note that filenames returned will be for "virtual" files,
- * which don't necessarily exist on the machine running clang - e.g. when
- * parsing preprocessed output obtained from a different environment. If
- * a non-NULL value is passed in, remember to dispose of the returned value
- * using \c clang_disposeString() once you've finished with it. For an invalid
- * source location, an empty string is returned.
- *
- * \param line [out] if non-NULL, will be set to the line number of the
- * source location. For an invalid source location, zero is returned.
- *
- * \param column [out] if non-NULL, will be set to the column number of the
- * source location. For an invalid source location, zero is returned.
- */
-fn void getPresumedLocation(
-  CXSourceLocation location, 
-  CXString* filename, 
-  CUInt* line, 
-  CUInt* column) 
-@extern("clang_getPresumedLocation");
+extern fn void getExpansionLocation(
+  CXSourceLocation location,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_getExpansionLocation");
 
-/**
- * Legacy API to retrieve the file, line, column, and offset represented
- * by the given source location.
- *
- * This interface has been replaced by the newer interface
- * #clang_getExpansionLocation(). See that interface's documentation for
- * details.
- */
-fn void getInstantiationLocation(
-  CXSourceLocation location, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_getInstantiationLocation");
+extern fn void getPresumedLocation(
+  CXSourceLocation location,
+  CXString* filename,
+  CUInt* line,
+  CUInt* column)
+@cname("clang_getPresumedLocation");
 
-/**
- * Retrieve the file, line, column, and offset represented by
- * the given source location.
- *
- * If the location refers into a macro instantiation, return where the
- * location was originally spelled in the source file.
- *
- * \param location the location within a source file that will be decomposed
- * into its parts.
- *
- * \param file [out] if non-NULL, will be set to the file to which the given
- * source location points.
- *
- * \param line [out] if non-NULL, will be set to the line to which the given
- * source location points.
- *
- * \param column [out] if non-NULL, will be set to the column to which the given
- * source location points.
- *
- * \param offset [out] if non-NULL, will be set to the offset into the
- * buffer to which the given source location points.
- */
-fn void getSpellingLocation(
-  CXSourceLocation location, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_getSpellingLocation");
+extern fn void getInstantiationLocation(
+  CXSourceLocation location,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_getInstantiationLocation");
 
-/**
- * Retrieve the file, line, column, and offset represented by
- * the given source location.
- *
- * If the location refers into a macro expansion, return where the macro was
- * expanded or where the macro argument was written, if the location points at
- * a macro argument.
- *
- * \param location the location within a source file that will be decomposed
- * into its parts.
- *
- * \param file [out] if non-NULL, will be set to the file to which the given
- * source location points.
- *
- * \param line [out] if non-NULL, will be set to the line to which the given
- * source location points.
- *
- * \param column [out] if non-NULL, will be set to the column to which the given
- * source location points.
- *
- * \param offset [out] if non-NULL, will be set to the offset into the
- * buffer to which the given source location points.
- */
-fn void getFileLocation(
-  CXSourceLocation location, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_getFileLocation");
+extern fn void getSpellingLocation(
+  CXSourceLocation location,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_getSpellingLocation");
 
-/**
- * Retrieve a source location representing the first character within a
- * source range.
- */
-fn CXSourceLocation getRangeStart(
-  CXSourceRange range) 
-@extern("clang_getRangeStart");
+extern fn void getFileLocation(
+  CXSourceLocation location,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_getFileLocation");
 
-/**
- * Retrieve a source location representing the last character within a
- * source range.
- */
-fn CXSourceLocation getRangeEnd(
-  CXSourceRange range) 
-@extern("clang_getRangeEnd");
+extern fn CXSourceLocation getRangeStart(
+  CXSourceRange range)
+@cname("clang_getRangeStart");
 
-/**
- * Identifies an array of ranges.
- */
+extern fn CXSourceLocation getRangeEnd(
+  CXSourceRange range)
+@cname("clang_getRangeEnd");
+
 struct CXSourceRangeList {
-  /* The number of ranges in the \c ranges array. */
   CUInt count;
-  /*
-   * An array of \c CXSourceRanges.
-   */
   CXSourceRange* ranges;
 }
 
-/**
- * Destroy the given \c CXSourceRangeList.
- */
-fn void disposeSourceRangeList(
-  CXSourceRangeList* ranges) 
-@extern("clang_disposeSourceRangeList");
-
-
-/*-------------------------------*\
-|                                 |
-|       File CXDiagnostic.h       |
-|                                 |
-\*-------------------------------*/
-
-/**
- * Describes the severity of a particular diagnostic.
- */
-typedef CXDiagnosticSeverity = inline CInt;
-
-/**
- * A diagnostic that has been suppressed, e.g., by a command-line
- * option.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_IGNORED = 0;
-
-/**
- * This diagnostic is a note that should be attached to the
- * previous (non-note) diagnostic.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_NOTE = 1;
-
-/**
- * This diagnostic indicates suspicious code that may not be
- * wrong.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_WARNING = 2;
-
-/**
- * This diagnostic indicates that the code is ill-formed.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_ERROR = 3;
-
-/**
- * This diagnostic indicates that the code is ill-formed such
- * that future parser recovery is unlikely to produce useful
- * results.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_FATAL = 4;
-
-
-/**
- * A single diagnostic, containing the diagnostic's severity,
- * location, text, source ranges, and fix-it hints.
- */
-typedef CXDiagnostic = inline void*;
-
-/**
- * A group of CXDiagnostics.
- */
-typedef CXDiagnosticSet = inline void*;
-
-/**
- * Determine the number of diagnostics in a CXDiagnosticSet.
- */
-fn CUInt getNumDiagnosticsInSet(
-  CXDiagnosticSet diags) 
-@extern("clang_getNumDiagnosticsInSet");
-
-/**
- * Retrieve a diagnostic associated with the given CXDiagnosticSet.
- *
- * \param Diags the CXDiagnosticSet to query.
- * \param Index the zero-based diagnostic number to retrieve.
- *
- * \returns the requested diagnostic. This diagnostic must be freed
- * via a call to \c clang_disposeDiagnostic().
- */
-fn CXDiagnostic getDiagnosticInSet(
-  CXDiagnosticSet diags, 
-  CUInt index) 
-@extern("clang_getDiagnosticInSet");
-
-/**
- * Describes the kind of error that occurred (if any) in a call to
- * \c clang_loadDiagnostics.
- */
-typedef CXLoadDiag_Error = inline CInt;
-/**
- * Indicates that no error occurred.
- */
-const CXLoadDiag_Error LOAD_DIAG_NONE = 0;
-
-/**
- * Indicates that an unknown error occurred while attempting to
- * deserialize diagnostics.
- */
-const CXLoadDiag_Error LOAD_DIAG_UNKNOWN = 1;
-
-/**
- * Indicates that the file containing the serialized diagnostics
- * could not be opened.
- */
-const CXLoadDiag_Error LOAD_DIAG_CANNOT_LOAD = 2;
-
-/**
- * Indicates that the serialized diagnostics file is invalid or
- * corrupt.
- */
-const CXLoadDiag_Error LOAD_DIAG_INVALID_FILE = 3;
-
-/**
- * Deserialize a set of diagnostics from a Clang diagnostics bitcode
- * file.
- *
- * \param file The name of the file to deserialize.
- * \param error A pointer to a enum value recording if there was a problem
- *        deserializing the diagnostics.
- * \param errorString A pointer to a CXString for recording the error string
- *        if the file was not successfully loaded.
- *
- * \returns A loaded CXDiagnosticSet if successful, and NULL otherwise.  These
- * diagnostics should be released using clang_disposeDiagnosticSet().
- */
-fn CXDiagnosticSet loadDiagnostics(
-  ZString file, 
-  CXLoadDiag_Error* error, 
-  CXString* errorString) 
-@extern("clang_loadDiagnostics");
-
-/**
- * Release a CXDiagnosticSet and all of its contained diagnostics.
- */
-fn void disposeDiagnosticSet(
-  CXDiagnosticSet diags) 
-@extern("clang_disposeDiagnosticSet");
-
-/**
- * Retrieve the child diagnostics of a CXDiagnostic.
- *
- * This CXDiagnosticSet does not need to be released by
- * clang_disposeDiagnosticSet.
- */
-fn CXDiagnosticSet getChildDiagnostics(
-  CXDiagnostic d) 
-@extern("clang_getChildDiagnostics");
-
-/**
- * Destroy a diagnostic.
- */
-fn void disposeDiagnostic(
-  CXDiagnostic diagnostic) 
-@extern("clang_disposeDiagnostic");
-
-/**
- * Options to control the display of diagnostics.
- *
- * The values in this enum are meant to be combined to customize the
- * behavior of \c clang_formatDiagnostic().
- */
-typedef CXDiagnosticDisplayOptions = inline CInt;
-
-/**
- * Display the source-location information where the
- * diagnostic was located.
- *
- * When set, diagnostics will be prefixed by the file, line, and
- * (optionally) column to which the diagnostic refers. For example,
- *
- * \code
- * test.c:28: warning: extra tokens at end of #endif directive
- * \endcode
- *
- * This option corresponds to the clang flag \c -fshow-source-location.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_SOURCE_LOCATION = 0x01;
-
-/**
- * If displaying the source-location information of the
- * diagnostic, also include the column number.
- *
- * This option corresponds to the clang flag \c -fshow-column.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_COLUMN = 0x02;
-
-/**
- * If displaying the source-location information of the
- * diagnostic, also include information about source ranges in a
- * machine-parsable format.
- *
- * This option corresponds to the clang flag
- * \c -fdiagnostics-print-source-range-info.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_SOURCE_RANGES = 0x04;
-
-/**
- * Display the option name associated with this diagnostic, if any.
- *
- * The option name displayed (e.g., -Wconversion) will be placed in brackets
- * after the diagnostic text. This option corresponds to the clang flag
- * \c -fdiagnostics-show-option.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_OPTION = 0x08;
-
-/**
- * Display the category number associated with this diagnostic, if any.
- *
- * The category number is displayed within brackets after the diagnostic text.
- * This option corresponds to the clang flag
- * \c -fdiagnostics-show-category=id.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_CATEGORY_ID = 0x10;
-
-/**
- * Display the category name associated with this diagnostic, if any.
- *
- * The category name is displayed within brackets after the diagnostic text.
- * This option corresponds to the clang flag
- * \c -fdiagnostics-show-category=name.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_CATEGORY_NAME = 0x20;
-
-/**
- * Format the given diagnostic in a manner that is suitable for display.
- *
- * This routine will format the given diagnostic to a string, rendering
- * the diagnostic according to the various options given. The
- * \c clang_defaultDiagnosticDisplayOptions() function returns the set of
- * options that most closely mimics the behavior of the clang compiler.
- *
- * \param Diagnostic The diagnostic to print.
- *
- * \param Options A set of options that control the diagnostic display,
- * created by combining \c CXDiagnosticDisplayOptions values.
- *
- * \returns A new string containing for formatted diagnostic.
- */
-fn CXString formatDiagnostic(
-  CXDiagnostic diagnostic, 
-  CUInt options) 
-@extern("clang_formatDiagnostic");
-
-/**
- * Retrieve the set of display options most similar to the
- * default behavior of the clang compiler.
- *
- * \returns A set of display options suitable for use with \c
- * clang_formatDiagnostic().
- */
-fn CUInt defaultDiagnosticDisplayOptions() 
-@extern("clang_defaultDiagnosticDisplayOptions");
-
-/**
- * Determine the severity of the given diagnostic.
- */
-fn CXDiagnosticSeverity getDiagnosticSeverity(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticSeverity");
-
-/**
- * Retrieve the source location of the given diagnostic.
- *
- * This location is where Clang would print the caret ('^') when
- * displaying the diagnostic on the command line.
- */
-fn CXSourceLocation getDiagnosticLocation(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticLocation");
-
-/**
- * Retrieve the text of the given diagnostic.
- */
-fn CXString getDiagnosticSpelling(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticSpelling");
-
-/**
- * Retrieve the name of the command-line option that enabled this
- * diagnostic.
- *
- * \param Diag The diagnostic to be queried.
- *
- * \param Disable If non-NULL, will be set to the option that disables this
- * diagnostic (if any).
- *
- * \returns A string that contains the command-line option used to enable this
- * warning, such as "-Wconversion" or "-pedantic".
- */
-fn CXString getDiagnosticOption(
-  CXDiagnostic diag, 
-  CXString* disable) 
-@extern("clang_getDiagnosticOption");
-
-/**
- * Retrieve the category number for this diagnostic.
- *
- * Diagnostics can be categorized into groups along with other, related
- * diagnostics (e.g., diagnostics under the same warning flag). This routine
- * retrieves the category number for the given diagnostic.
- *
- * \returns The number of the category that contains this diagnostic, or zero
- * if this diagnostic is uncategorized.
- */
-fn CUInt getDiagnosticCategory(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticCategory");
-
-/**
- * Retrieve the name of a particular diagnostic category.  This
- *  is now deprecated.  Use clang_getDiagnosticCategoryText()
- *  instead.
- *
- * \param Category A diagnostic category number, as returned by
- * \c clang_getDiagnosticCategory().
- *
- * \returns The name of the given diagnostic category.
- */
-fn CXString getDiagnosticCategoryName(
-  CUInt category) 
-@extern("clang_getDiagnosticCategoryName") 
-@deprecated("Use clang_getDiagnosticCategoryText()");
-
-/**
- * Retrieve the diagnostic category text for a given diagnostic.
- *
- * \returns The text of the given diagnostic category.
- */
-fn CXString getDiagnosticCategoryText(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticCategoryText");
-
-/**
- * Determine the number of source ranges associated with the given
- * diagnostic.
- */
-fn CUInt getDiagnosticNumRanges(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticNumRanges");
-
-/**
- * Retrieve a source range associated with the diagnostic.
- *
- * A diagnostic's source ranges highlight important elements in the source
- * code. On the command line, Clang displays source ranges by
- * underlining them with '~' characters.
- *
- * \param Diagnostic the diagnostic whose range is being extracted.
- *
- * \param Range the zero-based index specifying which range to
- *
- * \returns the requested source range.
- */
-fn CXSourceRange getDiagnosticRange(
-  CXDiagnostic diagnostic, 
-  CUInt range) 
-@extern("clang_getDiagnosticRange");
-
-/**
- * Determine the number of fix-it hints associated with the
- * given diagnostic.
- */
-fn CUInt getDiagnosticNumFixIts(
-  CXDiagnostic diagnostic) 
-@extern("clang_getDiagnosticNumFixIts");
-
-/**
- * Retrieve the replacement information for a given fix-it.
- *
- * Fix-its are described in terms of a source range whose contents
- * should be replaced by a string. This approach generalizes over
- * three kinds of operations: removal of source code (the range covers
- * the code to be removed and the replacement string is empty),
- * replacement of source code (the range covers the code to be
- * replaced and the replacement string provides the new code), and
- * insertion (both the start and end of the range point at the
- * insertion location, and the replacement string provides the text to
- * insert).
- *
- * \param Diagnostic The diagnostic whose fix-its are being queried.
- *
- * \param FixIt The zero-based index of the fix-it.
- *
- * \param ReplacementRange The source range whose contents will be
- * replaced with the returned replacement string. Note that source
- * ranges are half-open ranges [a, b), so the source code should be
- * replaced from a and up to (but not including) b.
- *
- * \returns A string containing text that should be replace the source
- * code indicated by the \c ReplacementRange.
- */
-fn CXString getDiagnosticFixIt(
-  CXDiagnostic diagnostic, 
-  CUInt fix_it, 
-  CXSourceRange* replacement_range) 
-@extern("clang_getDiagnosticFixIt");
-
-
-/*-------------------------------*\
-|                                 |
-|  File CXCompilationDatabase.h   |
-|                                 |
-\*-------------------------------*/
-
-/**
- * A compilation database holds all information used to compile files in a
- * project. For each file in the database, it can be queried for the working
- * directory or the command line used for the compiler invocation.
- *
- * Must be freed by \c clang_CompilationDatabase_dispose
- */
-typedef CXCompilationDatabase = inline void*;
-
-/**
- * Contains the results of a search in the compilation database
- *
- * When searching for the compile command for a file, the compilation db can
- * return several commands, as the file may have been compiled with
- * different options in different places of the project. This choice of compile
- * commands is wrapped in this opaque data structure. It must be freed by
- * \c clang_CompileCommands_dispose.
- */
-typedef CXCompileCommands = inline void*;
-
-/**
- * Represents the command line invocation to compile a specific file.
- */
-typedef CXCompileCommand = inline void*;
-
-/**
- * Error codes for Compilation Database
- */
-typedef CXCompilationDatabase_Error = inline CInt;
-
-/*
- * No error occurred
- */
-const CXCompilationDatabase_Error COMPILATION_DATABASE_NO_ERROR = 0;
-/*
- * Database can not be loaded
- */
-const CXCompilationDatabase_Error COMPILATION_DATABASE_CAN_NOT_LOAD_DATA_BASE = 1;
-
-/**
- * Creates a compilation database from the database found in directory
- * buildDir. For example, CMake can output a compile_commands.json which can
- * be used to build the database.
- *
- * It must be freed by \c clang_CompilationDatabase_dispose.
- */
-fn CXCompilationDatabase fromDirectory_CompilationDatabase(
-  ZString build_dir, 
-  CXCompilationDatabase_Error* error_code) 
-@extern("clang_CompilationDatabase_fromDirectory");
-
-/**
- * Free the given compilation database
- */
-fn void dispose_CompilationDatabase(
-  CXCompilationDatabase database) 
-@extern("clang_CompilationDatabase_dispose");
-
-/**
- * Find the compile commands used for a file. The compile commands
- * must be freed by \c clang_CompileCommands_dispose.
- */
-fn CXCompileCommands getCompileCommands_CompilationDatabase(
-  CXCompilationDatabase database, 
-  ZString complete_fileName) 
-@extern("clang_CompilationDatabase_getCompileCommands");
-
-/**
- * Get all the compile commands in the given compilation database.
- */
-fn CXCompileCommands getAllCompileCommands_CompilationDatabase(
-  CXCompilationDatabase database) 
-@extern("clang_CompilationDatabase_getAllCompileCommands");
-
-/**
- * Free the given CompileCommands
- */
-fn void dispose_CompileCommands(
-  CXCompileCommands commands) 
-@extern("clang_CompileCommands_dispose");
-
-/**
- * Get the number of CompileCommand we have for a file
- */
-fn CUInt getSize_CompileCommands(
-  CXCompileCommands commands) 
-@extern("clang_CompileCommands_getSize");
-
-/**
- * Get the I'th CompileCommand for a file
- *
- * Note : 0 <= i < clang_CompileCommands_getSize(CXCompileCommands)
- */
-fn CXCompileCommand getCommand_CompileCommands(
-  CXCompileCommands commands, 
-  CUInt i) 
-@extern("clang_CompileCommands_getCommand");
-
-/**
- * Get the working directory where the CompileCommand was executed from
- */
-fn CXString getDirectory_CompileCommand(
-  CXCompileCommand command) 
-@extern("clang_CompileCommand_getDirectory");
-
-/**
- * Get the filename associated with the CompileCommand.
- */
-fn CXString getFilename_CompileCommand(
-  CXCompileCommand command) 
-@extern("clang_CompileCommand_getFilename");
-
-/**
- * Get the number of arguments in the compiler invocation.
- *
- */
-fn CUInt getNumArgs_CompileCommand(
-  CXCompileCommand command) 
-@extern("clang_CompileCommand_getNumArgs");
-
-/**
- * Get the I'th argument value in the compiler invocations
- *
- * Invariant :
- *  - argument 0 is the compiler executable
- */
-fn CXString getArg_CompileCommand(
-  CXCompileCommand command, 
-  CUInt i) 
-@extern("clang_CompileCommand_getArg");
-
-/**
- * Get the number of source mappings for the compiler invocation.
- */
-fn CUInt getNumMappedSources_CompileCommand(
-  CXCompileCommand command) 
-@extern("clang_CompileCommand_getNumMappedSources");
-
-/**
- * Get the I'th mapped source path for the compiler invocation.
- */
-fn CXString getMappedSourcePath_CompileCommand(
-  CXCompileCommand command, 
-  CUInt i) 
-@extern("clang_CompileCommand_getMappedSourcePath");
-
-/**
- * Get the I'th mapped source content for the compiler invocation.
- */
-fn CXString getMappedSourceContent_CompileCommand(
-  CXCompileCommand command, 
-  CUInt i) 
-@extern("clang_CompileCommand_getMappedSourceContent");
-
-
-/*-------------------------------*\
-|                                 |
-|       File BuildSystem.h        |
-|                                 |
-\*-------------------------------*/
-
-/**
- * Return the timestamp for use with Clang's
- * \c -fbuild-session-timestamp= option.
- */
-fn CULongLong getBuildSessionTimestamp() 
-@extern("clang_getBuildSessionTimestamp");
-
-/**
- * Object encapsulating information about overlaying virtual
- * file/directories over the real file system.
- */
-typedef CXVirtualFileOverlay = inline void*;
-
-/**
- * Create a \c CXVirtualFileOverlay object.
- * Must be disposed with \c clang_VirtualFileOverlay_dispose().
- *
- * \param options is reserved, always pass 0.
- */
-fn CXVirtualFileOverlay createVirtualFileOverlay(
-  CUInt options) 
-@extern("clang_VirtualFileOverlay_create");
-
-/**
- * Map an absolute virtual file path to an absolute real one.
- * The virtual path must be canonicalized (not contain "."/"..").
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode addFileMapping_VirtualFileOverlay(
-  CXVirtualFileOverlay file_overlay, 
-  ZString virtual_path, 
-  ZString real_path) 
-@extern("clang_VirtualFileOverlay_addFileMapping");
-
-/**
- * Set the case sensitivity for the \c CXVirtualFileOverlay object.
- * The \c CXVirtualFileOverlay object is case-sensitive by default, this
- * option can be used to override the default.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode setCaseSensitivity_VirtualFileOverlay(
-  CXVirtualFileOverlay file_overaly, 
-  CInt case_sensitive) 
-@extern("clang_VirtualFileOverlay_setCaseSensitivity");
-
-/**
- * Write out the \c CXVirtualFileOverlay object to a CChar buffer.
- *
- * \param options is reserved, always pass 0.
- * \param out_buffer_ptr pointer to receive the buffer pointer, which should be
- * disposed using \c clang_free().
- * \param out_buffer_size pointer to receive the buffer size.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode writeToBuffer_VirtualFileOverlay(
-  CXVirtualFileOverlay file_overaly, 
-  CUInt options, 
-  CChar** out_buffer_ptr, 
-  CUInt* out_buffer_size) 
-@extern("clang_VirtualFileOverlay_writeToBuffer");
-
-/**
- * free memory allocated by libclang, such as the buffer returned by
- * \c CXVirtualFileOverlay() or \c clang_ModuleMapDescriptor_writeToBuffer().
- *
- * \param buffer memory pointer to free.
- */
-fn void free(
-  void* buffer) 
-@extern("clang_free");
-
-/**
- * Dispose a \c CXVirtualFileOverlay object.
- */
-fn void dispose_VirtualFileOverlay(
-  CXVirtualFileOverlay file_overlay) 
-@extern("clang_VirtualFileOverlay_dispose");
-
-/**
- * Object encapsulating information about a module.modulemap file.
- */
-typedef CXModuleMapDescriptor = inline void*;
-
-/**
- * Create a \c CXModuleMapDescriptor object.
- * Must be disposed with \c clang_ModuleMapDescriptor_dispose().
- *
- * \param options is reserved, always pass 0.
- */
-fn CXModuleMapDescriptor createModuleMapDescriptor(
-  CUInt options) 
-@extern("clang_ModuleMapDescriptor_create");
-
-/**
- * Sets the framework module name that the module.modulemap describes.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode setFrameworkModuleName_ModuleMapDescriptor(
-  CXModuleMapDescriptor descriptor, 
-  ZString name) 
-@extern("clang_ModuleMapDescriptor_setFrameworkModuleName");
-
-/**
- * Sets the umbrella header name that the module.modulemap describes.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode setUmbrellaHeader_ModuleMapDescriptor(
-  CXModuleMapDescriptor descriptor, 
-  ZString name) 
-@extern("clang_ModuleMapDescriptor_setUmbrellaHeader");
-
-/**
- * Write out the \c CXModuleMapDescriptor object to a CChar buffer.
- *
- * \param options is reserved, always pass 0.
- * \param out_buffer_ptr pointer to receive the buffer pointer, which should be
- * disposed using \c clang_free().
- * \param out_buffer_size pointer to receive the buffer size.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode writeToBuffer_ModuleMapDescriptor(
-  CXModuleMapDescriptor descriptor, 
-  CUInt options, 
-  CChar** out_buffer_ptr, 
-  CUInt* out_buffer_size) 
-@extern("clang_ModuleMapDescriptor_writeToBuffer");
-
-/**
- * Dispose a \c CXModuleMapDescriptor object.
- */
-fn void dispose_ModuleMapDescriptor(
-  CXModuleMapDescriptor descriptor) 
-@extern("clang_ModuleMapDescriptor_dispose");
-
-
-/*-------------------------------*\
-|                                 |
-|      File Documentation.h       |
-|                                 |
-\*-------------------------------*/
-
-/**
- * A parsed comment.
- */
-struct CXComment {
-  void* ast_node;
-  CXTranslationUnit translation_unit;
+extern fn void disposeSourceRangeList(
+  CXSourceRangeList* ranges)
+@cname("clang_disposeSourceRangeList");
+
+constdef CXDiagnosticSeverity : CInt {
+  DIAGNOSTIC_IGNORED = 0,
+  DIAGNOSTIC_NOTE = 1,
+  DIAGNOSTIC_WARNING = 2,
+  DIAGNOSTIC_ERROR = 3,
+  DIAGNOSTIC_FATAL = 4
 }
 
-/**
- * Given a cursor that represents a documentable entity (e.g.,
- * declaration), return the associated parsed comment as a
- * \c CXComment_FullComment AST node.
- */
-fn CXComment getParsedComment_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getParsedComment");
+alias CXDiagnostic = void*;
+
+alias CXDiagnosticSet = void*;
+
+extern fn CUInt getNumDiagnosticsInSet(
+  CXDiagnosticSet diags)
+@cname("clang_getNumDiagnosticsInSet");
+
+extern fn CXDiagnostic getDiagnosticInSet(
+  CXDiagnosticSet diags,
+  CUInt index)
+@cname("clang_getDiagnosticInSet");
+
+constdef CXLoadDiag_Error : CInt {
+  LOAD_DIAG_NONE = 0,
+  LOAD_DIAG_UNKNOWN = 1,
+  LOAD_DIAG_CANNOT_LOAD = 2,
+  LOAD_DIAG_INVALID_FILE = 3
+}
+
+extern fn CXDiagnosticSet loadDiagnostics(
+  ZString file,
+  CXLoadDiag_Error* error,
+  CXString* error_string)
+@cname("clang_loadDiagnostics");
+
+extern fn void disposeDiagnosticSet(
+  CXDiagnosticSet diags)
+@cname("clang_disposeDiagnosticSet");
+
+extern fn CXDiagnosticSet getChildDiagnostics(
+  CXDiagnostic d)
+@cname("clang_getChildDiagnostics");
+
+extern fn void disposeDiagnostic(
+  CXDiagnostic diagnostic)
+@cname("clang_disposeDiagnostic");
+
+constdef CXDiagnosticDisplayOptions : CInt {
+  DIAGNOSTIC_DISPLAY_SOURCE_LOCATION = 1,
+  DIAGNOSTIC_DISPLAY_COLUMN = 2,
+  DIAGNOSTIC_DISPLAY_SOURCE_RANGES = 4,
+  DIAGNOSTIC_DISPLAY_OPTION = 8,
+  DIAGNOSTIC_DISPLAY_CATEGORY_ID = 16,
+  DIAGNOSTIC_DISPLAY_CATEGORY_NAME = 32
+}
+
+extern fn CXString formatDiagnostic(
+  CXDiagnostic diagnostic,
+  CUInt options)
+@cname("clang_formatDiagnostic");
+
+extern fn CUInt defaultDiagnosticDisplayOptions()
+@cname("clang_defaultDiagnosticDisplayOptions");
+
+extern fn CXDiagnosticSeverity getDiagnosticSeverity(
+  CXDiagnostic)
+@cname("clang_getDiagnosticSeverity");
+
+extern fn CXSourceLocation getDiagnosticLocation(
+  CXDiagnostic)
+@cname("clang_getDiagnosticLocation");
+
+extern fn CXString getDiagnosticSpelling(
+  CXDiagnostic)
+@cname("clang_getDiagnosticSpelling");
+
+extern fn CXString getDiagnosticOption(
+  CXDiagnostic diag,
+  CXString* disable)
+@cname("clang_getDiagnosticOption");
+
+extern fn CUInt getDiagnosticCategory(
+  CXDiagnostic)
+@cname("clang_getDiagnosticCategory");
+
+extern fn CXString getDiagnosticCategoryName(
+  CUInt category)
+@cname("clang_getDiagnosticCategoryName");
+
+extern fn CXString getDiagnosticCategoryText(
+  CXDiagnostic)
+@cname("clang_getDiagnosticCategoryText");
+
+extern fn CUInt getDiagnosticNumRanges(
+  CXDiagnostic)
+@cname("clang_getDiagnosticNumRanges");
+
+extern fn CXSourceRange getDiagnosticRange(
+  CXDiagnostic diagnostic,
+  CUInt range)
+@cname("clang_getDiagnosticRange");
+
+extern fn CUInt getDiagnosticNumFixIts(
+  CXDiagnostic diagnostic)
+@cname("clang_getDiagnosticNumFixIts");
+
+extern fn CXString getDiagnosticFixIt(
+  CXDiagnostic diagnostic,
+  CUInt fix_it,
+  CXSourceRange* replacement_range)
+@cname("clang_getDiagnosticFixIt");
 
-/**
- * Describes the type of the comment AST node (\c CXComment).  A comment
- * node can be considered block content (e. g., paragraph), inline content
- * (plain text) or neither (the root AST node).
- */
-typedef CXCommentKind = inline CInt;
+alias CXIndex = void*;
 
-/**
- * Null comment.  No AST node is constructed at the requested location
- * because there is no text or a syntax error.
- */
-const CXCommentKind COMMENT_NULL = 0;
+alias CXTargetInfo = void*;
 
-/**
- * Plain text.  Inline content.
- */
-const CXCommentKind COMMENT_TEXT = 1;
+alias CXTranslationUnit = void*;
 
-/**
- * A command with word-like arguments that is considered inline content.
- *
- * For example: \\c command.
- */
-const CXCommentKind COMMENT_INLINE_COMMAND = 2;
+alias CXClientData = void*;
 
-/**
- * HTML start tag with attributes (name-value pairs).  Considered
- * inline content.
- *
- * For example:
- * \verbatim
- * <br> <br /> <a href="http://example.org/">
- * \endverbatim
- */
-const CXCommentKind COMMENT_HTML_START_TAG = 3;
-
-/**
- * HTML end tag.  Considered inline content.
- *
- * For example:
- * \verbatim
- * </a>
- * \endverbatim
- */
-const CXCommentKind COMMENT_HTML_END_TAG = 4;
-
-/**
- * A paragraph, contains inline comment.  The paragraph itself is
- * block content.
- */
-const CXCommentKind COMMENT_PARAGRAPH = 5;
-
-/**
- * A command that has zero or more word-like arguments (number of
- * word-like arguments depends on command name) and a paragraph as an
- * argument.  Block command is block content.
- *
- * Paragraph argument is also a child of the block command.
- *
- * For example: \has 0 word-like arguments and a paragraph argument.
- *
- * AST nodes of special kinds that parser knows about (e. g., \\param
- * command) have their own node kinds.
- */
-const CXCommentKind COMMENT_BLOCK_COMMAND = 6;
-
-/**
- * A \\param or \\arg command that describes the function parameter
- * (name, passing direction, description).
- *
- * For example: \\param [in] ParamName description.
- */
-const CXCommentKind COMMENT_PARAM_COMMAND = 7;
-
-/**
- * A \\tparam command that describes a template parameter (name and
- * description).
- *
- * For example: \\tparam T description.
- */
-const CXCommentKind COMMENT_TPARAM_COMMAND = 8;
-
-/**
- * A verbatim block command (e. g., preformatted code).  Verbatim
- * block has an opening and a closing command and contains multiple lines of
- * text (\c CXComment_VerbatimBlockLine child nodes).
- *
- * For example:
- * \\verbatim
- * aaa
- * \\endverbatim
- */
-const CXCommentKind COMMENT_VERBATIM_BLOCK_COMMAND = 9;
-
-/**
- * A line of text that is contained within a
- * CXComment_VerbatimBlockCommand node.
- */
-const CXCommentKind COMMENT_VERBATIM_BLOCK_LINE = 10;
-
-/**
- * A verbatim line command.  Verbatim line has an opening command,
- * a single line of text (up to the newline after the opening command) and
- * has no closing command.
- */
-const CXCommentKind COMMENT_VERBATIM_LINE = 11;
-
-/**
- * A full comment attached to a declaration, contains block content.
- */
-const CXCommentKind COMMENT_FULL_COMMENT = 12;
-
-/**
- * The most appropriate rendering mode for an inline command, chosen on
- * command semantics in Doxygen.
- */
-typedef CXCommentInlineCommandRenderKind = inline CInt;
-/**
- * Command argument should be rendered in a normal font.
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_NORMAL = 0;
-
-/**
- * Command argument should be rendered in a bold font.
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_BOLD = 1;
-
-/**
- * Command argument should be rendered in a monospaced font.
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_MONOSPACED = 2;
-
-/**
- * Command argument should be rendered emphasized (typically italic
- * font).
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_EMPHASIZED = 3;
-
-/**
- * Command argument should not be rendered (since it only defines an anchor).
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_ANCHOR = 4;
-
-/**
- * Describes parameter passing direction for \\param or \\arg command.
- */
-typedef CXCommentParamPassDirection = inline CInt;
-
-/**
- * The parameter is an input parameter.
- */
-const CXCommentParamPassDirection COMMENT_PARAM_PASS_DIRECTION_IN = 0;
-
-/**
- * The parameter is an output parameter.
- */
-const CXCommentParamPassDirection COMMENT_PARAM_PASS_DIRECTION_OUT = 1;
-
-/**
- * The parameter is an input and output parameter.
- */
-const CXCommentParamPassDirection COMMENT_PARAM_PASS_DIRECTION_IN_OUT = 2;
-
-/**
- * \param Comment AST node of any kind.
- *
- * \returns the type of the AST node.
- */
-fn CXCommentKind getKind_Comment(
-  CXComment comment) 
-@extern("clang_Comment_getKind");
-
-/**
- * \param Comment AST node of any kind.
- *
- * \returns number of children of the AST node.
- */
-fn CUInt getNumChildren_Comment(
-  CXComment comment) 
-@extern("clang_Comment_getNumChildren");
-
-/**
- * \param Comment AST node of any kind.
- *
- * \param ChildIdx child index (zero-based).
- *
- * \returns the specified child of the AST node.
- */
-fn CXComment getChild_Comment(
-  CXComment comment, 
-  CUInt child_idx) 
-@extern("clang_Comment_getChild");
-
-/**
- * A \c CXComment_Paragraph node is considered whitespace if it contains
- * only \c CXComment_Text nodes that are empty or whitespace.
- *
- * Other AST nodes (except \c CXComment_Paragraph and \c CXComment_Text) are
- * never considered whitespace.
- *
- * \returns non-zero if \c Comment is whitespace.
- */
-fn CUInt isWhitespace_Comment(
-  CXComment comment) 
-@extern("clang_Comment_isWhitespace");
-
-/**
- * \returns non-zero if \c Comment is inline content and has a newline
- * immediately following it in the comment text.  Newlines between paragraphs
- * do not count.
- */
-fn CUInt hasTrailingNewlineInlineContentComment(
-  CXComment comment) 
-@extern("clang_InlineContentComment_hasTrailingNewline");
-
-/**
- * \param Comment a \c CXComment_Text AST node.
- *
- * \returns text contained in the AST node.
- */
-fn CXString getTextTextComment(
-  CXComment comment) 
-@extern("clang_TextComment_getText");
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns name of the inline command.
- */
-fn CXString getCommandNameInlineCommandComment(
-  CXComment comment) 
-@extern("clang_InlineCommandComment_getCommandName");
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns the most appropriate rendering mode, chosen on command
- * semantics in Doxygen.
- */
-fn CXCommentInlineCommandRenderKind getRenderKindInlineCommandComment(
-  CXComment comment) 
-@extern("clang_InlineCommandComment_getRenderKind");
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns number of command arguments.
- */
-fn CUInt getNumArgsInlineCommandComment(
-  CXComment comment) 
-@extern("clang_InlineCommandComment_getNumArgs");
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \param ArgIdx argument index (zero-based).
- *
- * \returns text of the specified argument.
- */
-fn CXString getArgTextInlineCommandComment(
-  CXComment comment, 
-  CUInt arg_idx) 
-@extern("clang_InlineCommandComment_getArgText");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
- * node.
- *
- * \returns HTML tag name.
- */
-fn CXString getTagNameHTMLTagComment(
-  CXComment comment) 
-@extern("clang_HTMLTagComment_getTagName");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \returns non-zero if tag is self-closing (for example, &lt;br /&gt;).
- */
-fn CUInt isSelfClosingHTMLStartTagComment(
-  CXComment comment) 
-@extern("clang_HTMLStartTagComment_isSelfClosing");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \returns number of attributes (name-value pairs) attached to the start tag.
- */
-fn CUInt getNumAttrsHTMLStartTag(
-  CXComment comment) 
-@extern("clang_HTMLStartTag_getNumAttrs");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \param AttrIdx attribute index (zero-based).
- *
- * \returns name of the specified attribute.
- */
-fn CXString getAttrNameHTMLStartTag(
-  CXComment comment, 
-  CUInt attr_idx) 
-@extern("clang_HTMLStartTag_getAttrName");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \param AttrIdx attribute index (zero-based).
- *
- * \returns value of the specified attribute.
- */
-fn CXString getAttrValueHTMLStartTag(
-  CXComment comment, 
-  CUInt attr_idx) 
-@extern("clang_HTMLStartTag_getAttrValue");
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \returns name of the block command.
- */
-fn CXString getCommandNameCXBlockCommandComment(
-  CXComment comment) 
-@extern("clang_BlockCommandComment_getCommandName");
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \returns number of word-like arguments.
- */
-fn CUInt getNumArgsBlockCommandComment(
-  CXComment comment) 
-@extern("clang_BlockCommandComment_getNumArgs");
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \param ArgIdx argument index (zero-based).
- *
- * \returns text of the specified word-like argument.
- */
-fn CXString getArgTextBlockCommandComment(
-  CXComment comment, 
-  CUInt arg_idx) 
-@extern("clang_BlockCommandComment_getArgText");
-
-/**
- * \param Comment a \c CXComment_BlockCommand or
- * \c CXComment_VerbatimBlockCommand AST node.
- *
- * \returns paragraph argument of the block command.
- */
-fn CXComment getParagraphBlockCommandComment(
-  CXComment comment) 
-@extern("clang_BlockCommandComment_getParagraph");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns parameter name.
- */
-fn CXString getParamNameParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_getParamName");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns non-zero if the parameter that this AST node represents was found
- * in the function prototype and \c clang_ParamCommandComment_getParamIndex
- * function will return a meaningful value.
- */
-fn CUInt isParamIndexValidParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_isParamIndexValid");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns zero-based parameter index in function prototype.
- */
-fn CUInt getParamIndexParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_getParamIndex");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns non-zero if parameter passing direction was specified explicitly in
- * the comment.
- */
-fn CUInt isDirectionExplicitParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_isDirectionExplicit");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns parameter passing direction.
- */
-fn CXCommentParamPassDirection getDirectionParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_getDirection");
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns template parameter name.
- */
-fn CXString getParamNameTParamCommandComment(
-  CXComment comment) 
-@extern("clang_TParamCommandComment_getParamName");
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns non-zero if the parameter that this AST node represents was found
- * in the template parameter list and
- * \c clang_TParamCommandComment_getDepth and
- * \c clang_TParamCommandComment_getIndex functions will return a meaningful
- * value.
- */
-fn CUInt isParamPositionValidTParamCommandComment(
-  CXComment comment) 
-@extern("clang_TParamCommandComment_isParamPositionValid");
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns zero-based nesting depth of this parameter in the template parameter list.
- *
- * For example,
- * \verbatim
- *     template<typename C, template<typename T> class TT>
- *     void test(TT<CInt> aaa);
- * \endverbatim
- * for C and TT nesting depth is 0,
- * for T nesting depth is 1.
- */
-fn CUInt getDepthTParamCommandComment(
-  CXComment comment) 
-@extern("clang_TParamCommandComment_getDepth");
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns zero-based parameter index in the template parameter list at a
- * given nesting depth.
- *
- * For example,
- * \verbatim
- *     template<typename C, template<typename T> class TT>
- *     void test(TT<CInt> aaa);
- * \endverbatim
- * for C and TT nesting depth is 0, so we can ask for index at depth 0:
- * at depth 0 C's index is 0, TT's index is 1.
- *
- * For T nesting depth is 1, so we can ask for index at depth 0 and 1:
- * at depth 0 T's index is 1 (same as TT's),
- * at depth 1 T's index is 0.
- */
-fn CUInt getIndexTParamCommandComment(
-  CXComment comment, 
-  CUInt depth) 
-@extern("clang_TParamCommandComment_getIndex");
-
-/**
- * \param Comment a \c CXComment_VerbatimBlockLine AST node.
- *
- * \returns text contained in the AST node.
- */
-fn CXString getTextVerbatimBlockLineComment(
-  CXComment comment) 
-@extern("clang_VerbatimBlockLineComment_getText");
-
-/**
- * \param Comment a \c CXComment_VerbatimLine AST node.
- *
- * \returns text contained in the AST node.
- */
-fn CXString getTextVerbatimLineComment(
-  CXComment comment) 
-@extern("clang_VerbatimLineComment_getText");
-
-/**
- * Convert an HTML tag AST node to string.
- *
- * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
- * node.
- *
- * \returns string containing an HTML tag.
- */
-fn CXString getAsStringHTMLTagComment(
-  CXComment comment) 
-@extern("clang_HTMLTagComment_getAsString");
-
-/**
- * Convert a given full parsed comment to an HTML fragment.
- *
- * Specific details of HTML layout are subject to change.  Don't try to parse
- * this HTML back into an AST, use other APIs instead.
- *
- * Currently the following CSS classes are used:
- * \li "para-brief" for \paragraph and equivalent commands;
- * \li "para-returns" for \\returns paragraph and equivalent commands;
- * \li "word-returns" for the "Returns" word in \\returns paragraph.
- *
- * Function argument documentation is rendered as a \<dl\> list with arguments
- * sorted in function prototype order.  CSS classes used:
- * \li "param-name-index-NUMBER" for parameter name (\<dt\>);
- * \li "param-descr-index-NUMBER" for parameter description (\<dd\>);
- * \li "param-name-index-invalid" and "param-descr-index-invalid" are used if
- * parameter index is invalid.
- *
- * Template parameter documentation is rendered as a \<dl\> list with
- * parameters sorted in template parameter list order.  CSS classes used:
- * \li "tparam-name-index-NUMBER" for parameter name (\<dt\>);
- * \li "tparam-descr-index-NUMBER" for parameter description (\<dd\>);
- * \li "tparam-name-index-other" and "tparam-descr-index-other" are used for
- * names inside template template parameters;
- * \li "tparam-name-index-invalid" and "tparam-descr-index-invalid" are used if
- * parameter position is invalid.
- *
- * \param Comment a \c CXComment_FullComment AST node.
- *
- * \returns string containing an HTML fragment.
- */
-fn CXString getAsHTMLFullComment(
-  CXComment comment) 
-@extern("clang_FullComment_getAsHTML");
-
-/**
- * Convert a given full parsed comment to an XML document.
- *
- * A Relax NG schema for the XML can be found in comment-xml-schema.rng file
- * inside clang source tree.
- *
- * \param Comment a \c CXComment_FullComment AST node.
- *
- * \returns string containing an XML document.
- */
-fn CXString getAsXMLFullComment(
-  CXComment comment) 
-@extern("clang_FullComment_getAsXML");
-
-/**
- * CXAPISet is an opaque type that represents a data structure containing all
- * the API information for a given translation unit. This can be used for a
- * single symbol symbol graph for a given symbol.
- */
-typedef CXAPISet = inline void*;
-
-/**
- * Traverses the translation unit to create a \c CXAPISet.
- *
- * \param tu is the \c CXTranslationUnit to build the \c CXAPISet for.
- *
- * \param out_api is a pointer to the output of this function. It is needs to be
- * disposed of by calling clang_disposeAPISet.
- *
- * \returns Error code indicating success or failure of the APISet creation.
- */
-fn CXErrorCode createAPISet(
-  CXTranslationUnit tu, 
-  CXAPISet* out_api) 
-@extern("clang_createAPISet");
-
-/**
- * Dispose of an APISet.
- *
- * The provided \c CXAPISet can not be used after this function is called.
- */
-fn void disposeAPISet(
-  CXAPISet api) 
-@extern("clang_disposeAPISet");
-
-/**
- * Generate a single symbol symbol graph for the given USR. Returns a null
- * string if the associated symbol can not be found in the provided \c CXAPISet.
- *
- * The output contains the symbol graph as well as some additional information
- * about related symbols.
- *
- * \param usr is a string containing the USR of the symbol to generate the
- * symbol graph for.
- *
- * \param api the \c CXAPISet to look for the symbol in.
- *
- * \returns a string containing the serialized symbol graph representation for
- * the symbol being queried or a null string if it can not be found in the
- * APISet.
- */
-fn CXString getSymbolGraphForUSR(
-  ZString usr, 
-  CXAPISet api) 
-@extern("clang_getSymbolGraphForUSR");
-
-/**
- * Generate a single symbol symbol graph for the declaration at the given
- * cursor. Returns a null string if the AST node for the cursor isn't a
- * declaration.
- *
- * The output contains the symbol graph as well as some additional information
- * about related symbols.
- *
- * \param cursor the declaration for which to generate the single symbol symbol
- * graph.
- *
- * \returns a string containing the serialized symbol graph representation for
- * the symbol being queried or a null string if it can not be found in the
- * APISet.
- */
-fn CXString getSymbolGraphForCursor(
-  CXCursor cursor) 
-@extern("clang_getSymbolGraphForCursor");
-
-
-/*-------------------------------*\
-|                                 |
-|     File FatalErrorHandler.h    |
-|                                 |
-\*-------------------------------*/
-
-/**
- * Installs error handler that prints error message to stderr and calls abort().
- * Replaces currently installed error handler (if any).
- */
-fn void installAbortingLLVMFatalErrorHandler() 
-@extern("clang_install_aborting_llvm_fatal_error_handler");
-
-/**
- * Removes currently installed error handler (if any).
- * If no error handler is intalled, the default strategy is to print error
- * message to stderr and call exit(1).
- */
-fn void uninstallLLVMFatalErrorHandler() 
-@extern("clang_uninstall_llvm_fatal_error_handler");
-
-
-/*-------------------------------*\
-|                                 |
-|         File Rewrite.h          |
-|                                 |
-\*-------------------------------*/
-
-typedef CXRewriter = void*;
-
-/**
- * Create CXRewriter.
- */
-fn CXRewriter create_Rewriter(
-  CXTranslationUnit tu) 
-@extern("clang_CXRewriter_create");
-
-/**
- * Insert the specified string at the specified location in the original buffer.
- */
-fn void insertTextBefore_Rewriter(
-  CXRewriter rew, 
-  CXSourceLocation loc, 
-  ZString insert) 
-@extern("clang_CXRewriter_insertTextBefore");
-
-/**
- * Replace the specified range of characters in the input with the specified
- * replacement.
- */
-fn void replaceText_Rewriter(
-  CXRewriter rew, 
-  CXSourceRange to_be_replaced, 
-  ZString replacement) 
-@extern("clang_CXRewriter_replaceText");
-
-/**
- * Remove the specified range.
- */
-fn void removeText_Rewriter(
-  CXRewriter rew, 
-  CXSourceRange to_be_removed) 
-@extern("clang_CXRewriter_removeText");
-
-/**
- * Save all changed files to disk.
- * Returns 1 if any files were not saved successfully, returns 0 otherwise.
- */
-fn CInt overwriteChangedFiles_Rewriter(
-  CXRewriter rew) 
-@extern("clang_CXRewriter_overwriteChangedFiles");
-
-/**
- * Write out rewritten version of the main file to stdout.
- */
-fn void writeMainFileToStdOut_Rewriter(
-  CXRewriter rew) 
-@extern("clang_CXRewriter_writeMainFileToStdOut");
-
-/**
- * Free the given CXRewriter.
- */
-fn void dispose_Rewriter(
-  CXRewriter rew) 
-@extern("clang_CXRewriter_dispose");
-
-
-/*-------------------------------*\
-|                                 |
-|          File Index.h           |
-|                                 |
-\*-------------------------------*/
-
-/**
- * An "index" that consists of a set of translation units that would
- * typically be linked together into an executable or library.
- */
-typedef CXIndex = inline void*;
-
-/**
- * An opaque type representing target information for a given translation
- * unit.
- */
-typedef CXTargetInfo = inline void*;
-
-/**
- * A single translation unit, which resides in an index.
- */
-typedef CXTranslationUnit = inline void*;
-
-/**
- * Opaque pointer representing client data that will be passed through
- * to various callbacks and visitors.
- */
-typedef CXClientData = inline void*;
-
-/**
- * Provides the contents of a file that has not yet been saved to disk.
- *
- * Each CXUnsavedFile instance provides the name of a file on the
- * system along with the current contents of that file that have not
- * yet been saved to disk.
- */
 struct CXUnsavedFile {
-  /*
-   * The file whose contents have not yet been saved.
-   *
-   * This file must already exist in the file system.
-   */
   ZString filename;
-
-  /*
-   * A buffer containing the unsaved contents of this file.
-   */
   ZString contents;
-
-  /* 
-   * The length of the unsaved contents of this buffer.
-   */
-  ulong length;
+  CULong length;
 }
 
-/**
- * Describes the availability of a particular entity, which indicates
- * whether the use of this entity will result in a warning or error due to
- * it being deprecated or unavailable.
- */
-typedef CXAvailabilityKind = inline CInt;
+constdef CXAvailabilityKind : CInt {
+  AVAILABILITY_AVAILABLE = 0,
+  AVAILABILITY_DEPRECATED = 1,
+  AVAILABILITY_NOT_AVAILABLE = 2,
+  AVAILABILITY_NOT_ACCESSIBLE = 3
+}
 
-/**
- * The entity is available.
- */
-const CXAvailabilityKind AVAILABILITY_AVAILABLE = 0;
-/*
- * The entity is available, but has been deprecated (and its use is
- * not recommended).
- */
-const CXAvailabilityKind AVAILABILITY_DEPRECATED = 1;
-/*
- * The entity is not available; any use of it will be an error.
- */
-const CXAvailabilityKind AVAILABILITY_NOT_AVAILABLE = 2;
-/*
- * The entity is available, but not accessible; any use of it will be
- * an error.
- */
-const CXAvailabilityKind AVAILABILITY_NOT_ACCESSIBLE = 3;
-
-/**
- * Describes a version number of the form major.minor.subminor.
- */
 struct CXVersion {
-  /*
-   * The major version number, e.g., the '10' in '10.7.3'. A negative
-   * value indicates that there is no version number at all.
-   */
   CInt major;
-
-  /*
-   * The minor version number, e.g., the '7' in '10.7.3'. This value
-   * will be negative if no minor version number was provided, e.g., for
-   * version '10'.
-   */
   CInt minor;
-
-  /*
-   * The subminor version number, e.g., the '3' in '10.7.3'. This value
-   * will be negative if no minor or subminor version number was provided,
-   * e.g., in version '10' or '10.7'.
-   */
   CInt subminor;
 }
 
-/**
- * Describes the exception specification of a cursor.
- *
- * A negative value indicates that the cursor is not a function declaration.
- */
-typedef CXCursor_ExceptionSpecificationKind = inline CInt;
-
-/**
- * The cursor has no exception specification.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_NONE = 0;
-/**
- * The cursor has exception specification throw()
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC_NONE = 1;
-/**
- * The cursor has exception specification throw(T1, T2)
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC = 2;
-/**
- * The cursor has exception specification throw(...).
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_MS_ANY = 3;
-/**
- * The cursor has exception specification basic noexcept.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_BASIC_NOEXCEPT = 4;
-/**
- * The cursor has exception specification computed noexcept.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_COMPUTED_NOEXCEPT = 5;
-/**
- * The exception specification has not yet been evaluated.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_UNEVALUATED = 6;
-/**
- * The exception specification has not yet been instantiated.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_UNINSTANTIATED = 7;
-/**
- * The exception specification has not been parsed yet.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_UNPARSED = 8;
-/**
- * The cursor has a __declspec(nothrow) exception specification.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_NO_THROW = 9;
-
-
-/**
- * Provides a shared context for creating translation units.
- *
- * It provides two options:
- *
- * - excludeDeclarationsFromPCH: When non-zero, allows enumeration of "local"
- * declarations (when loading any new translation units). A "local" declaration
- * is one that belongs in the translation unit itself and not in a precompiled
- * header that was used by the translation unit. If zero, all declarations
- * will be enumerated.
- *
- * Here is an example:
- *
- * \code
- *   // excludeDeclsFromPCH = 1, displayDiagnostics=1
- *   Idx = clang_createIndex(1, 1);
- *
- *   // IndexTest.pch was produced with the following command:
- *   // "clang -x c IndexTest.h -emit-ast -o IndexTest.pch"
- *   TU = clang_createTranslationUnit(Idx, "IndexTest.pch");
- *
- *   // This will load all the symbols from 'IndexTest.pch'
- *   clang_visitChildren(clang_getTranslationUnitCursor(TU),
- *                       TranslationUnitVisitor, 0);
- *   clang_disposeTranslationUnit(TU);
- *
- *   // This will load all the symbols from 'IndexTest.c', excluding symbols
- *   // from 'IndexTest.pch'.
- *   CChar *args[] = { "-Xclang", "-include-pch=IndexTest.pch" };
- *   TU = clang_createTranslationUnitFromSourceFile(Idx, "IndexTest.c", 2, args,
- *                                                  0, 0);
- *   clang_visitChildren(clang_getTranslationUnitCursor(TU),
- *                       TranslationUnitVisitor, 0);
- *   clang_disposeTranslationUnit(TU);
- * \endcode
- *
- * This process of creating the 'pch', loading it separately, and using it (via
- * -include-pch) allows 'excludeDeclsFromPCH' to remove redundant callbacks
- * (which gives the indexer the same performance benefit as the compiler).
- */
-fn CXIndex createIndex(
-  CInt excludeDeclarationsFromPCH, 
-  CInt displayDiagnostics) 
-@extern("clang_createIndex");
-
-/**
- * Destroy the given index.
- *
- * The index must not be destroyed until all of the translation units created
- * within that index have been destroyed.
- */
-fn void disposeIndex(
-  CXIndex index) 
-@extern("clang_disposeIndex");
-
-typedef CXChoice = inline CInt;
-
-/*
- * Use the default value of an option that may depend on the process
- * environment.
- */
-const CXChoice CHOICE_DEFAULT = 0;
-/*
- * Enable the option.
- */
-const CXChoice CHOICE_ENABLED = 1;
-/*
- * Disable the option.
- */
-const CXChoice CHOICE_DISABLED = 2;
-
-typedef CXGlobalOptFlags = inline CInt;
-/*
- * Used to indicate that no special CXIndex options are needed.
- */
-
-const CXGlobalOptFlags GLOBAL_OPT_FLAGS_NONE = 0x0;
-
-/*
- * Used to indicate that threads that libclang creates for indexing
- * purposes should use background priority.
- *
- * Affects #clang_indexSourceFile, #clang_indexTranslationUnit,
- * #clang_parseTranslationUnit, #clang_saveTranslationUnit.
- */
-const CXGlobalOptFlags GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_INDEXING = 0x1;
-/*
- * Used to indicate that threads that libclang creates for editing
- * purposes should use background priority.
- *
- * Affects #clang_reparseTranslationUnit, #clang_codeCompleteAt,
- * #clang_annotateTokens
- */
-const CXGlobalOptFlags GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_EDITING = 0x2;
-/*
- * Used to indicate that all threads that libclang creates should use
- * background priority.
- */
-const CXGlobalOptFlags GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_ALL = GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_INDEXING | GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_EDITING;
-
-
-/**
- * Index initialization options.
- *
- * 0 is the default value of each member of this struct except for Size.
- * Initialize the struct in one of the following three ways to avoid adapting
- * code each time a new member is added to it:
- * \code
- * CXIndexOptions Opts;
- * memset(&Opts, 0, sizeof(Opts));
- * Opts.Size = sizeof(CXIndexOptions);
- * \endcode
- * or explicitly initialize the first data member and zero-initialize the rest:
- * \code
- * CXIndexOptions Opts = { sizeof(CXIndexOptions) };
- * \endcode
- * or to prevent the -Wmissing-field-initializers warning for the above version:
- * \code
- * CXIndexOptions Opts{};
- * Opts.Size = sizeof(CXIndexOptions);
- * \endcode
- */
-struct CXIndexOptions {
-  /*
-   * The size of struct CXIndexOptions used for option versioning.
-   *
-   * Always initialize this member to sizeof(CXIndexOptions), or assign
-   * sizeof(CXIndexOptions) to it right after creating a CXIndexOptions object.
-   */
-  CUInt size;
-
-  /*
-   * A CXChoice enumerator that specifies the indexing priority policy.
-   * \sa CXGlobalOpt_ThreadBackgroundPriorityForIndexing
-   */
-  CChar thread_background_priority_for_indexing;
-
-  /*
-   * A CXChoice enumerator that specifies the editing priority policy.
-   * \sa CXGlobalOpt_ThreadBackgroundPriorityForEditing
-   */
-  CChar thread_background_priority_for_editing;
-
-  bitstruct : ushort {
-    /*
-     * \see clang_createIndex()
-     */
-    bool exclude_declarations_from_pch;
-
-    /*
-     * \see clang_createIndex()
-     */
-    bool display_diagnostics;
-
-    /*
-     * Store PCH in memory. If zero, PCH are stored in temporary files.
-     */
-    bool store_preambles_in_memory;
-  }
-
-  /*
-   * The path to a directory, in which to store temporary PCH files. If null or
-   * empty, the default system temporary directory is used. These PCH files are
-   * deleted on clean exit but stay on disk if the program crashes or is killed.
-   *
-   * This option is ignored if \a StorePreamblesInMemory is non-zero.
-   *
-   * Libclang does not create the directory at the specified path in the file
-   * system. Therefore it must exist, or storing PCH files will fail.
-   */
-  ZString preamble_storage_path;
-
-  /*
-   * Specifies a path which will contain log files for certain libclang
-   * invocations. A null value implies that libclang invocations are not logged.
-   */
-  ZString invocation_emission_path;
+constdef CXCursor_ExceptionSpecificationKind : CInt {
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_NONE = 0,
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC_NONE = 1,
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC = 2,
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_MS_ANY = 3,
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_BASIC_NOEXCEPT = 4,
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_COMPUTED_NOEXCEPT = 5,
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_UNEVALUATED = 6,
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_UNINSTANTIATED = 7,
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_UNPARSED = 8,
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_NO_THROW = 9
 }
 
-/**
- * Provides a shared context for creating translation units.
- *
- * Call this function instead of clang_createIndex() if you need to configure
- * the additional options in CXIndexOptions.
- *
- * \returns The created index or null in case of error, such as an unsupported
- * value of options->Size.
- *
- * For example:
- * \code
- * CXIndex createIndex(ZString ApplicationTemporaryPath) {
- *   const CInt ExcludeDeclarationsFromPCH = 1;
- *   const CInt DisplayDiagnostics = 1;
- *   CXIndex Idx;
- * #if CINDEX_VERSION_MINOR >= 64
- *   CXIndexOptions Opts;
- *   memset(&Opts, 0, sizeof(Opts));
- *   Opts.Size = sizeof(CXIndexOptions);
- *   Opts.ThreadBackgroundPriorityForIndexing = 1;
- *   Opts.ExcludeDeclarationsFromPCH = ExcludeDeclarationsFromPCH;
- *   Opts.DisplayDiagnostics = DisplayDiagnostics;
- *   Opts.PreambleStoragePath = ApplicationTemporaryPath;
- *   Idx = clang_createIndexWithOptions(&Opts);
- *   if (Idx)
- *     return Idx;
- *   fprintf(stderr,
- *           "clang_createIndexWithOptions() failed. "
- *           "CINDEX_VERSION_MINOR = %d, sizeof(CXIndexOptions) = %u\n",
- *           CINDEX_VERSION_MINOR, Opts.Size);
- * #else
- *   (void)ApplicationTemporaryPath;
- * #endif
- *   Idx = clang_createIndex(ExcludeDeclarationsFromPCH, DisplayDiagnostics);
- *   clang_CXIndex_setGlobalOptions(
- *       Idx, clang_CXIndex_getGlobalOptions(Idx) |
- *                CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
- *   return Idx;
- * }
- * \endcode
- *
- * \sa clang_createIndex()
- */
-fn CXIndex createIndexWithOptions(
-  CXIndexOptions *options) 
-@extern("clang_createIndexWithOptions");
+extern fn CXIndex createIndex(
+  CInt exclude_declarations_from_pch,
+  CInt display_diagnostics)
+@cname("clang_createIndex");
 
-/**
- * Sets general options associated with a CXIndex.
- *
- * This function is DEPRECATED. Set
- * CXIndexOptions::ThreadBackgroundPriorityForIndexing and/or
- * CXIndexOptions::ThreadBackgroundPriorityForEditing and call
- * clang_createIndexWithOptions() instead.
- *
- * For example:
- * \code
- * CXIndex idx = ...;
- * clang_CXIndex_setGlobalOptions(idx,
- *     clang_CXIndex_getGlobalOptions(idx) |
- *     CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
- * \endcode
- *
- * \param options A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags.
- */
-fn void setGlobalOptions_Index(
-  CXIndex index,
-  CUInt options) 
-@extern("clang_CXIndex_setGlobalOptions")
-@deprecated("Set CXIndexOptions::ThreadBackgroundPriorityForIndexing and/or CXIndexOptions::ThreadBackgroundPriorityForEditing and call clang_createIndexWithOptions() instead.");
-
-/**
- * Gets the general options associated with a CXIndex.
- *
- * This function allows to obtain the final option values used by libclang after
- * specifying the option policies via CXChoice enumerators.
- *
- * \returns A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags that
- * are associated with the given CXIndex object.
- */
-fn CUInt getGlobalOptions_Index(
+extern fn void disposeIndex(
   CXIndex index)
-@extern("clang_CXIndex_getGlobalOptions");
+@cname("clang_disposeIndex");
 
-/**
- * Sets the invocation emission path option in a CXIndex.
- *
- * This function is DEPRECATED. Set CXIndexOptions::InvocationEmissionPath and
- * call clang_createIndexWithOptions() instead.
- *
- * The invocation emission path specifies a path which will contain log
- * files for certain libclang invocations. A null value (default) implies that
- * libclang invocations are not logged..
- */
-fn void setInvocationEmissionPathOption_Index(
-  CXIndex self, 
-  ZString path) 
-@extern("clang_CXIndex_setInvocationEmissionPathOption")
-@deprecated("Set CXIndexOptions::InvocationEmissionPath and call clang_createIndexWithOptions() instead.");
+constdef CXChoice : CInt {
+  CHOICE_DEFAULT = 0,
+  CHOICE_ENABLED = 1,
+  CHOICE_DISABLED = 2
+}
 
-/**
- * Determine whether the given header is guarded against
- * multiple inclusions, either with the conventional
- * \#ifndef/\#define/\#endif macro guards or with \#pragma once.
- */
-fn CUInt isFileMultipleIncludeGuarded(
-  CXTranslationUnit tu, 
-  CXFile file) 
-@extern("clang_isFileMultipleIncludeGuarded");
+constdef CXGlobalOptFlags : CInt {
+  GLOBAL_OPT_NONE = 0,
+  GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_INDEXING = 1,
+  GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_EDITING = 2,
+  GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_ALL = 3
+}
 
-/**
- * Retrieve a file handle within the given translation unit.
- *
- * \param tu the translation unit
- *
- * \param file_name the name of the file.
- *
- * \returns the file handle for the named file in the translation unit \p tu,
- * or a NULL file handle if the file was not a part of this translation unit.
- */
-fn CXFile getFile(
-  CXTranslationUnit tu, 
-  ZString file_name) 
-@extern("clang_getFile");
+struct CXIndexOptions {
+  CUInt size;
+  char thread_background_priority_for_indexing;
+  char thread_background_priority_for_editing;
+  bitstruct : ushort {
+    CUInt exclude_declarations_from_pch : 0..0;
+    CUInt display_diagnostics : 1..1;
+    CUInt store_preambles_in_memory : 2..2;
+    CUInt x : 3..15;
+  }
+  ZString* preamble_storage_path;
+  ZString* invocation_emission_path;
+}
 
-/**
- * Retrieve the buffer associated with the given file.
- *
- * \param tu the translation unit
- *
- * \param file the file for which to retrieve the buffer.
- *
- * \param size [out] if non-NULL, will be set to the size of the buffer.
- *
- * \returns a pointer to the buffer in memory that holds the contents of
- * \p file, or a NULL pointer when the file is not loaded.
- */
-fn ZString getFileContents(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  usz *size) 
-@extern("clang_getFileContents");
+extern fn CXIndex createIndexWithOptions(
+  CXIndexOptions* options)
+@cname("clang_createIndexWithOptions");
 
-/**
- * Retrieves the source location associated with a given file/line/column
- * in a particular translation unit.
- */
-fn CXSourceLocation getLocation(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  CUInt line, 
-  CUInt column) 
-@extern("clang_getLocation");
+extern fn void cXIndex_setGlobalOptions(
+  CXIndex,
+  CUInt options)
+@cname("clang_CXIndex_setGlobalOptions");
 
-/**
- * Retrieves the source location associated with a given character offset
- * in a particular translation unit.
- */
-fn CXSourceLocation getLocationForOffset(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  CUInt offset) 
-@extern("clang_getLocationForOffset");
+extern fn CUInt cXIndex_getGlobalOptions(
+  CXIndex)
+@cname("clang_CXIndex_getGlobalOptions");
 
-/**
- * Retrieve all ranges that were skipped by the preprocessor.
- *
- * The preprocessor will skip lines when they are surrounded by an
- * if/ifdef/ifndef directive whose condition does not evaluate to true.
- */
-fn CXSourceRangeList* getSkippedRanges(
-  CXTranslationUnit tu, 
-  CXFile file) 
-@extern("clang_getSkippedRanges");
+extern fn void cXIndex_setInvocationEmissionPathOption(
+  CXIndex,
+  ZString* path)
+@cname("clang_CXIndex_setInvocationEmissionPathOption");
 
-/**
- * Retrieve all ranges from all files that were skipped by the
- * preprocessor.
- *
- * The preprocessor will skip lines when they are surrounded by an
- * if/ifdef/ifndef directive whose condition does not evaluate to true.
- */
-fn CXSourceRangeList* getAllSkippedRanges(
-  CXTranslationUnit tu) 
-@extern("clang_getAllSkippedRanges");
+extern fn CUInt isFileMultipleIncludeGuarded(
+  CXTranslationUnit tu,
+  CXFile file)
+@cname("clang_isFileMultipleIncludeGuarded");
 
-/**
- * Determine the number of diagnostics produced for the given
- * translation unit.
- */
-fn CUInt getNumDiagnostics(
-  CXTranslationUnit unit) 
-@extern("clang_getNumDiagnostics");
+extern fn CXFile getFile(
+  CXTranslationUnit tu,
+  ZString file_name)
+@cname("clang_getFile");
 
-/**
- * Retrieve a diagnostic associated with the given translation unit.
- *
- * \param Unit the translation unit to query.
- * \param Index the zero-based diagnostic number to retrieve.
- *
- * \returns the requested diagnostic. This diagnostic must be freed
- * via a call to \c clang_disposeDiagnostic().
- */
-fn CXDiagnostic getDiagnostic(
-  CXTranslationUnit unit, 
-  CUInt index) 
-@extern("clang_getDiagnostic");
+extern fn ZString getFileContents(
+  CXTranslationUnit tu,
+  CXFile file,
+  usz* size)
+@cname("clang_getFileContents");
 
-/**
- * Retrieve the complete set of diagnostics associated with a
- *        translation unit.
- *
- * \param Unit the translation unit to query.
- */
-fn CXDiagnosticSet getDiagnosticSetFromTU(
-  CXTranslationUnit unit) 
-@extern("clang_getDiagnosticSetFromTU");
+extern fn CXSourceLocation getLocation(
+  CXTranslationUnit tu,
+  CXFile file,
+  CUInt line,
+  CUInt column)
+@cname("clang_getLocation");
 
-/**
- * Get the original translation unit source file name.
- */
-fn CXString getTranslationUnitSpelling(
-  CXTranslationUnit ct_unit) 
-@extern("clang_getTranslationUnitSpelling");
+extern fn CXSourceLocation getLocationForOffset(
+  CXTranslationUnit tu,
+  CXFile file,
+  CUInt offset)
+@cname("clang_getLocationForOffset");
 
-/**
- * Return the CXTranslationUnit for a given source file and the provided
- * command line arguments one would pass to the compiler.
- *
- * Note: The 'source_filename' argument is optional.  If the caller provides a
- * NULL pointer, the name of the source file is expected to reside in the
- * specified command line arguments.
- *
- * Note: When encountered in 'clang_command_line_args', the following options
- * are ignored:
- *
- *   '-c'
- *   '-emit-ast'
- *   '-fsyntax-only'
- *   '-o \<output file>'  (both '-o' and '\<output file>' are ignored)
- *
- * \param CIdx The index object with which the translation unit will be
- * associated.
- *
- * \param source_filename The name of the source file to load, or NULL if the
- * source file is included in \p clang_command_line_args.
- *
- * \param num_clang_command_line_args The number of command-line arguments in
- * \p clang_command_line_args.
- *
- * \param clang_command_line_args The command-line arguments that would be
- * passed to the \c clang executable if it were being invoked out-of-process.
- * These command-line options will be parsed and will affect how the translation
- * unit is parsed. Note that the following options are ignored: '-c',
- * '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
- *
- * \param num_unsaved_files the number of unsaved file entries in \p
- * unsaved_files.
- *
- * \param unsaved_files the files that have not yet been saved to disk
- * but may be required for code completion, including the contents of
- * those files.  The contents and name of these files (as specified by
- * CXUnsavedFile) are copied when necessary, so the client only needs to
- * guarantee their validity until the call to this function returns.
- */
-fn CXTranslationUnit createTranslationUnitFromSourceFile(
-  CXIndex c_idx, 
-  ZString source_filename, 
-  CInt num_clang_command_line_args, 
-  ZString* clang_command_line_args, 
-  CUInt num_unsaved_files, 
-  CXUnsavedFile* unsaved_files) 
-@extern("clang_createTranslationUnitFromSourceFile");
+extern fn CXSourceRangeList* getSkippedRanges(
+  CXTranslationUnit tu,
+  CXFile file)
+@cname("clang_getSkippedRanges");
 
-/**
- * Same as \c clang_createTranslationUnit2, but returns
- * the \c CXTranslationUnit instead of an error code.  In case of an error this
- * routine returns a \c NULL \c CXTranslationUnit, without further detailed
- * error codes.
- */
-fn CXTranslationUnit createTranslationUnit(
-  CXIndex c_idx, 
-  ZString ast_filename) 
-@extern("clang_createTranslationUnit");
-
-/**
- * Create a translation unit from an AST file (\c -emit-ast).
- *
- * \param[out] out_TU A non-NULL pointer to store the created
- * \c CXTranslationUnit.
- *
- * \returns Zero on success, otherwise returns an error code.
- */
-fn CXErrorCode createTranslationUnit2(
-  CXIndex c_idx, 
-  ZString ast_filename, 
-  CXTranslationUnit* out_tu) 
-@extern("clang_createTranslationUnit2");
-
-/**
- * Flags that control the creation of translation units.
- *
- * The enumerators in this enumeration type are meant to be bitwise
- * ORed together to specify which options should be used when
- * constructing the translation unit.
- */
-typedef CXTranslationUnit_Flags = inline CInt;
-
-/*
- * Used to indicate that no special translation-unit options are
- * needed.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_NONE = 0x0;
-/*
- * Used to indicate that the parser should construct a "detailed"
- * preprocessing record, including all macro definitions and instantiations.
- *
- * Constructing a detailed preprocessing record requires more memory
- * and time to parse, since the information contained in the record
- * is usually not retained. However, it can be useful for
- * applications that require more detailed information about the
- * behavior of the preprocessor.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD = 0x01;
-/*
- * Used to indicate that the translation unit is incomplete.
- *
- * When a translation unit is considered "incomplete", semantic
- * analysis that is typically performed at the end of the
- * translation unit will be suppressed. For example, this suppresses
- * the completion of tentative declarations in C and of
- * instantiation of implicitly-instantiation function templates in
- * C++. This option is typically used when parsing a header with the
- * intent of producing a precompiled header.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_INCOMPLETE = 0x02;
-/*
- * Used to indicate that the translation unit should be built with an
- * implicit precompiled header for the preamble.
- *
- * An implicit precompiled header is used as an optimization when a
- * particular translation unit is likely to be reparsed many times
- * when the sources aren't changing that often. In this case, an
- * implicit precompiled header will be built containing all of the
- * initial includes at the top of the main file (what we refer to as
- * the "preamble" of the file). In subsequent parses, if the
- * preamble or the files in it have not changed, \c
- * clang_reparseTranslationUnit() will re-use the implicit
- * precompiled header to improve parsing performance.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_PRECOMPILED_PREAMBLE = 0x04;
-/*
- * Used to indicate that the translation unit should cache some
- * code-completion results with each reparse of the source file.
- *
- * Caching of code-completion results is a performance optimization that
- * introduces some overhead to reparsing but improves the performance of
- * code-completion operations.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_CACHE_COMPLETION_RESULTS = 0x08;
-/*
- * Used to indicate that the translation unit will be serialized with
- * \c clang_saveTranslationUnit.
- *
- * This option is typically used when parsing a header with the intent of
- * producing a precompiled header.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_FOR_SERIALIZATION = 0x10;
-/*
- * DEPRECATED: Enabled chained precompiled preambles in C++.
- *
- * Note: this is a *temporary* option that is available only while
- * we are testing C++ precompiled preamble support. It is deprecated.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_CXX_CHAINED_PCH = 0x20;
-/*
- * Used to indicate that function/method bodies should be skipped while
- * parsing.
- *
- * This option can be used to search for declarations/definitions while
- * ignoring the usages.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_SKIP_FUNCTION_BODIES = 0x40;
-/*
- * Used to indicate that brief documentation comments should be
- * included into the set of code completions returned from this translation
- * unit.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_INCLUDE_BRIEF_COMMENTS_IN_CODE_COMPLETION = 0x80;
-/*
- * Used to indicate that the precompiled preamble should be created on
- * the first parse. Otherwise it will be created on the first reparse. This
- * trades runtime on the first parse (serializing the preamble takes time) for
- * reduced runtime on the second parse (can now reuse the preamble).
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_CREATE_PREAMBLE_ON_FIRST_PARSE = 0x100;
-/*
- * Do not stop processing when fatal errors are encountered.
- *
- * When fatal errors are encountered while parsing a translation unit,
- * semantic analysis is typically stopped early when compiling code. A common
- * source for fatal errors are unresolvable include files. For the
- * purposes of an IDE, this is undesirable behavior and as much information
- * as possible should be reported. Use this flag to enable this behavior.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_KEEP_GOING = 0x200;
-/*
- * Sets the preprocessor in a mode for parsing a single file only.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_SINGLE_FILE_PARSE = 0x400;
-/*
- * Used in combination with CXTranslationUnit_SkipFunctionBodies to
- * constrain the skipping of function bodies to the preamble.
- *
- * The function bodies of the main file are not skipped.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_LIMIT_SKIP_FUNCTION_BODIES_TO_PREAMBLE = 0x800;
-/*
- * Used to indicate that attributed types should be included in CXType.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_INCLUDE_ATTRIBUTED_TYPES = 0x1000;
-/*
- * Used to indicate that implicit attributes should be visited.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_VISIT_IMPLICIT_ATTRIBUTES = 0x2000;
-/*
- * Used to indicate that non-errors from included files should be ignored.
- *
- * If set, clang_getDiagnosticSetFromTU() will not report e.g. warnings from
- * included files anymore. This speeds up clang_getDiagnosticSetFromTU() for
- * the case where these warnings are not of interest, as for an IDE for
- * example, which typically shows only the diagnostics in the main file.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES = 0x4000;
-/*
- * Tells the preprocessor not to skip excluded conditional blocks.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_RETAIN_EXCLUDED_CONDITIONAL_BLOCKS = 0x8000;
-
-/**
- * Returns the set of flags that is suitable for parsing a translation
- * unit that is being edited.
- *
- * The set of flags returned provide options for \c clang_parseTranslationUnit()
- * to indicate that the translation unit is likely to be reparsed many times,
- * either explicitly (via \c clang_reparseTranslationUnit()) or implicitly
- * (e.g., by code completion (\c clang_codeCompletionAt())). The returned flag
- * set contains an unspecified set of optimizations (e.g., the precompiled
- * preamble) geared toward improving the performance of these routines. The
- * set of optimizations enabled may change from one version to the next.
- */
-fn CUInt defaultEditingTranslationUnitOptions() 
-@extern("clang_defaultEditingTranslationUnitOptions");
-
-/**
- * Same as \c clang_parseTranslationUnit2, but returns
- * the \c CXTranslationUnit instead of an error code.  In case of an error this
- * routine returns a \c NULL \c CXTranslationUnit, without further detailed
- * error codes.
- */
-fn CXTranslationUnit parseTranslationUnit(
-  CXIndex cidx, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CUInt options) 
-@extern("clang_parseTranslationUnit");
-
-/**
- * Parse the given source file and the translation unit corresponding
- * to that file.
- *
- * This routine is the main entry poCInt for the Clang C API, providing the
- * ability to parse a source file into a translation unit that can then be
- * queried by other functions in the API. This routine accepts a set of
- * command-line arguments so that the compilation can be configured in the same
- * way that the compiler is configured on the command line.
- *
- * \param CIdx The index object with which the translation unit will be
- * associated.
- *
- * \param source_filename The name of the source file to load, or NULL if the
- * source file is included in \c command_line_args.
- *
- * \param command_line_args The command-line arguments that would be
- * passed to the \c clang executable if it were being invoked out-of-process.
- * These command-line options will be parsed and will affect how the translation
- * unit is parsed. Note that the following options are ignored: '-c',
- * '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
- *
- * \param num_command_line_args The number of command-line arguments in
- * \c command_line_args.
- *
- * \param unsaved_files the files that have not yet been saved to disk
- * but may be required for parsing, including the contents of
- * those files.  The contents and name of these files (as specified by
- * CXUnsavedFile) are copied when necessary, so the client only needs to
- * guarantee their validity until the call to this function returns.
- *
- * \param num_unsaved_files the number of unsaved file entries in \p
- * unsaved_files.
- *
- * \param options A bitmask of options that affects how the translation unit
- * is managed but not its compilation. This should be a bitwise OR of the
- * CXTranslationUnit_XXX flags.
- *
- * \param[out] out_TU A non-NULL pointer to store the created
- * \c CXTranslationUnit, describing the parsed code and containing any
- * diagnostics produced by the compiler.
- *
- * \returns Zero on success, otherwise returns an error code.
- */
-fn CXErrorCode parseTranslationUnit2(
-  CXIndex c_idx, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CUInt options, 
-  CXTranslationUnit* out_TU)
-@extern("clang_parseTranslationUnit2");
-
-/**
- * Same as clang_parseTranslationUnit2 but requires a full command line
- * for \c command_line_args including argv[0]. This is useful if the standard
- * library paths are relative to the binary.
- */
-fn CXErrorCode parseTranslationUnit2FullArgv(
-  CXIndex c_idx, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CUInt options, 
-  CXTranslationUnit* out_TU) 
-@extern("clang_parseTranslationUnit2FullArgv");
-
-/**
- * Flags that control how translation units are saved.
- *
- * The enumerators in this enumeration type are meant to be bitwise
- * ORed together to specify which options should be used when
- * saving the translation unit.
- */
-typedef CXSaveTranslationUnit_Flags = inline CInt;
-
-/*
- * Used to indicate that no special saving options are needed.
- */
-const CXSaveTranslationUnit_Flags SAVE_TRANSLATION_UNIT_NONE = 0x0;
-
-/**
- * Returns the set of flags that is suitable for saving a translation
- * unit.
- *
- * The set of flags returned provide options for
- * \c clang_saveTranslationUnit() by default. The returned flag
- * set contains an unspecified set of options that save translation units with
- * the most commonly-requested data.
- */
-fn CUInt defaultSaveOptions(
-  CXTranslationUnit tu) 
-@extern("clang_defaultSaveOptions");
-
-/**
- * Describes the kind of error that occurred (if any) in a call to
- * \c clang_saveTranslationUnit().
- */
-typedef CXSaveError = inline CInt; 
-
-/*
- * Indicates that no error occurred while saving a translation unit.
- */
-const CXSaveError SAVE_ERROR_NONE = 0;
-/*
- * Indicates that an unknown error occurred while attempting to save
- * the file.
- *
- * This error typically indicates that file I/O failed when attempting to
- * write the file.
- */
-const CXSaveError SAVE_ERROR_UNKNOWN = 1;
-/*
- * Indicates that errors during translation prevented this attempt
- * to save the translation unit.
- *
- * Errors that prevent the translation unit from being saved can be
- * extracted using \c clang_getNumDiagnostics() and \c clang_getDiagnostic().
- */
-const CXSaveError SAVE_ERROR_TRANSLATION_ERRORS = 2;
-/*
- * Indicates that the translation unit to be saved was somehow
- * invalid (e.g., NULL).
- */
-const CXSaveError SAVE_ERROR_INVALID_TU = 3;
-
-/**
- * Saves a translation unit into a serialized representation of
- * that translation unit on disk.
- *
- * Any translation unit that was parsed without error can be saved
- * into a file. The translation unit can then be deserialized into a
- * new \c CXTranslationUnit with \c clang_createTranslationUnit() or,
- * if it is an incomplete translation unit that corresponds to a
- * header, used as a precompiled header when parsing other translation
- * units.
- *
- * \param TU The translation unit to save.
- *
- * \param FileName The file to which the translation unit will be saved.
- *
- * \param options A bitmask of options that affects how the translation unit
- * is saved. This should be a bitwise OR of the
- * CXSaveTranslationUnit_XXX flags.
- *
- * \returns A value that will match one of the enumerators of the CXSaveError
- * enumeration. Zero (CXSaveError_None) indicates that the translation unit was
- * saved successfully, while a non-zero value indicates that a problem occurred.
- */
-fn CInt saveTranslationUnit(
-  CXTranslationUnit tu, 
-  ZString file_name, 
-  CUInt options) 
-@extern("clang_saveTranslationUnit");
-
-/**
- * Suspend a translation unit in order to free memory associated with it.
- *
- * A suspended translation unit uses significantly less memory but on the other
- * side does not support any other calls than \c clang_reparseTranslationUnit
- * to resume it or \c clang_disposeTranslationUnit to dispose it completely.
- */
-fn CUInt suspendTranslationUnit(
+extern fn CXSourceRangeList* getAllSkippedRanges(
   CXTranslationUnit tu)
-@extern("clang_suspendTranslationUnit");
+@cname("clang_getAllSkippedRanges");
 
-/**
- * Destroy the specified CXTranslationUnit object.
- */
-fn void disposeTranslationUnit(
-  CXTranslationUnit tu) 
-@extern("clang_disposeTranslationUnit");
+extern fn CUInt getNumDiagnostics(
+  CXTranslationUnit unit)
+@cname("clang_getNumDiagnostics");
 
-/**
- * Flags that control the reparsing of translation units.
- *
- * The enumerators in this enumeration type are meant to be bitwise
- * ORed together to specify which options should be used when
- * reparsing the translation unit.
- */
-typedef CXReparse_Flags = inline CInt;
+extern fn CXDiagnostic getDiagnostic(
+  CXTranslationUnit unit,
+  CUInt index)
+@cname("clang_getDiagnostic");
 
-const CXReparse_Flags REPARSE_FLAGS_NONE = 0x0;
+extern fn CXDiagnosticSet getDiagnosticSetFromTU(
+  CXTranslationUnit unit)
+@cname("clang_getDiagnosticSetFromTU");
 
-/**
- * Returns the set of flags that is suitable for reparsing a translation
- * unit.
- *
- * The set of flags returned provide options for
- * \c clang_reparseTranslationUnit() by default. The returned flag
- * set contains an unspecified set of optimizations geared toward common uses
- * of reparsing. The set of optimizations enabled may change from one version
- * to the next.
- */
-fn CUInt defaultReparseOptions(
-  CXTranslationUnit tu) 
-@extern("clang_defaultReparseOptions");
+extern fn CXString getTranslationUnitSpelling(
+  CXTranslationUnit ct_unit)
+@cname("clang_getTranslationUnitSpelling");
 
-/**
- * Reparse the source files that produced this translation unit.
- *
- * This routine can be used to re-parse the source files that originally
- * created the given translation unit, for example because those source files
- * have changed (either on disk or as passed via \p unsaved_files). The
- * source code will be reparsed with the same command-line options as it
- * was originally parsed.
- *
- * Reparsing a translation unit invalidates all cursors and source locations
- * that refer into that translation unit. This makes reparsing a translation
- * unit semantically equivalent to destroying the translation unit and then
- * creating a new translation unit with the same command-line arguments.
- * However, it may be more efficient to reparse a translation
- * unit using this routine.
- *
- * \param TU The translation unit whose contents will be re-parsed. The
- * translation unit must originally have been built with
- * \c clang_createTranslationUnitFromSourceFile().
- *
- * \param num_unsaved_files The number of unsaved file entries in \p
- * unsaved_files.
- *
- * \param unsaved_files The files that have not yet been saved to disk
- * but may be required for parsing, including the contents of
- * those files.  The contents and name of these files (as specified by
- * CXUnsavedFile) are copied when necessary, so the client only needs to
- * guarantee their validity until the call to this function returns.
- *
- * \param options A bitset of options composed of the flags in CXReparse_Flags.
- * The function \c clang_defaultReparseOptions() produces a default set of
- * options recommended for most uses, based on the translation unit.
- *
- * \returns 0 if the sources could be reparsed.  A non-zero error code will be
- * returned if reparsing was impossible, such that the translation unit is
- * invalid. In such cases, the only valid call for \c TU is
- * \c clang_disposeTranslationUnit(TU).  The error codes returned by this
- * routine are described by the \c CXErrorCode enum.
- */
-fn CInt reparseTranslationUnit(
-  CXTranslationUnit tu, 
-  CUInt num_unsaved_files,  
-  CXUnsavedFile *unsaved_files, 
-  CUInt options) 
-@extern("clang_reparseTranslationUnit");
+extern fn CXTranslationUnit createTranslationUnitFromSourceFile(
+  CXIndex c_idx,
+  ZString source_filename,
+  CInt num_clang_command_line_args,
+  ZString* clang_command_line_args,
+  CUInt num_unsaved_files,
+  CXUnsavedFile* unsaved_files)
+@cname("clang_createTranslationUnitFromSourceFile");
 
-/**
- * Categorizes how memory is being used by a translation unit.
- */
-typedef CXTUResourceUsageKind = inline CInt; 
+extern fn CXTranslationUnit createTranslationUnit(
+  CXIndex c_idx,
+  ZString ast_filename)
+@cname("clang_createTranslationUnit");
 
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_AST = 1;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_IDENTIFIERS = 2;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SELECTORS = 3;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_GLOBAL_COMPLETION_RESULTS = 4;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SOURCE_MANAGER_CONTENT_CACHE = 5;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_AST_SIDE_TABLES = 6;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_MALLOC = 7;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_MMAP = 8;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_MALLOC = 9;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_MMAP = 10;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_PREPROCESSOR = 11;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_PREPROCESSING_RECORD = 12;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SOURCE_MANAGER_DATA_STRUCTURES = 13;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH = 14;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_MEMORY_IN_BYTES_BEGIN = TU_RESOURCE_USAGE_AST;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_MEMORY_IN_BYTES_END = TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_FIRST = TU_RESOURCE_USAGE_AST;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_LAST = TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH;
+extern fn CXErrorCode createTranslationUnit2(
+  CXIndex c_idx,
+  ZString ast_filename,
+  CXTranslationUnit* out_tu)
+@cname("clang_createTranslationUnit2");
 
-/**
- * Returns the human-readable null-terminated C string that represents
- *  the name of the memory category.  This string should never be freed.
- */
-fn
-ZString getTUResourceUsageName(
-  CXTUResourceUsageKind kind) 
-@extern("clang_getTUResourceUsageName");
+constdef CXTranslationUnit_Flags : CInt {
+  TRANSLATION_UNIT_NONE = 0,
+  TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD = 1,
+  TRANSLATION_UNIT_INCOMPLETE = 2,
+  TRANSLATION_UNIT_PRECOMPILED_PREAMBLE = 4,
+  TRANSLATION_UNIT_CACHE_COMPLETION_RESULTS = 8,
+  TRANSLATION_UNIT_FOR_SERIALIZATION = 16,
+  TRANSLATION_UNIT_CXX_CHAINED_PCH = 32,
+  TRANSLATION_UNIT_SKIP_FUNCTION_BODIES = 64,
+  TRANSLATION_UNIT_INCLUDE_BRIEF_COMMENTS_IN_CODE_COMPLETION = 128,
+  TRANSLATION_UNIT_CREATE_PREAMBLE_ON_FIRST_PARSE = 256,
+  TRANSLATION_UNIT_KEEP_GOING = 512,
+  TRANSLATION_UNIT_SINGLE_FILE_PARSE = 1024,
+  TRANSLATION_UNIT_LIMIT_SKIP_FUNCTION_BODIES_TO_PREAMBLE = 2048,
+  TRANSLATION_UNIT_INCLUDE_ATTRIBUTED_TYPES = 4096,
+  TRANSLATION_UNIT_VISIT_IMPLICIT_ATTRIBUTES = 8192,
+  TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES = 16384,
+  TRANSLATION_UNIT_RETAIN_EXCLUDED_CONDITIONAL_BLOCKS = 32768
+}
+
+extern fn CUInt defaultEditingTranslationUnitOptions()
+@cname("clang_defaultEditingTranslationUnitOptions");
+
+extern fn CXTranslationUnit parseTranslationUnit(
+  CXIndex c_idx,
+  ZString source_filename,
+  ZString* command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CUInt options)
+@cname("clang_parseTranslationUnit");
+
+extern fn CXErrorCode parseTranslationUnit2(
+  CXIndex c_idx,
+  ZString source_filename,
+  ZString* command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CUInt options,
+  CXTranslationUnit* out_tu)
+@cname("clang_parseTranslationUnit2");
+
+extern fn CXErrorCode parseTranslationUnit2FullArgv(
+  CXIndex c_idx,
+  ZString source_filename,
+  CChar** command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CUInt options,
+  CXTranslationUnit* out_tu)
+@cname("clang_parseTranslationUnit2FullArgv");
+
+constdef CXSaveTranslationUnit_Flags : CInt {
+  SAVE_TRANSLATION_UNIT_NONE = 0
+}
+
+extern fn CUInt defaultSaveOptions(
+  CXTranslationUnit tu)
+@cname("clang_defaultSaveOptions");
+
+constdef CXSaveError : CInt {
+  SAVE_ERROR_NONE = 0,
+  SAVE_ERROR_UNKNOWN = 1,
+  SAVE_ERROR_TRANSLATION_ERRORS = 2,
+  SAVE_ERROR_INVALID_TU = 3
+}
+
+extern fn CInt saveTranslationUnit(
+  CXTranslationUnit tu,
+  ZString file_name,
+  CUInt options)
+@cname("clang_saveTranslationUnit");
+
+extern fn CUInt suspendTranslationUnit(
+  CXTranslationUnit)
+@cname("clang_suspendTranslationUnit");
+
+extern fn void disposeTranslationUnit(
+  CXTranslationUnit)
+@cname("clang_disposeTranslationUnit");
+
+constdef CXReparse_Flags : CInt {
+  REPARSE_NONE = 0
+}
+
+extern fn CUInt defaultReparseOptions(
+  CXTranslationUnit tu)
+@cname("clang_defaultReparseOptions");
+
+extern fn CInt reparseTranslationUnit(
+  CXTranslationUnit tu,
+  CUInt num_unsaved_files,
+  CXUnsavedFile* unsaved_files,
+  CUInt options)
+@cname("clang_reparseTranslationUnit");
+
+constdef CXTUResourceUsageKind : CInt {
+  TU_RESOURCE_USAGE_AST = 1,
+  TU_RESOURCE_USAGE_IDENTIFIERS = 2,
+  TU_RESOURCE_USAGE_SELECTORS = 3,
+  TU_RESOURCE_USAGE_GLOBAL_COMPLETION_RESULTS = 4,
+  TU_RESOURCE_USAGE_SOURCE_MANAGER_CONTENT_CACHE = 5,
+  TU_RESOURCE_USAGE_AST_SIDE_TABLES = 6,
+  TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_MALLOC = 7,
+  TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_M_MAP = 8,
+  TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_MALLOC = 9,
+  TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_M_MAP = 10,
+  TU_RESOURCE_USAGE_PREPROCESSOR = 11,
+  TU_RESOURCE_USAGE_PREPROCESSING_RECORD = 12,
+  TU_RESOURCE_USAGE_SOURCE_MANAGER_DATA_STRUCTURES = 13,
+  TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH = 14,
+  TU_RESOURCE_USAGE_MEMORY_IN_BYTES_BEGIN = 1,
+  TU_RESOURCE_USAGE_MEMORY_IN_BYTES_END = 14,
+  TU_RESOURCE_USAGE_FIRST = 1,
+  TU_RESOURCE_USAGE_LAST = 14
+}
+
+extern fn ZString getTUResourceUsageName(
+  CXTUResourceUsageKind kind)
+@cname("clang_getTUResourceUsageName");
 
 struct CXTUResourceUsageEntry {
-  /* The memory usage category. */
   CXTUResourceUsageKind kind;
-
-  /* Amount of resources used.
-     The units will depend on the resource kind. */
   CULong amount;
 }
 
-/**
- * The memory usage of a CXTranslationUnit, broken into categories.
- */
 struct CXTUResourceUsage {
-  /* Private data member, used for queries. */
   void* data;
-
-  /* The number of entries in the 'entries' array. */
-  CUInt numEntries;
-
-  /* An array of key-value pairs, representing the breakdown of memory
-            usage. */
+  CUInt num_entries;
   CXTUResourceUsageEntry* entries;
 }
 
-/**
- * Return the memory usage of a translation unit.  This object
- *  should be released with clang_disposeCXTUResourceUsage().
- */
-fn CXTUResourceUsage getCXTUResourceUsage(
-  CXTranslationUnit tu) 
-@extern("clang_getCXTUResourceUsage");
+extern fn CXTUResourceUsage getCXTUResourceUsage(
+  CXTranslationUnit tu)
+@cname("clang_getCXTUResourceUsage");
+
+extern fn void disposeCXTUResourceUsage(
+  CXTUResourceUsage usage)
+@cname("clang_disposeCXTUResourceUsage");
+
+extern fn CXTargetInfo getTranslationUnitTargetInfo(
+  CXTranslationUnit ct_unit)
+@cname("clang_getTranslationUnitTargetInfo");
+
+extern fn void targetInfo_dispose(
+  CXTargetInfo info)
+@cname("clang_TargetInfo_dispose");
+
+extern fn CXString targetInfo_getTriple(
+  CXTargetInfo info)
+@cname("clang_TargetInfo_getTriple");
+
+extern fn CInt targetInfo_getPointerWidth(
+  CXTargetInfo info)
+@cname("clang_TargetInfo_getPointerWidth");
+
+constdef CXCursorKind : CInt {
+  CURSOR_UNEXPOSED_DECL = 1,
+  CURSOR_STRUCT_DECL = 2,
+  CURSOR_UNION_DECL = 3,
+  CURSOR_CLASS_DECL = 4,
+  CURSOR_ENUM_DECL = 5,
+  CURSOR_FIELD_DECL = 6,
+  CURSOR_ENUM_CONSTANT_DECL = 7,
+  CURSOR_FUNCTION_DECL = 8,
+  CURSOR_VAR_DECL = 9,
+  CURSOR_PARM_DECL = 10,
+  CURSOR_OBJ_C_INTERFACE_DECL = 11,
+  CURSOR_OBJ_C_CATEGORY_DECL = 12,
+  CURSOR_OBJ_C_PROTOCOL_DECL = 13,
+  CURSOR_OBJ_C_PROPERTY_DECL = 14,
+  CURSOR_OBJ_C_IVAR_DECL = 15,
+  CURSOR_OBJ_C_INSTANCE_METHOD_DECL = 16,
+  CURSOR_OBJ_C_CLASS_METHOD_DECL = 17,
+  CURSOR_OBJ_C_IMPLEMENTATION_DECL = 18,
+  CURSOR_OBJ_C_CATEGORY_IMPL_DECL = 19,
+  CURSOR_TYPEDEF_DECL = 20,
+  CURSOR_CXX_METHOD = 21,
+  CURSOR_NAMESPACE = 22,
+  CURSOR_LINKAGE_SPEC = 23,
+  CURSOR_CONSTRUCTOR = 24,
+  CURSOR_DESTRUCTOR = 25,
+  CURSOR_CONVERSION_FUNCTION = 26,
+  CURSOR_TEMPLATE_TYPE_PARAMETER = 27,
+  CURSOR_NON_TYPE_TEMPLATE_PARAMETER = 28,
+  CURSOR_TEMPLATE_TEMPLATE_PARAMETER = 29,
+  CURSOR_FUNCTION_TEMPLATE = 30,
+  CURSOR_CLASS_TEMPLATE = 31,
+  CURSOR_CLASS_TEMPLATE_PARTIAL_SPECIALIZATION = 32,
+  CURSOR_NAMESPACE_ALIAS = 33,
+  CURSOR_USING_DIRECTIVE = 34,
+  CURSOR_USING_DECLARATION = 35,
+  CURSOR_TYPE_ALIAS_DECL = 36,
+  CURSOR_OBJ_C_SYNTHESIZE_DECL = 37,
+  CURSOR_OBJ_C_DYNAMIC_DECL = 38,
+  CURSOR_CXX_ACCESS_SPECIFIER = 39,
+  CURSOR_FIRST_DECL = 1,
+  CURSOR_LAST_DECL = 39,
+  CURSOR_FIRST_REF = 40,
+  CURSOR_OBJ_C_SUPER_CLASS_REF = 40,
+  CURSOR_OBJ_C_PROTOCOL_REF = 41,
+  CURSOR_OBJ_C_CLASS_REF = 42,
+  CURSOR_TYPE_REF = 43,
+  CURSOR_CXX_BASE_SPECIFIER = 44,
+  CURSOR_TEMPLATE_REF = 45,
+  CURSOR_NAMESPACE_REF = 46,
+  CURSOR_MEMBER_REF = 47,
+  CURSOR_LABEL_REF = 48,
+  CURSOR_OVERLOADED_DECL_REF = 49,
+  CURSOR_VARIABLE_REF = 50,
+  CURSOR_LAST_REF = 50,
+  CURSOR_FIRST_INVALID = 70,
+  CURSOR_INVALID_FILE = 70,
+  CURSOR_NO_DECL_FOUND = 71,
+  CURSOR_NOT_IMPLEMENTED = 72,
+  CURSOR_INVALID_CODE = 73,
+  CURSOR_LAST_INVALID = 73,
+  CURSOR_FIRST_EXPR = 100,
+  CURSOR_UNEXPOSED_EXPR = 100,
+  CURSOR_DECL_REF_EXPR = 101,
+  CURSOR_MEMBER_REF_EXPR = 102,
+  CURSOR_CALL_EXPR = 103,
+  CURSOR_OBJ_C_MESSAGE_EXPR = 104,
+  CURSOR_BLOCK_EXPR = 105,
+  CURSOR_INTEGER_LITERAL = 106,
+  CURSOR_FLOATING_LITERAL = 107,
+  CURSOR_IMAGINARY_LITERAL = 108,
+  CURSOR_STRING_LITERAL = 109,
+  CURSOR_CHARACTER_LITERAL = 110,
+  CURSOR_PAREN_EXPR = 111,
+  CURSOR_UNARY_OPERATOR = 112,
+  CURSOR_ARRAY_SUBSCRIPT_EXPR = 113,
+  CURSOR_BINARY_OPERATOR = 114,
+  CURSOR_COMPOUND_ASSIGN_OPERATOR = 115,
+  CURSOR_CONDITIONAL_OPERATOR = 116,
+  CURSOR_C_STYLE_CAST_EXPR = 117,
+  CURSOR_COMPOUND_LITERAL_EXPR = 118,
+  CURSOR_INIT_LIST_EXPR = 119,
+  CURSOR_ADDR_LABEL_EXPR = 120,
+  CURSOR_STMT_EXPR = 121,
+  CURSOR_GENERIC_SELECTION_EXPR = 122,
+  CURSOR_GNU_NULL_EXPR = 123,
+  CURSOR_CXX_STATIC_CAST_EXPR = 124,
+  CURSOR_CXX_DYNAMIC_CAST_EXPR = 125,
+  CURSOR_CXX_REINTERPRET_CAST_EXPR = 126,
+  CURSOR_CXX_CONST_CAST_EXPR = 127,
+  CURSOR_CXX_FUNCTIONAL_CAST_EXPR = 128,
+  CURSOR_CXX_TYPEID_EXPR = 129,
+  CURSOR_CXX_BOOL_LITERAL_EXPR = 130,
+  CURSOR_CXX_NULL_PTR_LITERAL_EXPR = 131,
+  CURSOR_CXX_THIS_EXPR = 132,
+  CURSOR_CXX_THROW_EXPR = 133,
+  CURSOR_CXX_NEW_EXPR = 134,
+  CURSOR_CXX_DELETE_EXPR = 135,
+  CURSOR_UNARY_EXPR = 136,
+  CURSOR_OBJ_C_STRING_LITERAL = 137,
+  CURSOR_OBJ_C_ENCODE_EXPR = 138,
+  CURSOR_OBJ_C_SELECTOR_EXPR = 139,
+  CURSOR_OBJ_C_PROTOCOL_EXPR = 140,
+  CURSOR_OBJ_C_BRIDGED_CAST_EXPR = 141,
+  CURSOR_PACK_EXPANSION_EXPR = 142,
+  CURSOR_SIZE_OF_PACK_EXPR = 143,
+  CURSOR_LAMBDA_EXPR = 144,
+  CURSOR_OBJ_C_BOOL_LITERAL_EXPR = 145,
+  CURSOR_OBJ_C_SELF_EXPR = 146,
+  CURSOR_ARRAY_SECTION_EXPR = 147,
+  CURSOR_OBJ_C_AVAILABILITY_CHECK_EXPR = 148,
+  CURSOR_FIXED_POINT_LITERAL = 149,
+  CURSOR_OMP_ARRAY_SHAPING_EXPR = 150,
+  CURSOR_OMP_ITERATOR_EXPR = 151,
+  CURSOR_CXX_ADDRSPACE_CAST_EXPR = 152,
+  CURSOR_CONCEPT_SPECIALIZATION_EXPR = 153,
+  CURSOR_REQUIRES_EXPR = 154,
+  CURSOR_CXX_PAREN_LIST_INIT_EXPR = 155,
+  CURSOR_PACK_INDEXING_EXPR = 156,
+  CURSOR_LAST_EXPR = 156,
+  CURSOR_FIRST_STMT = 200,
+  CURSOR_UNEXPOSED_STMT = 200,
+  CURSOR_LABEL_STMT = 201,
+  CURSOR_COMPOUND_STMT = 202,
+  CURSOR_CASE_STMT = 203,
+  CURSOR_DEFAULT_STMT = 204,
+  CURSOR_IF_STMT = 205,
+  CURSOR_SWITCH_STMT = 206,
+  CURSOR_WHILE_STMT = 207,
+  CURSOR_DO_STMT = 208,
+  CURSOR_FOR_STMT = 209,
+  CURSOR_GOTO_STMT = 210,
+  CURSOR_INDIRECT_GOTO_STMT = 211,
+  CURSOR_CONTINUE_STMT = 212,
+  CURSOR_BREAK_STMT = 213,
+  CURSOR_RETURN_STMT = 214,
+  CURSOR_GCC_ASM_STMT = 215,
+  CURSOR_ASM_STMT = 215,
+  CURSOR_OBJ_C_AT_TRY_STMT = 216,
+  CURSOR_OBJ_C_AT_CATCH_STMT = 217,
+  CURSOR_OBJ_C_AT_FINALLY_STMT = 218,
+  CURSOR_OBJ_C_AT_THROW_STMT = 219,
+  CURSOR_OBJ_C_AT_SYNCHRONIZED_STMT = 220,
+  CURSOR_OBJ_C_AUTORELEASE_POOL_STMT = 221,
+  CURSOR_OBJ_C_FOR_COLLECTION_STMT = 222,
+  CURSOR_CXX_CATCH_STMT = 223,
+  CURSOR_CXX_TRY_STMT = 224,
+  CURSOR_CXX_FOR_RANGE_STMT = 225,
+  CURSOR_SEH_TRY_STMT = 226,
+  CURSOR_SEH_EXCEPT_STMT = 227,
+  CURSOR_SEH_FINALLY_STMT = 228,
+  CURSOR_MS_ASM_STMT = 229,
+  CURSOR_NULL_STMT = 230,
+  CURSOR_DECL_STMT = 231,
+  CURSOR_OMP_PARALLEL_DIRECTIVE = 232,
+  CURSOR_OMP_SIMD_DIRECTIVE = 233,
+  CURSOR_OMP_FOR_DIRECTIVE = 234,
+  CURSOR_OMP_SECTIONS_DIRECTIVE = 235,
+  CURSOR_OMP_SECTION_DIRECTIVE = 236,
+  CURSOR_OMP_SINGLE_DIRECTIVE = 237,
+  CURSOR_OMP_PARALLEL_FOR_DIRECTIVE = 238,
+  CURSOR_OMP_PARALLEL_SECTIONS_DIRECTIVE = 239,
+  CURSOR_OMP_TASK_DIRECTIVE = 240,
+  CURSOR_OMP_MASTER_DIRECTIVE = 241,
+  CURSOR_OMP_CRITICAL_DIRECTIVE = 242,
+  CURSOR_OMP_TASKYIELD_DIRECTIVE = 243,
+  CURSOR_OMP_BARRIER_DIRECTIVE = 244,
+  CURSOR_OMP_TASKWAIT_DIRECTIVE = 245,
+  CURSOR_OMP_FLUSH_DIRECTIVE = 246,
+  CURSOR_SEH_LEAVE_STMT = 247,
+  CURSOR_OMP_ORDERED_DIRECTIVE = 248,
+  CURSOR_OMP_ATOMIC_DIRECTIVE = 249,
+  CURSOR_OMP_FOR_SIMD_DIRECTIVE = 250,
+  CURSOR_OMP_PARALLEL_FOR_SIMD_DIRECTIVE = 251,
+  CURSOR_OMP_TARGET_DIRECTIVE = 252,
+  CURSOR_OMP_TEAMS_DIRECTIVE = 253,
+  CURSOR_OMP_TASKGROUP_DIRECTIVE = 254,
+  CURSOR_OMP_CANCELLATION_POINT_DIRECTIVE = 255,
+  CURSOR_OMP_CANCEL_DIRECTIVE = 256,
+  CURSOR_OMP_TARGET_DATA_DIRECTIVE = 257,
+  CURSOR_OMP_TASK_LOOP_DIRECTIVE = 258,
+  CURSOR_OMP_TASK_LOOP_SIMD_DIRECTIVE = 259,
+  CURSOR_OMP_DISTRIBUTE_DIRECTIVE = 260,
+  CURSOR_OMP_TARGET_ENTER_DATA_DIRECTIVE = 261,
+  CURSOR_OMP_TARGET_EXIT_DATA_DIRECTIVE = 262,
+  CURSOR_OMP_TARGET_PARALLEL_DIRECTIVE = 263,
+  CURSOR_OMP_TARGET_PARALLEL_FOR_DIRECTIVE = 264,
+  CURSOR_OMP_TARGET_UPDATE_DIRECTIVE = 265,
+  CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 266,
+  CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 267,
+  CURSOR_OMP_DISTRIBUTE_SIMD_DIRECTIVE = 268,
+  CURSOR_OMP_TARGET_PARALLEL_FOR_SIMD_DIRECTIVE = 269,
+  CURSOR_OMP_TARGET_SIMD_DIRECTIVE = 270,
+  CURSOR_OMP_TEAMS_DISTRIBUTE_DIRECTIVE = 271,
+  CURSOR_OMP_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 272,
+  CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 273,
+  CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 274,
+  CURSOR_OMP_TARGET_TEAMS_DIRECTIVE = 275,
+  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_DIRECTIVE = 276,
+  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 277,
+  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 278,
+  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 279,
+  CURSOR_BUILTIN_BIT_CAST_EXPR = 280,
+  CURSOR_OMP_MASTER_TASK_LOOP_DIRECTIVE = 281,
+  CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_DIRECTIVE = 282,
+  CURSOR_OMP_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 283,
+  CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 284,
+  CURSOR_OMP_PARALLEL_MASTER_DIRECTIVE = 285,
+  CURSOR_OMP_DEPOBJ_DIRECTIVE = 286,
+  CURSOR_OMP_SCAN_DIRECTIVE = 287,
+  CURSOR_OMP_TILE_DIRECTIVE = 288,
+  CURSOR_OMP_CANONICAL_LOOP = 289,
+  CURSOR_OMP_INTEROP_DIRECTIVE = 290,
+  CURSOR_OMP_DISPATCH_DIRECTIVE = 291,
+  CURSOR_OMP_MASKED_DIRECTIVE = 292,
+  CURSOR_OMP_UNROLL_DIRECTIVE = 293,
+  CURSOR_OMP_META_DIRECTIVE = 294,
+  CURSOR_OMP_GENERIC_LOOP_DIRECTIVE = 295,
+  CURSOR_OMP_TEAMS_GENERIC_LOOP_DIRECTIVE = 296,
+  CURSOR_OMP_TARGET_TEAMS_GENERIC_LOOP_DIRECTIVE = 297,
+  CURSOR_OMP_PARALLEL_GENERIC_LOOP_DIRECTIVE = 298,
+  CURSOR_OMP_TARGET_PARALLEL_GENERIC_LOOP_DIRECTIVE = 299,
+  CURSOR_OMP_PARALLEL_MASKED_DIRECTIVE = 300,
+  CURSOR_OMP_MASKED_TASK_LOOP_DIRECTIVE = 301,
+  CURSOR_OMP_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 302,
+  CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_DIRECTIVE = 303,
+  CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 304,
+  CURSOR_OMP_ERROR_DIRECTIVE = 305,
+  CURSOR_OMP_SCOPE_DIRECTIVE = 306,
+  CURSOR_OMP_REVERSE_DIRECTIVE = 307,
+  CURSOR_OMP_INTERCHANGE_DIRECTIVE = 308,
+  CURSOR_OMP_ASSUME_DIRECTIVE = 309,
+  CURSOR_OMP_STRIPE_DIRECTIVE = 310,
+  CURSOR_OMP_FUSE_DIRECTIVE = 311,
+  CURSOR_OPEN_ACC_COMPUTE_CONSTRUCT = 320,
+  CURSOR_OPEN_ACC_LOOP_CONSTRUCT = 321,
+  CURSOR_OPEN_ACC_COMBINED_CONSTRUCT = 322,
+  CURSOR_OPEN_ACC_DATA_CONSTRUCT = 323,
+  CURSOR_OPEN_ACC_ENTER_DATA_CONSTRUCT = 324,
+  CURSOR_OPEN_ACC_EXIT_DATA_CONSTRUCT = 325,
+  CURSOR_OPEN_ACC_HOST_DATA_CONSTRUCT = 326,
+  CURSOR_OPEN_ACC_WAIT_CONSTRUCT = 327,
+  CURSOR_OPEN_ACC_INIT_CONSTRUCT = 328,
+  CURSOR_OPEN_ACC_SHUTDOWN_CONSTRUCT = 329,
+  CURSOR_OPEN_ACC_SET_CONSTRUCT = 330,
+  CURSOR_OPEN_ACC_UPDATE_CONSTRUCT = 331,
+  CURSOR_OPEN_ACC_ATOMIC_CONSTRUCT = 332,
+  CURSOR_OPEN_ACC_CACHE_CONSTRUCT = 333,
+  CURSOR_LAST_STMT = 333,
+  CURSOR_TRANSLATION_UNIT = 350,
+  CURSOR_FIRST_ATTR = 400,
+  CURSOR_UNEXPOSED_ATTR = 400,
+  CURSOR_IB_ACTION_ATTR = 401,
+  CURSOR_IB_OUTLET_ATTR = 402,
+  CURSOR_IB_OUTLET_COLLECTION_ATTR = 403,
+  CURSOR_CXX_FINAL_ATTR = 404,
+  CURSOR_CXX_OVERRIDE_ATTR = 405,
+  CURSOR_ANNOTATE_ATTR = 406,
+  CURSOR_ASM_LABEL_ATTR = 407,
+  CURSOR_PACKED_ATTR = 408,
+  CURSOR_PURE_ATTR = 409,
+  CURSOR_CONST_ATTR = 410,
+  CURSOR_NO_DUPLICATE_ATTR = 411,
+  CURSOR_CUDA_CONSTANT_ATTR = 412,
+  CURSOR_CUDA_DEVICE_ATTR = 413,
+  CURSOR_CUDA_GLOBAL_ATTR = 414,
+  CURSOR_CUDA_HOST_ATTR = 415,
+  CURSOR_CUDA_SHARED_ATTR = 416,
+  CURSOR_VISIBILITY_ATTR = 417,
+  CURSOR_DLL_EXPORT = 418,
+  CURSOR_DLL_IMPORT = 419,
+  CURSOR_NS_RETURNS_RETAINED = 420,
+  CURSOR_NS_RETURNS_NOT_RETAINED = 421,
+  CURSOR_NS_RETURNS_AUTORELEASED = 422,
+  CURSOR_NS_CONSUMES_SELF = 423,
+  CURSOR_NS_CONSUMED = 424,
+  CURSOR_OBJ_C_EXCEPTION = 425,
+  CURSOR_OBJ_CNS_OBJECT = 426,
+  CURSOR_OBJ_C_INDEPENDENT_CLASS = 427,
+  CURSOR_OBJ_C_PRECISE_LIFETIME = 428,
+  CURSOR_OBJ_C_RETURNS_INNER_POINTER = 429,
+  CURSOR_OBJ_C_REQUIRES_SUPER = 430,
+  CURSOR_OBJ_C_ROOT_CLASS = 431,
+  CURSOR_OBJ_C_SUBCLASSING_RESTRICTED = 432,
+  CURSOR_OBJ_C_EXPLICIT_PROTOCOL_IMPL = 433,
+  CURSOR_OBJ_C_DESIGNATED_INITIALIZER = 434,
+  CURSOR_OBJ_C_RUNTIME_VISIBLE = 435,
+  CURSOR_OBJ_C_BOXABLE = 436,
+  CURSOR_FLAG_ENUM = 437,
+  CURSOR_CONVERGENT_ATTR = 438,
+  CURSOR_WARN_UNUSED_ATTR = 439,
+  CURSOR_WARN_UNUSED_RESULT_ATTR = 440,
+  CURSOR_ALIGNED_ATTR = 441,
+  CURSOR_LAST_ATTR = 441,
+  CURSOR_PREPROCESSING_DIRECTIVE = 500,
+  CURSOR_MACRO_DEFINITION = 501,
+  CURSOR_MACRO_EXPANSION = 502,
+  CURSOR_MACRO_INSTANTIATION = 502,
+  CURSOR_INCLUSION_DIRECTIVE = 503,
+  CURSOR_FIRST_PREPROCESSING = 500,
+  CURSOR_LAST_PREPROCESSING = 503,
+  CURSOR_MODULE_IMPORT_DECL = 600,
+  CURSOR_TYPE_ALIAS_TEMPLATE_DECL = 601,
+  CURSOR_STATIC_ASSERT = 602,
+  CURSOR_FRIEND_DECL = 603,
+  CURSOR_CONCEPT_DECL = 604,
+  CURSOR_FIRST_EXTRA_DECL = 600,
+  CURSOR_LAST_EXTRA_DECL = 604,
+  CURSOR_OVERLOAD_CANDIDATE = 700
+}
 
-fn void disposeCXTUResourceUsage(
-  CXTUResourceUsage usage) 
-@extern("clang_disposeCXTUResourceUsage");
-
-/**
- * Get target information for this translation unit.
- *
- * The CXTargetInfo object cannot outlive the CXTranslationUnit object.
- */
-fn CXTargetInfo getTranslationUnitTargetInfo(
-  CXTranslationUnit ct_unit) 
-@extern("clang_getTranslationUnitTargetInfo");
-
-/**
- * Destroy the CXTargetInfo object.
- */
-fn void dispose_TargetInfo(
-  CXTargetInfo info) 
-@extern("clang_TargetInfo_dispose");
-
-/**
- * Get the normalized target triple as a string.
- *
- * Returns the empty string in case of any error.
- */
-fn CXString getTriple_TargetInfo(
-  CXTargetInfo info) 
-@extern("clang_TargetInfo_getTriple");
-
-/**
- * Get the pointer width of the target in bits.
- *
- * Returns -1 in case of error.
- */
-fn CInt getPointerWidth_TargetInfo(
-  CXTargetInfo info) 
-@extern("clang_TargetInfo_getPointerWidth");
-
-/**
- * Describes the kind of entity that a cursor refers to.
- */
-typedef CXCursorKind = inline CInt;
-
-/* Declarations */
-/**
- * A declaration whose specific kind is not exposed via this
- * interface.
- *
- * Unexposed declarations have the same operations as any other kind
- * of declaration; one can extract their location information,
- * spelling, find their definitions, etc. However, the specific kind
- * of the declaration is not reported.
- */
-const CXCursorKind CURSOR_UNEXPOSED_DECL = 1;
-/** A C or C++ struct.
-  */
-const CXCursorKind CURSOR_STRUCT_DECL = 2;
-/** A C or C++ union. 
-  */
-const CXCursorKind CURSOR_UNION_DECL = 3;
-/** A C++ class. 
-  */
-const CXCursorKind CURSOR_CLASS_DECL = 4;
-/** An enumeration. 
-  */
-const CXCursorKind CURSOR_ENUM_DECL = 5;
-/**
- * A field (in C) or non-static data member (in C++) in a
- * struct, union, or C++ class.
- */
-const CXCursorKind CURSOR_FIELD_DECL = 6;
-/** An enumerator constant.
-  */
-const CXCursorKind CURSOR_ENUM_CONSTANT_DECL = 7;
-/** A function. 
-  */
-const CXCursorKind CURSOR_FUNCTION_DECL = 8;
-/** A variable. 
-  */
-const CXCursorKind CURSOR_VAR_DECL = 9;
-/** A function or method parameter. 
-  */
-const CXCursorKind CURSOR_PARM_DECL = 10;
-/** An Objective-C \@interface. 
-  */
-const CXCursorKind CURSOR_OBJC_INTERFACE_DECL = 11;
-/** An Objective-C \@interface for a category. 
-  */
-const CXCursorKind CURSOR_OBJC_CATEGORY_DECL = 12;
-/** An Objective-C \@protocol declaration. 
-  */
-const CXCursorKind CURSOR_OBJC_PROTOCOL_DECL = 13;
-/** An Objective-C \@property declaration. 
-  */
-const CXCursorKind CURSOR_OBJC_PROPERTY_DECL = 14;
-/** An Objective-C instance variable. 
-  */
-const CXCursorKind CURSOR_OBJC_IVAR_DECL = 15;
-/** An Objective-C instance method. 
-  */
-const CXCursorKind CURSOR_OBJC_INSTANCE_METHOD_DECL = 16;
-/** An Objective-C class method. 
-  */
-const CXCursorKind CURSOR_OBJC_CLASS_METHOD_DECL = 17;
-/** An Objective-C \@implementation. 
-  */
-const CXCursorKind CURSOR_OBJC_IMPLEMENTATION_DECL = 18;
-/** An Objective-C \@implementation for a category. 
-  */
-const CXCursorKind CURSOR_OBJC_CATEGORY_IMPL_DECL = 19;
-/** A typedef. 
-  */
-const CXCursorKind CURSOR_TYPEDEF_DECL = 20;
-/** A C++ class method. 
-  */
-const CXCursorKind CURSOR_CXX_METHOD = 21;
-/** A C++ namespace. 
-  */
-const CXCursorKind CURSOR_NAMESPACE = 22;
-/** A linkage specification, e.g. 'extern "C"'. 
-  */
-const CXCursorKind CURSOR_LINKAGE_SPEC = 23;
-/** A C++ constructor. 
-  */
-const CXCursorKind CURSOR_CONSTRUCTOR = 24;
-/** A C++ destructor. 
-  */
-const CXCursorKind CURSOR_DESTRUCTOR = 25;
-/** A C++ conversion function. 
-  */
-const CXCursorKind CURSOR_CONVERSION_FUNCTION = 26;
-/** A C++ template type parameter. 
-  */
-const CXCursorKind CURSOR_TEMPLATE_TYPE_PARAMETER = 27;
-/** A C++ non-type template parameter. 
-  */
-const CXCursorKind CURSOR_NON_TYPE_TEMPLATE_PARAMETER = 28;
-/** A C++ template template parameter. 
-  */
-const CXCursorKind CURSOR_TEMPLATE_TEMPLATE_PARAMETER = 29;
-/** A C++ function template. 
-  */
-const CXCursorKind CURSOR_FUNCTION_TEMPLATE = 30;
-/** A C++ class template. 
-  */
-const CXCursorKind CURSOR_CLASS_TEMPLATE = 31;
-/** A C++ class template partial specialization. 
-  */
-const CXCursorKind CURSOR_CLASS_TEMPLATE_PARTIAL_SPECIALIZATION = 32;
-/** A C++ namespace alias declaration. 
-  */
-const CXCursorKind CURSOR_NAMESPACEALIAS = 33;
-/** A C++ using directive. 
-  */
-const CXCursorKind CURSOR_USING_DIRECTIVE = 34;
-/** A C++ using declaration. 
-  */
-const CXCursorKind CURSOR_USING_DECLARATION = 35;
-/** A C++ alias declaration 
-  */
-const CXCursorKind CURSOR_TYPE_ALIAS_DECL = 36;
-/** An Objective-C \@synthesize definition. 
-  */
-const CXCursorKind CURSOR_OBJC_SYNTHESIZE_DECL = 37;
-/** An Objective-C \@dynamic definition. 
-  */
-const CXCursorKind CURSOR_OBJC_DYNAMIC_DECL = 38;
-/** An access specifier. 
-  */
-const CXCursorKind CURSOR_CXX_ACCESS_SPECIFIER = 39;
-
-const CXCursorKind CURSOR_FIRST_DECL = CURSOR_UNEXPOSED_DECL;
-const CXCursorKind CURSOR_LAST_DECL = CURSOR_CXX_ACCESS_SPECIFIER;
-
-/* References */
-const CXCursorKind CURSOR_FIRST_REF = 40; /* Decl references */
-const CXCursorKind CURSOR_OBJC_SUPER_CLASS_REF = 40;
-const CXCursorKind CURSOR_OBJC_PROTOCOL_REF = 41;
-const CXCursorKind CURSOR_OBJC_CLASS_REF = 42;
-/**
- * A reference to a type declaration.
- *
- * A type reference occurs anywhere where a type is named but not
- * declared. For example, given:
- *
- * \code
- * typedef CUInt size_type;
- * size_type size;
- * \endcode
- *
- * The typedef is a declaration of size_type (CXCursor_TypedefDecl),
- * while the type of the variable "size" is referenced. The cursor
- * referenced by the type of size is the typedef for size_type.
- */
-const CXCursorKind CURSOR_TYPE_REF = 43;
-const CXCursorKind CURSOR_CXX_BASE_SPECIFIER = 44;
-/**
- * A reference to a class template, function template, template
- * template parameter, or class template partial specialization.
- */
-const CXCursorKind CURSOR_TEMPLATE_REF = 45;
-/**
- * A reference to a namespace or namespace alias.
- */
-const CXCursorKind CURSOR_NAMESPACE_REF = 46;
-/**
- * A reference to a member of a struct, union, or class that occurs in
- * some non-expression context, e.g., a designated initializer.
- */
-const CXCursorKind CURSOR_MEMBER_REF = 47;
-/**
- * A reference to a labeled statement.
- *
- * This cursor kind is used to describe the jump to "start_over" in the
- * goto statement in the following example:
- *
- * \code
- *   start_over:
- *     ++counter;
- *
- *     goto start_over;
- * \endcode
- *
- * A label reference cursor refers to a label statement.
- */
-const CXCursorKind CURSOR_LABEL_REF = 48;
-
-/**
- * A reference to a set of overloaded functions or function templates
- * that has not yet been resolved to a specific function or function template.
- *
- * An overloaded declaration reference cursor occurs in C++ templates where
- * a dependent name refers to a function. For example:
- *
- * \code
- * template<typename T> void swap(T&, T&);
- *
- * struct X { ... };
- * void swap(X&, X&);
- *
- * template<typename T>
- * void reverse(T* first, T* last) {
- *   while (first < last - 1) {
- *     swap(*first, *--last);
- *     ++first;
- *   }
- * }
- *
- * struct Y { };
- * void swap(Y&, Y&);
- * \endcode
- *
- * Here, the identifier "swap" is associated with an overloaded declaration
- * reference. In the template definition, "swap" refers to either of the two
- * "swap" functions declared above, so both results will be available. At
- * instantiation time, "swap" may also refer to other functions found via
- * argument-dependent lookup (e.g., the "swap" function at the end of the
- * example).
- *
- * The functions \c clang_getNumOverloadedDecls() and
- * \c clang_getOverloadedDecl() can be used to retrieve the definitions
- * referenced by this cursor.
- */
-const CXCursorKind CURSOR_OVERLOADED_DECL_REF = 49;
-
-/**
- * A reference to a variable that occurs in some non-expression
- * context, e.g., a C++ lambda capture list.
- */
-const CXCursorKind CURSOR_VARIABLE_REF = 50;
-
-const CXCursorKind CURSOR_LAST_REF = CURSOR_VARIABLE_REF;
-
-/* Error conditions */
-const CXCursorKind CURSOR_FIRST_INVALID = 70;
-const CXCursorKind CURSOR_INVALID_FILE = 70;
-const CXCursorKind CURSOR_NO_DECL_FOUND = 71;
-const CXCursorKind CURSOR_NOT_IMPLEMENTED = 72;
-const CXCursorKind CURSOR_INVALID_CODE = 73;
-const CXCursorKind CURSOR_LAST_INVALID = CURSOR_INVALID_CODE;
-
-/* Expressions */
-const CXCursorKind CURSOR_FIRST_EXPR = 100;
-
-/**
- * An expression whose specific kind is not exposed via this
- * interface.
- *
- * Unexposed expressions have the same operations as any other kind
- * of expression; one can extract their location information,
- * spelling, children, etc. However, the specific kind of the
- * expression is not reported.
- */
-const CXCursorKind CURSOR_UNEXPOSED_EXPR = 100;
-
-/**
- * An expression that refers to some value declaration, such
- * as a function, variable, or enumerator.
- */
-const CXCursorKind CURSOR_DECL_REF_EXPR = 101;
-
-/**
- * An expression that refers to a member of a struct, union,
- * class, Objective-C class, etc.
- */
-const CXCursorKind CURSOR_MEMBER_REF_EXPR = 102;
-
-/** An expression that calls a function. 
-  */
-const CXCursorKind CURSOR_CALL_EXPR = 103;
-
-/** An expression that sends a message to an Objective-C
- object or class. 
-  */
-const CXCursorKind CURSOR_OBJC_MESSAGE_EXPR = 104;
-
-/** An expression that represents a block literal. 
-  */
-const CXCursorKind CURSOR_BLOCK_EXPR = 105;
-
-/** An integer literal.
- */
-const CXCursorKind CURSOR_INTEGER_LITERAL = 106;
-
-/** A floating poCInt number literal.
- */
-const CXCursorKind CURSOR_FLOATING_LITERAL = 107;
-
-/** An imaginary number literal.
- */
-const CXCursorKind CURSOR_IMAGINARY_LITERAL = 108;
-
-/** A string literal.
- */
-const CXCursorKind CURSOR_STRING_LITERAL = 109;
-
-/** A character literal.
- */
-const CXCursorKind CURSOR_CHARACTER_LITERAL = 110;
-
-/** A parenthesized expression, e.g. "(1)".
- *
- * This AST node is only formed if full location information is requested.
- */
-const CXCursorKind CURSOR_PAREN_EXPR = 111;
-
-/** This represents the unary-expression's (except sizeof and
- * alignof).
- */
-const CXCursorKind CURSOR_UNARY_OPERATOR = 112;
-
-/** [C99 6.5.2.1] Array Subscripting.
- */
-const CXCursorKind CURSOR_ARRAY_SUBSCRIPT_EXPR = 113;
-
-/** A builtin binary operation expression such as "x + y" or
- * "x <= y".
- */
-const CXCursorKind CURSOR_BINARY_OPERATOR = 114;
-
-/** Compound assignment such as "+=".
- */
-const CXCursorKind CURSOR_COMPOUND_ASSIGN_OPERATOR = 115;
-
-/** The ?: ternary operator.
- */
-const CXCursorKind CURSOR_CONDITIONAL_OPERATOR = 116;
-
-/** An explicit cast in C (C99 6.5.4) or a C-style cast in C++
- * (C++ [expr.cast]), which uses the syntax (Type)expr.
- *
- * For example: (CInt)f.
- */
-const CXCursorKind CURSOR_C_STYLE_CAST_EXPR = 117;
-
-/** [C99 6.5.2.5]
- */
-const CXCursorKind CURSOR_COMPOUND_LITERAL_EXPR = 118;
-
-/** Describes an C or C++ initializer list.
- */
-const CXCursorKind CURSOR_INIT_LIST_EXPR = 119;
-
-/** The GNU address of label extension, representing &&label.
- */
-const CXCursorKind CURSOR_ADDR_LABEL_EXPR = 120;
-
-/** This is the GNU Statement Expression extension: ({CInt X=4; X;})
- */
-const CXCursorKind CURSOR_STMT_EXPR = 121;
-
-/** Represents a C11 generic selection.
- */
-const CXCursorKind CURSOR_GENERIC_SELECTION_EXPR = 122;
-
-/** Implements the GNU __null extension, which is a name for a null
- * pointer constant that has integral type (e.g., CInt or long) and is the same
- * size and alignment as a pointer.
- *
- * The __null extension is typically only used by system headers, which define
- * NULL as __null in C++ rather than using 0 (which is an integer that may not
- * match the size of a pointer).
- */
-const CXCursorKind CURSOR_GNU_NULL_EXPR = 123;
-
-/** C++'s static_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_STATIC_CAST_EXPR = 124;
-
-/** C++'s dynamic_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_DYNAMIC_CAST_EXPR = 125;
-
-/** C++'s reinterpret_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_REINTERPRET_CAST_EXPR = 126;
-
-/** C++'s const_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_CONST_CAST_EXPR = 127;
-
-/** Represents an explicit C++ type conversion that uses "functional"
- * notion (C++ [expr.type.conv]).
- *
- * Example:
- * \code
- *   x = CInt(0.5);
- * \endcode
- */
-const CXCursorKind CURSOR_CXX_FUNCTIONAL_CAST_EXPR = 128;
-
-/** A C++ typeid expression (C++ [expr.typeid]).
- */
-const CXCursorKind CURSOR_CXX_TYPEID_EXPR = 129;
-
-/** [C++ 2.13.5] C++ Boolean Literal.
- */
-const CXCursorKind CURSOR_CXX_BOOL_LITERAL_EXPR = 130;
-
-/** [C++0x 2.14.7] C++ Pointer Literal.
- */
-const CXCursorKind CURSOR_CXX_NULLPTR_LITERAL_EXPR = 131;
-
-/** Represents the "this" expression in C++
- */
-const CXCursorKind CURSOR_CXX_THIS_EXPR = 132;
-
-/** [C++ 15] C++ Throw Expression.
- *
- * This handles 'throw' and 'throw' assignment-expression. When
- * assignment-expression isn't present, Op will be null.
- */
-const CXCursorKind CURSOR_CXX_THROW_EXPR = 133;
-
-/** A new expression for memory allocation and constructor calls, e.g:
- * "new CXXNewExpr(foo)".
- */
-const CXCursorKind CURSOR_CXX_NEW_EXPR = 134;
-
-/** A delete expression for memory deallocation and destructor calls,
- * e.g. "delete[] pArray".
- */
-const CXCursorKind CURSOR_CXX_DELETE_EXPR = 135;
-
-/** A unary expression. (noexcept, sizeof, or other traits)
- */
-const CXCursorKind CURSOR_UNARY_EXPR = 136;
-
-/** An Objective-C string literal i.e. @"foo".
- */
-const CXCursorKind CURSOR_OBJC_STRINGLITERAL = 137;
-
-/** An Objective-C \@encode expression.
- */
-const CXCursorKind CURSOR_OBJC_ENCODE_EXPR = 138;
-
-/** An Objective-C \@selector expression.
- */
-const CXCursorKind CURSOR_OBJC_SELECTOR_EXPR = 139;
-
-/** An Objective-C \@protocol expression.
- */
-const CXCursorKind CURSOR_OBJC_PROTOCOL_EXPR = 140;
-
-/** An Objective-C "bridged" cast expression, which casts between
- * Objective-C pointers and C pointers, transferring ownership in the process.
- *
- * \code
- *   NSString *str = (__bridge_transfer NSString *)CFCreateString();
- * \endcode
- */
-const CXCursorKind CURSOR_OBJC_BRIDGED_CAST_EXPR = 141;
-
-/** Represents a C++0x pack expansion that produces a sequence of
- * expressions.
- *
- * A pack expansion expression contains a pattern (which itself is an
- * expression) followed by an ellipsis. For example:
- *
- * \code
- * template<typename F, typename ...Types>
- * void forward(F f, Types &&...args) {
- *  f(static_cast<Types&&>(args)...);
- * }
- * \endcode
- */
-const CXCursorKind CURSOR_PACK_EXPANSION_EXPR = 142;
-
-/** Represents an expression that computes the length of a parameter
- * pack.
- *
- * \code
- * template<typename ...Types>
- * struct count {
- *   static const CUInt value = sizeof...(Types);
- * };
- * \endcode
- */
-const CXCursorKind CURSOR_SIZEOF_PACK_EXPR = 143;
-
-/* Represents a C++ lambda expression that produces a local function
- * object.
- *
- * \code
- * void abssort(float *x, CUInt N) {
- *   std::sort(x, x + N,
- *             [](float a, float b) {
- *               return std::abs(a) < std::abs(b);
- *             });
- * }
- * \endcode
- */
-const CXCursorKind CURSOR_LAMBDA_EXPR = 144;
-
-/** Objective-c Boolean Literal.
- */
-const CXCursorKind CURSOR_OBJC_BOOL_LITERAL_EXPR = 145;
-
-/** Represents the "self" expression in an Objective-C method.
- */
-const CXCursorKind CURSOR_OBJC_SELF_EXPR = 146;
-
-/** OpenMP 5.0 [2.1.5, Array Section].
- */
-const CXCursorKind CURSOR_OMP_ARRAY_SECTION_EXPR = 147;
-
-/** Represents an @available(...) check.
- */
-const CXCursorKind CURSOR_OBJC_AVAILABILITY_CHECK_EXPR = 148;
-
-/**
- * Fixed poCInt literal
- */
-const CXCursorKind CURSOR_FIXED_POINT_LITERAL = 149;
-
-/** OpenMP 5.0 [2.1.4, Array Shaping].
- */
-const CXCursorKind CURSOR_OMP_ARRAY_SHAPING_EXPR = 150;
-
-/**
- * OpenMP 5.0 [2.1.6 Iterators]
- */
-const CXCursorKind CURSOR_OMP_ITERATOR_EXPR = 151;
-
-/** OpenCL's addrspace_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_ADDR_SPACE_CAST_EXPR = 152;
-
-/**
- * Expression that references a C++20 concept.
- */
-const CXCursorKind CURSOR_CONCEPT_SPECIALIZATION_EXPR = 153;
-
-/**
- * Expression that references a C++20 concept.
- */
-const CXCursorKind CURSOR_REQUIRES_EXPR = 154;
-
-/**
- * Expression that references a C++20 parenthesized list aggregate
- * initializer.
- */
-const CXCursorKind CURSOR_CXX_PAREN_LIST_INIT_EXPR = 155;
-
-const CXCursorKind CURSOR_LASTEXPR = CURSOR_CXX_PAREN_LIST_INIT_EXPR;
-
-/* Statements */
-const CXCursorKind CURSOR_FIRST_STMT = 200;
-/**
- * A statement whose specific kind is not exposed via this
- * interface.
- *
- * Unexposed statements have the same operations as any other kind of
- * statement; one can extract their location information, spelling,
- * children, etc. However, the specific kind of the statement is not
- * reported.
- */
-const CXCursorKind CURSOR_UNEXPOSED_STMT = 200;
-
-/** A labelled statement in a function.
- *
- * This cursor kind is used to describe the "start_over:" label statement in
- * the following example:
- *
- * \code
- *   start_over:
- *     ++counter;
- * \endcode
- *
- */
-const CXCursorKind CURSOR_LABEL_STMT = 201;
-
-/** A group of statements like { stmt stmt }.
- *
- * This cursor kind is used to describe compound statements, e.g. function
- * bodies.
- */
-const CXCursorKind CURSOR_COMPOUND_STMT = 202;
-
-/** A case statement.
- */
-const CXCursorKind CURSOR_CASE_STMT = 203;
-
-/** A default statement.
- */
-const CXCursorKind CURSOR_DEFAULT_STMT = 204;
-
-/** An if statement
- */
-const CXCursorKind CURSOR_IF_STMT = 205;
-
-/** A switch statement.
- */
-const CXCursorKind CURSOR_SWITCH_STMT = 206;
-
-/** A while statement.
- */
-const CXCursorKind CURSOR_WHILE_STMT = 207;
-
-/** A do statement.
- */
-const CXCursorKind CURSOR_DO_STMT = 208;
-
-/** A for statement.
- */
-const CXCursorKind CURSOR_FOR_STMT = 209;
-
-/** A goto statement.
- */
-const CXCursorKind CURSOR_GOTO_STMT = 210;
-
-/** An indirect goto statement.
- */
-const CXCursorKind CURSOR_INDIRECT_GOTO_STMT = 211;
-
-/** A continue statement.
- */
-const CXCursorKind CURSOR_CONTINUE_STMT = 212;
-
-/** A break statement.
- */
-const CXCursorKind CURSOR_BREAK_STMT = 213;
-
-/** A return statement.
- */
-const CXCursorKind CURSOR_RETURN_STMT = 214;
-
-/** A GCC inline assembly statement extension.
- */
-const CXCursorKind CURSOR_GCC_ASM_STMT = 215;
-const CXCursorKind CURSOR_ASMSTMT = CURSOR_GCC_ASM_STMT;
-
-/** Objective-C's overall \@try-\@catch-\@finally statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_TRY_STMT = 216;
-
-/** Objective-C's \@catch statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_CATCH_STMT = 217;
-
-/** Objective-C's \@finally statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_FINALLY_STMT = 218;
-
-/** Objective-C's \@throw statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_THROW_STMT = 219;
-
-/** Objective-C's \@synchronized statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_SYNCHRONIZED_STMT = 220;
-
-/** Objective-C's autorelease pool statement.
- */
-const CXCursorKind CURSOR_OBJC_AUTORELEASE_POOL_STMT = 221;
-
-/** Objective-C's collection statement.
- */
-const CXCursorKind CURSOR_OBJC_FOR_COLLECTION_STMT = 222;
-
-/** C++'s catch statement.
- */
-const CXCursorKind CURSOR_CXX_CATCH_STMT = 223;
-
-/** C++'s try statement.
- */
-const CXCursorKind CURSOR_CXX_TRY_STMT = 224;
-
-/** C++'s for (* : *) statement.
- */
-const CXCursorKind CURSOR_CXX_FOR_RANGE_STMT = 225;
-
-/** Windows Structured Exception Handling's try statement.
- */
-const CXCursorKind CURSOR_SEH_TRY_STMT = 226;
-
-/** Windows Structured Exception Handling's except statement.
- */
-const CXCursorKind CURSOR_SEH_EXCEPT_STMT = 227;
-
-/** Windows Structured Exception Handling's finally statement.
- */
-const CXCursorKind CURSOR_SEH_FINALLY_STMT = 228;
-
-/** A MS inline assembly statement extension.
- */
-const CXCursorKind CURSOR_MS_ASM_STMT = 229;
-
-/** The null statement ";": C99 6.8.3p3.
- *
- * This cursor kind is used to describe the null statement.
- */
-const CXCursorKind CURSOR_NULL_STMT = 230;
-
-/** Adaptor class for mixing declarations with statements and
- * expressions.
- */
-const CXCursorKind CURSOR_DECL_STMT = 231;
-
-/** OpenMP parallel directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_DIRECTIVE = 232;
-
-/** OpenMP SIMD directive.
- */
-const CXCursorKind CURSOR_OMP_SIMD_DIRECTIVE = 233;
-
-/** OpenMP for directive.
- */
-const CXCursorKind CURSOR_OMP_FOR_DIRECTIVE = 234;
-
-/** OpenMP sections directive.
- */
-const CXCursorKind CURSOR_OMP_SECTIONS_DIRECTIVE = 235;
-
-/** OpenMP section directive.
- */
-const CXCursorKind CURSOR_OMP_SECTION_DIRECTIVE = 236;
-
-/** OpenMP single directive.
- */
-const CXCursorKind CURSOR_OMP_SINGLE_DIRECTIVE = 237;
-
-/** OpenMP parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_FOR_DIRECTIVE = 238;
-
-/** OpenMP parallel sections directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_SECTIONS_DIRECTIVE = 239;
-
-/** OpenMP task directive.
- */
-const CXCursorKind CURSOR_OMP_TASK_DIRECTIVE = 240;
-
-/** OpenMP master directive.
- */
-const CXCursorKind CURSOR_OMP_MASTER_DIRECTIVE = 241;
-
-/** OpenMP critical directive.
- */
-const CXCursorKind CURSOR_OMP_CRITICAL_DIRECTIVE = 242;
-
-/** OpenMP taskyield directive.
- */
-const CXCursorKind CURSOR_OMP_TASKYIELD_DIRECTIVE = 243;
-
-/** OpenMP barrier directive.
- */
-const CXCursorKind CURSOR_OMP_BARRIER_DIRECTIVE = 244;
-
-/** OpenMP taskwait directive.
- */
-const CXCursorKind CURSOR_OMP_TASKWAIT_DIRECTIVE = 245;
-
-/** OpenMP flush directive.
- */
-const CXCursorKind CURSOR_OMP_FLUSH_DIRECTIVE = 246;
-
-/** Windows Structured Exception Handling's leave statement.
- */
-const CXCursorKind CURSOR_SEH_LEAVE_STMT = 247;
-
-/** OpenMP ordered directive.
- */
-const CXCursorKind CURSOR_OMP_ORDERED_DIRECTIVE = 248;
-
-/** OpenMP atomic directive.
- */
-const CXCursorKind CURSOR_OMP_ATOMIC_DIRECTIVE = 249;
-
-/** OpenMP for SIMD directive.
- */
-const CXCursorKind CURSOR_OMP_FOR_SIMD_DIRECTIVE = 250;
-
-/** OpenMP parallel for SIMD directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_FOR_SIMD_DIRECTIVE = 251;
-
-/** OpenMP target directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_DIRECTIVE = 252;
-
-/** OpenMP teams directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DIRECTIVE = 253;
-
-/** OpenMP taskgroup directive.
- */
-const CXCursorKind CURSOR_OMP_TASKGROUP_DIRECTIVE = 254;
-
-/** OpenMP cancellation poCInt directive.
- */
-const CXCursorKind CURSOR_OMP_CANCELLATION_POINT_DIRECTIVE = 255;
-
-/** OpenMP cancel directive.
- */
-const CXCursorKind CURSOR_OMP_CANCEL_DIRECTIVE = 256;
-
-/** OpenMP target data directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_DATA_DIRECTIVE = 257;
-
-/** OpenMP taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_TASK_LOOP_DIRECTIVE = 258;
-
-/** OpenMP taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_TASK_LOOP_SIMD_DIRECTIVE = 259;
-
-/** OpenMP distribute directive.
- */
-const CXCursorKind CURSOR_OMP_DISTRIBUTE_DIRECTIVE = 260;
-
-/** OpenMP target enter data directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_ENTER_DATA_DIRECTIVE = 261;
-
-/** OpenMP target exit data directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_EXIT_DATA_DIRECTIVE = 262;
-
-/** OpenMP target parallel directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_PARALLEL_DIRECTIVE = 263;
-
-/** OpenMP target parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_PARALLEL_FOR_DIRECTIVE = 264;
-
-/** OpenMP target update directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_UPDATE_DIRECTIVE = 265;
-
-/** OpenMP distribute parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 266;
-
-/** OpenMP distribute parallel for simd directive.
- */
-const CXCursorKind CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 267;
-
-/** OpenMP distribute simd directive.
- */
-const CXCursorKind CURSOR_OMP_DISTRIBUTE_SIMD_DIRECTIVE = 268;
-
-/** OpenMP target parallel for simd directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_PARALLEL_FOR_SIMD_DIRECTIVE = 269;
-
-/** OpenMP target simd directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_SIMD_DIRECTIVE = 270;
-
-/** OpenMP teams distribute directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DISTRIBUTE_DIRECTIVE = 271;
-
-/** OpenMP teams distribute simd directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 272;
-
-/** OpenMP teams distribute parallel for simd directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 273;
-
-/** OpenMP teams distribute parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 274;
-
-/** OpenMP target teams directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DIRECTIVE = 275;
-
-/** OpenMP target teams distribute directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_DIRECTIVE = 276;
-
-/** OpenMP target teams distribute parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 277;
-
-/** OpenMP target teams distribute parallel for simd directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 278;
-
-/** OpenMP target teams distribute simd directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 279;
-
-/** C++2a std::bit_cast expression.
- */
-const CXCursorKind CURSOR_BUILTIN_BIT_CAST_EXPR = 280;
-
-/** OpenMP master taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_MASTER_TASK_LOOP_DIRECTIVE = 281;
-
-/** OpenMP parallel master taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_DIRECTIVE = 282;
-
-/** OpenMP master taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 283;
-
-/** OpenMP parallel master taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 284;
-
-/** OpenMP parallel master directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASTER_DIRECTIVE = 285;
-
-/** OpenMP depobj directive.
- */
-const CXCursorKind CURSOR_OMP_DEPOBJ_DIRECTIVE = 286;
-
-/** OpenMP scan directive.
- */
-const CXCursorKind CURSOR_OMP_SCAN_DIRECTIVE = 287;
-
-/** OpenMP tile directive.
- */
-const CXCursorKind CURSOR_OMP_TILE_DIRECTIVE = 288;
-
-/** OpenMP canonical loop.
- */
-const CXCursorKind CURSOR_OMP_CANONICAL_LOOP = 289;
-
-/** OpenMP interop directive.
- */
-const CXCursorKind CURSOR_OMP_INTEROP_DIRECTIVE = 290;
-
-/** OpenMP dispatch directive.
- */
-const CXCursorKind CURSOR_OMP_DISPATCH_DIRECTIVE = 291;
-
-/** OpenMP masked directive.
- */
-const CXCursorKind CURSOR_OMP_MASKED_DIRECTIVE = 292;
-
-/** OpenMP unroll directive.
- */
-const CXCursorKind CURSOR_OMP_UNROLL_DIRECTIVE = 293;
-
-/** OpenMP metadirective directive.
- */
-const CXCursorKind CURSOR_OMP_META_DIRECTIVE = 294;
-
-/** OpenMP loop directive.
- */
-const CXCursorKind CURSOR_OMP_GENERIC_LOOP_DIRECTIVE = 295;
-
-/** OpenMP teams loop directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_GENERIC_LOOP_DIRECTIVE = 296;
-
-/** OpenMP target teams loop directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_GENERIC_LOOP_DIRECTIVE = 297;
-
-/** OpenMP parallel loop directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_GENERIC_LOOP_DIRECTIVE = 298;
-
-/** OpenMP target parallel loop directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_PARALLEL_GENERIC_LOOP_DIRECTIVE = 299;
-
-/** OpenMP parallel masked directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASKED_DIRECTIVE = 300;
-
-/** OpenMP masked taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_MASKED_TASK_LOOP_DIRECTIVE = 301;
-
-/** OpenMP masked taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 302;
-
-/** OpenMP parallel masked taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_DIRECTIVE = 303;
-
-/** OpenMP parallel masked taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 304;
-
-/** OpenMP error directive.
- */
-const CXCursorKind CURSOR_OMP_ERROR_DIRECTIVE = 305;
-
-/** OpenMP scope directive.
- */
-const CXCursorKind CURSOR_OMP_SCOPE_DIRECTIVE = 306;
-
-const CXCursorKind CURSOR_LAST_STMT = CURSOR_OMP_ERROR_DIRECTIVE;
-
-/**
- * Cursor that represents the translation unit itself.
- *
- * The translation unit cursor exists primarily to act as the root
- * cursor for traversing the contents of a translation unit.
- */
-const CXCursorKind CURSOR_TRANSLATION_UNIT = 350;
-
-/* Attributes */
-const CXCursorKind CURSOR_FIRST_ATTR = 400;
-/**
- * An attribute whose specific kind is not exposed via this
- * interface.
- */
-const CXCursorKind CURSOR_UNEXPOSED_ATTR = 400;
-
-const CXCursorKind CURSOR_IB_ACTION_ATTR = 401;
-const CXCursorKind CURSOR_IB_OUTLET_ATTR = 402;
-const CXCursorKind CURSOR_IB_OUTLET_COLLECTION_ATTR = 403;
-const CXCursorKind CURSOR_CXX_FINAL_ATTR = 404;
-const CXCursorKind CURSOR_CXX_OVERRIDE_ATTR = 405;
-const CXCursorKind CURSOR_ANNOTATE_ATTR = 406;
-const CXCursorKind CURSOR_ASM_LABEL_ATTR = 407;
-const CXCursorKind CURSOR_PACKED_ATTR = 408;
-const CXCursorKind CURSOR_PURE_ATTR = 409;
-const CXCursorKind CURSOR_CONST_ATTR = 410;
-const CXCursorKind CURSOR_NO_DUPLICATE_ATTR = 411;
-const CXCursorKind CURSOR_CUDA_CONSTANT_ATTR = 412;
-const CXCursorKind CURSOR_CUDA_DEVICE_ATTR = 413;
-const CXCursorKind CURSOR_CUDA_GLOBAL_ATTR = 414;
-const CXCursorKind CURSOR_CUDA_HOST_ATTR = 415;
-const CXCursorKind CURSOR_CUDA_SHARED_ATTR = 416;
-const CXCursorKind CURSOR_VISIBILITY_ATTR = 417;
-const CXCursorKind CURSOR_DLL_EXPORT = 418;
-const CXCursorKind CURSOR_DLL_IMPORT = 419;
-const CXCursorKind CURSOR_NS_RETURNS_RETAINED = 420;
-const CXCursorKind CURSOR_NS_RETURNS_NOT_RETAINED = 421;
-const CXCursorKind CURSOR_NS_RETURNS_AUTORELEASED = 422;
-const CXCursorKind CURSOR_NS_CONSUMES_SELF = 423;
-const CXCursorKind CURSOR_NS_CONSUMED = 424;
-const CXCursorKind CURSOR_OBJC_EXCEPTION = 425;
-const CXCursorKind CURSOR_OBJC_NS_OBJECT = 426;
-const CXCursorKind CURSOR_OBJC_INDEPENDENT_CLASS = 427;
-const CXCursorKind CURSOR_OBJC_PRECISE_LIFETIME = 428;
-const CXCursorKind CURSOR_OBJC_RETURNS_INNER_POINTER = 429;
-const CXCursorKind CURSOR_OBJC_REQUIRES_SUPER = 430;
-const CXCursorKind CURSOR_OBJC_ROOT_CLASS = 431;
-const CXCursorKind CURSOR_OBJC_SUBCLASSING_RESTRICTED = 432;
-const CXCursorKind CURSOR_OBJC_EXPLICIT_PROTOCOL_IMPL = 433;
-const CXCursorKind CURSOR_OBJC_DESIGNATED_INITIALIZER = 434;
-const CXCursorKind CURSOR_OBJC_RUNTIME_VISIBLE = 435;
-const CXCursorKind CURSOR_OBJC_BOXABLE = 436;
-const CXCursorKind CURSOR_FLAG_ENUM = 437;
-const CXCursorKind CURSOR_CONVERGENT_ATTR = 438;
-const CXCursorKind CURSOR_WARN_UNUSED_ATTR = 439;
-const CXCursorKind CURSOR_WARN_UNUSED_RESULT_ATTR = 440;
-const CXCursorKind CURSOR_ALIGNED_ATTR = 441;
-const CXCursorKind CURSOR_LAST_ATTR = CURSOR_ALIGNED_ATTR;
-
-/* Preprocessing */
-const CXCursorKind CURSOR_PREPROCESSING_DIRECTIVE = 500;
-const CXCursorKind CURSOR_MACRO_DEFINITION = 501;
-const CXCursorKind CURSOR_MACRO_EXPANSION = 502;
-const CXCursorKind CURSOR_MACRO_INSTANTIATION = CURSOR_MACRO_EXPANSION;
-const CXCursorKind CURSOR_INCLUSION_DIRECTIVE = 503;
-const CXCursorKind CURSOR_FIRST_PREPROCESSING = CURSOR_PREPROCESSING_DIRECTIVE;
-const CXCursorKind CURSOR_LAST_PREPROCESSING = CURSOR_INCLUSION_DIRECTIVE;
-
-/* Extra Declarations */
-/**
- * A module import declaration.
- */
-const CXCursorKind CURSOR_MODULE_IMPORT_DECL = 600;
-const CXCursorKind CURSOR_TYPE_ALIAS_TEMPLATE_DECL = 601;
-/**
- * A static_assert or _Static_assert node
- */
-const CXCursorKind CURSOR_STATIC_ASSERT = 602;
-/**
- * a friend declaration.
- */
-const CXCursorKind CURSOR_FRIEND_DECL = 603;
-/**
- * a concept declaration.
- */
-const CXCursorKind CURSOR_CONCEPT_DECL = 604;
-
-const CXCursorKind CURSOR_FIRST_EXTRA_DECL = CURSOR_MODULE_IMPORT_DECL;
-const CXCursorKind CURSOR_LAST_EXTRA_DECL = CURSOR_CONCEPT_DECL;
-
-/**
- * A code completion overload candidate.
- */
-const CXCursorKind CURSOR_OVERLOAD_CANDIDATE = 700;
-
-/**
- * A cursor representing some element in the abstract syntax tree for
- * a translation unit.
- *
- * The cursor abstraction unifies the different kinds of entities in a
- * program--declaration, statements, expressions, references to declarations,
- * etc.--under a single "cursor" abstraction with a common set of operations.
- * Common operation for a cursor include: getting the physical location in
- * a source file where the cursor points, getting the name associated with a
- * cursor, and retrieving cursors for any child nodes of a particular cursor.
- *
- * Cursors can be produced in two specific ways.
- * clang_getTranslationUnitCursor() produces a cursor for a translation unit,
- * from which one can use clang_visitChildren() to explore the rest of the
- * translation unit. clang_getCursor() maps from a physical source location
- * to the entity that resides at that location, allowing one to map from the
- * source code into the AST.
- */
 struct CXCursor {
   CXCursorKind kind;
   CInt xdata;
   void*[3] data;
 }
 
-/**
- * Retrieve the NULL cursor, which represents no entity.
- */
-fn CXCursor getNullCursor() 
-@extern("clang_getNullCursor");
+extern fn CXCursor getNullCursor()
+@cname("clang_getNullCursor");
 
-/**
- * Retrieve the cursor that represents the given translation unit.
- *
- * The translation unit cursor can be used to start traversing the
- * various declarations within the given translation unit.
- */
-fn CXCursor getTranslationUnitCursor(
-  CXTranslationUnit tu) 
-@extern("clang_getTranslationUnitCursor");
+extern fn CXCursor getTranslationUnitCursor(
+  CXTranslationUnit)
+@cname("clang_getTranslationUnitCursor");
 
-/**
- * Determine whether two cursors are equivalent.
- */
-fn CUInt equalCursors(
-  CXCursor cursor1, 
-  CXCursor cursor2) 
-@extern("clang_equalCursors");
+extern fn CUInt equalCursors(
+  CXCursor,
+  CXCursor)
+@cname("clang_equalCursors");
 
-/**
- * Returns non-zero if \p cursor is null.
- */
-fn CInt isNull_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_isNull");
+extern fn CInt cursor_isNull(
+  CXCursor cursor)
+@cname("clang_Cursor_isNull");
 
-/**
- * Compute a hash value for the given cursor.
- */
-fn CUInt hashCursor(
-  CXCursor cursor) 
-@extern("clang_hashCursor");
+extern fn CUInt hashCursor(
+  CXCursor)
+@cname("clang_hashCursor");
 
-/**
- * Retrieve the kind of the given cursor.
- */
-fn CXCursorKind getCursorKind(
-  CXCursor cursor) 
-@extern("clang_getCursorKind");
+extern fn CXCursorKind getCursorKind(
+  CXCursor)
+@cname("clang_getCursorKind");
 
-/**
- * Determine whether the given cursor kind represents a declaration.
- */
-fn CUInt isDeclaration(
-  CXCursorKind cursor_kind) 
-@extern("clang_isDeclaration");
+extern fn CUInt isDeclaration(
+  CXCursorKind)
+@cname("clang_isDeclaration");
 
-/**
- * Determine whether the given declaration is invalid.
- *
- * A declaration is invalid if it could not be parsed successfully.
- *
- * \returns non-zero if the cursor represents a declaration and it is
- * invalid, otherwise NULL.
- */
-fn CUInt isInvalidDeclaration(
-  CXCursor cursor) 
-@extern("clang_isInvalidDeclaration");
+extern fn CUInt isInvalidDeclaration(
+  CXCursor)
+@cname("clang_isInvalidDeclaration");
 
-/**
- * Determine whether the given cursor kind represents a simple
- * reference.
- *
- * Note that other kinds of cursors (such as expressions) can also refer to
- * other cursors. Use clang_getCursorReferenced() to determine whether a
- * particular cursor refers to another entity.
- */
-fn CUInt isReference(
-  CXCursorKind kind) 
-@extern("clang_isReference");
+extern fn CUInt isReference(
+  CXCursorKind)
+@cname("clang_isReference");
 
-/**
- * Determine whether the given cursor kind represents an expression.
- */
-fn CUInt isExpression(
-  CXCursorKind kind) 
-@extern("clang_isExpression");
+extern fn CUInt isExpression(
+  CXCursorKind)
+@cname("clang_isExpression");
 
-/**
- * Determine whether the given cursor kind represents a statement.
- */
-fn CUInt isStatement(
-  CXCursorKind kind) 
-@extern("clang_isStatement");
+extern fn CUInt isStatement(
+  CXCursorKind)
+@cname("clang_isStatement");
 
-/**
- * Determine whether the given cursor kind represents an attribute.
- */
-fn CUInt isAttribute(
-  CXCursorKind kind) 
-@extern("clang_isAttribute");
+extern fn CUInt isAttribute(
+  CXCursorKind)
+@cname("clang_isAttribute");
 
-/**
- * Determine whether the given cursor has any attributes.
- */
-fn CUInt hasAttrs_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_hasAttrs");
+extern fn CUInt cursor_hasAttrs(
+  CXCursor c)
+@cname("clang_Cursor_hasAttrs");
 
-/**
- * Determine whether the given cursor kind represents an invalid
- * cursor.
- */
-fn CUInt isInvalid(
-  CXCursorKind kind) 
-@extern("clang_isInvalid");
+extern fn CUInt isInvalid(
+  CXCursorKind)
+@cname("clang_isInvalid");
 
-/**
- * Determine whether the given cursor kind represents a translation
- * unit.
- */
-fn CUInt isTranslationUnit(
-  CXCursorKind kind) 
-@extern("clang_isTranslationUnit");
+extern fn CUInt isTranslationUnit(
+  CXCursorKind)
+@cname("clang_isTranslationUnit");
 
-/***
- * Determine whether the given cursor represents a preprocessing
- * element, such as a preprocessor directive or macro instantiation.
- */
-fn CUInt isPreprocessing(
-  CXCursorKind kind) 
-@extern("clang_isPreprocessing");
+extern fn CUInt isPreprocessing(
+  CXCursorKind)
+@cname("clang_isPreprocessing");
 
-/***
- * Determine whether the given cursor represents a currently
- *  unexposed piece of the AST (e.g., CXCursor_UnexposedStmt).
- */
-fn CUInt isUnexposed(
-  CXCursorKind kind) 
-@extern("clang_isUnexposed");
+extern fn CUInt isUnexposed(
+  CXCursorKind)
+@cname("clang_isUnexposed");
 
-/**
- * Describe the linkage of the entity referred to by a cursor.
- */
-typedef CXLinkageKind = inline CInt;
+constdef CXLinkageKind : CInt {
+  LINKAGE_INVALID = 0,
+  LINKAGE_NO_LINKAGE = 1,
+  LINKAGE_INTERNAL = 2,
+  LINKAGE_UNIQUE_EXTERNAL = 3,
+  LINKAGE_EXTERNAL = 4
+}
 
-/** This value indicates that no linkage information is available
- * for a provided CXCursor. 
- */
-const CXLinkageKind LINKAGE_INVALID = 0;
-/**
- * This is the linkage for variables, parameters, and so on that
- *  have automatic storage.  This covers normal (non-extern) local variables.
- */
-const CXLinkageKind LINKAGE_NO_LINKAGE = 1;
-/** This is the linkage for static variables and static functions. 
- */
-const CXLinkageKind LINKAGE_INTERNAL = 2;
-/** This is the linkage for entities with external linkage that live
- * in C++ anonymous namespaces.
- */
-const CXLinkageKind LINKAGE_UNIQUE_EXTERNAL = 3;
-/** This is the linkage for entities with true, external linkage. 
- */
-const CXLinkageKind LINKAGE_EXTERNAL = 4;
+extern fn CXLinkageKind getCursorLinkage(
+  CXCursor cursor)
+@cname("clang_getCursorLinkage");
 
-/**
- * Determine the linkage of the entity referred to by a given cursor.
- */
-fn CXLinkageKind getCursorLinkage(
-  CXCursor cursor) 
-@extern("clang_getCursorLinkage");
+constdef CXVisibilityKind : CInt {
+  VISIBILITY_INVALID = 0,
+  VISIBILITY_HIDDEN = 1,
+  VISIBILITY_PROTECTED = 2,
+  VISIBILITY_DEFAULT = 3
+}
 
-typedef CXVisibilityKind = inline CInt;
+extern fn CXVisibilityKind getCursorVisibility(
+  CXCursor cursor)
+@cname("clang_getCursorVisibility");
 
-/** This value indicates that no visibility information is available
- * for a provided CXCursor. 
- */
-const CXVisibilityKind VISIBILITY_INVALID = 0;
-/** Symbol not seen by the linker. 
- */
-const CXVisibilityKind VISIBILITY_HIDDEN = 1;
-/** Symbol seen by the linker but resolves to a symbol inside this object. 
- */
-const CXVisibilityKind VISIBILITY_PROTECTED = 2;
-/** Symbol seen by the linker and acts like a normal symbol. 
- */
-const CXVisibilityKind VISIBILITY_DEFAULT = 3;
+extern fn CXAvailabilityKind getCursorAvailability(
+  CXCursor cursor)
+@cname("clang_getCursorAvailability");
 
-/**
- * Describe the visibility of the entity referred to by a cursor.
- *
- * This returns the default visibility if not explicitly specified by
- * a visibility attribute. The default visibility may be changed by
- * commandline arguments.
- *
- * \param cursor The cursor to query.
- *
- * \returns The visibility of the cursor.
- */
-fn CXVisibilityKind getCursorVisibility(
-  CXCursor cursor) 
-@extern("clang_getCursorVisibility");
-
-/**
- * Determine the availability of the entity that this cursor refers to,
- * taking the current target platform into account.
- *
- * \param cursor The cursor to query.
- *
- * \returns The availability of the cursor.
- */
-fn CXAvailabilityKind getCursorAvailability(
-  CXCursor cursor) 
-@extern("clang_getCursorAvailability");
-
-/**
- * Describes the availability of a given entity on a particular platform, e.g.,
- * a particular class might only be available on Mac OS 10.7 or newer.
- */
 struct CXPlatformAvailability {
-  /*
-   * A string that describes the platform for which this structure
-   * provides availability information.
-   *
-   * Possible values are "ios" or "macos".
-   */
   CXString platform;
-  /*
-   * The version number in which this entity was introduced.
-   */
   CXVersion introduced;
-  /*
-   * The version number in which this entity was deprecated (but is
-   * still available).
-   */
   CXVersion deprecated;
-  /*
-   * The version number in which this entity was obsoleted, and therefore
-   * is no longer available.
-   */
   CXVersion obsoleted;
-  /*
-   * Whether the entity is unconditionally unavailable on this platform.
-   */
   CInt unavailable;
-  /*
-   * An optional message to provide to a user of this API, e.g., to
-   * suggest replacement APIs.
-   */
   CXString message;
 }
 
-/**
- * Determine the availability of the entity that this cursor refers to
- * on any platforms for which availability information is known.
- *
- * \param cursor The cursor to query.
- *
- * \param always_deprecated If non-NULL, will be set to indicate whether the
- * entity is deprecated on all platforms.
- *
- * \param deprecated_message If non-NULL, will be set to the message text
- * provided along with the unconditional deprecation of this entity. The client
- * is responsible for deallocating this string.
- *
- * \param always_unavailable If non-NULL, will be set to indicate whether the
- * entity is unavailable on all platforms.
- *
- * \param unavailable_message If non-NULL, will be set to the message text
- * provided along with the unconditional unavailability of this entity. The
- * client is responsible for deallocating this string.
- *
- * \param availability If non-NULL, an array of CXPlatformAvailability instances
- * that will be populated with platform availability information, up to either
- * the number of platforms for which availability information is available (as
- * returned by this function) or \c availability_size, whichever is smaller.
- *
- * \param availability_size The number of elements available in the
- * \c availability array.
- *
- * \returns The number of platforms (N) for which availability information is
- * available (which is unrelated to \c availability_size).
- *
- * Note that the client is responsible for calling
- * \c clang_disposeCXPlatformAvailability to free each of the
- * platform-availability structures returned. There are
- * \c min(N, availability_size) such structures.
- */
-fn CInt getCursorPlatformAvailability(
-  CXCursor cursor, 
-  CInt* always_deprecated, 
-  CXString* deprecated_message, 
-  CInt* always_unavailable, 
-  CXString* unavailable_message, 
-  CXPlatformAvailability* availability, 
-  CInt availability_size) 
-@extern("clang_getCursorPlatformAvailability");
+extern fn CInt getCursorPlatformAvailability(
+  CXCursor cursor,
+  CInt* always_deprecated,
+  CXString* deprecated_message,
+  CInt* always_unavailable,
+  CXString* unavailable_message,
+  CXPlatformAvailability* availability,
+  CInt availability_size)
+@cname("clang_getCursorPlatformAvailability");
 
-/**
- * Free the memory associated with a \c CXPlatformAvailability structure.
- */
-fn void disposeCXPlatformAvailability(
-  CXPlatformAvailability* availability) 
-@extern("clang_disposeCXPlatformAvailability");
+extern fn void disposeCXPlatformAvailability(
+  CXPlatformAvailability* availability)
+@cname("clang_disposeCXPlatformAvailability");
 
-/**
- * If cursor refers to a variable declaration and it has initializer returns
- * cursor referring to the initializer otherwise return null cursor.
- */
-fn CXCursor getVarDeclInitializer_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_getVarDeclInitializer");
+extern fn CXCursor cursor_getVarDeclInitializer(
+  CXCursor cursor)
+@cname("clang_Cursor_getVarDeclInitializer");
 
-/**
- * If cursor refers to a variable declaration that has global storage returns 1.
- * If cursor refers to a variable declaration that doesn't have global storage
- * returns 0. Otherwise returns -1.
- */
-fn CInt hasVarDeclGlobalStorage_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_hasVarDeclGlobalStorage");
+extern fn CInt cursor_hasVarDeclGlobalStorage(
+  CXCursor cursor)
+@cname("clang_Cursor_hasVarDeclGlobalStorage");
 
-/**
- * If cursor refers to a variable declaration that has external storage
- * returns 1. If cursor refers to a variable declaration that doesn't have
- * external storage returns 0. Otherwise returns -1.
- */
-fn CInt hasVarDeclExternalStorage_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_hasVarDeclExternalStorage");
+extern fn CInt cursor_hasVarDeclExternalStorage(
+  CXCursor cursor)
+@cname("clang_Cursor_hasVarDeclExternalStorage");
 
-/**
- * Describe the "language" of the entity referred to by a cursor.
- */
-typedef CXLanguageKind = inline CInt;
-const CXLinkageKind LANGUAGE_INVALID = 0;
-const CXLinkageKind LANGUAGE_C = 1;
-const CXLinkageKind LANGUAGE_OBJC = 2;
-const CXLinkageKind LANGUAGE_C_PLUS_PLUS = 3;
+constdef CXLanguageKind : CInt {
+  LANGUAGE_INVALID = 0,
+  LANGUAGE_C = 1,
+  LANGUAGE_OBJ_C = 2,
+  LANGUAGE_C_PLUS_PLUS = 3
+}
 
-/**
- * Determine the "language" of the entity referred to by a given cursor.
- */
-fn CXLanguageKind getCursorLanguage(
-  CXCursor cursor) 
-@extern("clang_getCursorLanguage");
+extern fn CXLanguageKind getCursorLanguage(
+  CXCursor cursor)
+@cname("clang_getCursorLanguage");
 
-/**
- * Describe the "thread-local storage (TLS) kind" of the declaration
- * referred to by a cursor.
- */
-typedef CXTLSKind = inline CInt;
-const CXTLSKind TLS_NONE = 0;
-const CXTLSKind TLS_DYNAMIC = 1;
-const CXTLSKind TLS_STATIC = 2;
+constdef CXTLSKind : CInt {
+  TLS_NONE = 0,
+  TLS_DYNAMIC = 1,
+  TLS_STATIC = 2
+}
 
-/**
- * Determine the "thread-local storage (TLS) kind" of the declaration
- * referred to by a cursor.
- */
-fn CXTLSKind getCursorTLSKind(
-  CXCursor cursor) 
-@extern("clang_getCursorTLSKind");
+extern fn CXTLSKind getCursorTLSKind(
+  CXCursor cursor)
+@cname("clang_getCursorTLSKind");
 
-/**
- * Returns the translation unit that a cursor originated from.
- */
-fn CXTranslationUnit getTranslationUnit_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_getTranslationUnit");
+extern fn CXTranslationUnit cursor_getTranslationUnit(
+  CXCursor)
+@cname("clang_Cursor_getTranslationUnit");
 
-/**
- * A fast container representing a set of CXCursors.
- */
-typedef CXCursorSet = inline void*;
+alias CXCursorSet = void*;
 
-/**
- * Creates an empty CXCursorSet.
- */
-fn CXCursorSet createCXCursorSet() 
-@extern("clang_createCXCursorSet");
+extern fn CXCursorSet createCXCursorSet()
+@cname("clang_createCXCursorSet");
 
-/**
- * Disposes a CXCursorSet and releases its associated memory.
- */
-fn void disposeCXCursorSet(
-  CXCursorSet cset) 
-@extern("clang_disposeCXCursorSet");
+extern fn void disposeCXCursorSet(
+  CXCursorSet cset)
+@cname("clang_disposeCXCursorSet");
 
-/**
- * Queries a CXCursorSet to see if it contains a specific CXCursor.
- *
- * \returns non-zero if the set contains the specified cursor.
- */
-fn CUInt contains_CursorSet(
-  CXCursorSet cset, 
-  CXCursor cursor) 
-@extern("clang_CXCursorSet_contains");
+extern fn CUInt cXCursorSet_contains(
+  CXCursorSet cset,
+  CXCursor cursor)
+@cname("clang_CXCursorSet_contains");
 
-/**
- * Inserts a CXCursor into a CXCursorSet.
- *
- * \returns zero if the CXCursor was already in the set, and non-zero otherwise.
- */
-fn CUInt insert_CursorSet(
-  CXCursorSet cset, 
-  CXCursor cursor) 
-@extern("clang_CXCursorSet_insert");
+extern fn CUInt cXCursorSet_insert(
+  CXCursorSet cset,
+  CXCursor cursor)
+@cname("clang_CXCursorSet_insert");
 
-/**
- * Determine the semantic parent of the given cursor.
- *
- * The semantic parent of a cursor is the cursor that semantically contains
- * the given \p cursor. For many declarations, the lexical and semantic parents
- * are equivalent (the lexical parent is returned by
- * \c clang_getCursorLexicalParent()). They diverge when declarations or
- * definitions are provided out-of-line. For example:
- *
- * \code
- * class C {
- *  void f();
- * };
- *
- * void C::f() { }
- * \endcode
- *
- * In the out-of-line definition of \c C::f, the semantic parent is
- * the class \c C, of which this function is a member. The lexical parent is
- * the place where the declaration actually occurs in the source code; in this
- * case, the definition occurs in the translation unit. In general, the
- * lexical parent for a given entity can change without affecting the semantics
- * of the program, and the lexical parent of different declarations of the
- * same entity may be different. Changing the semantic parent of a declaration,
- * on the other hand, can have a major impact on semantics, and redeclarations
- * of a particular entity should all have the same semantic context.
- *
- * In the example above, both declarations of \c C::f have \c C as their
- * semantic context, while the lexical context of the first \c C::f is \c C
- * and the lexical context of the second \c C::f is the translation unit.
- *
- * For global declarations, the semantic parent is the translation unit.
- */
-fn CXCursor getCursorSemanticParent(
-  CXCursor cursor) 
-@extern("clang_getCursorSemanticParent");
+extern fn CXCursor getCursorSemanticParent(
+  CXCursor cursor)
+@cname("clang_getCursorSemanticParent");
 
-/**
- * Determine the lexical parent of the given cursor.
- *
- * The lexical parent of a cursor is the cursor in which the given \p cursor
- * was actually written. For many declarations, the lexical and semantic parents
- * are equivalent (the semantic parent is returned by
- * \c clang_getCursorSemanticParent()). They diverge when declarations or
- * definitions are provided out-of-line. For example:
- *
- * \code
- * class C {
- *  void f();
- * };
- *
- * void C::f() { }
- * \endcode
- *
- * In the out-of-line definition of \c C::f, the semantic parent is
- * the class \c C, of which this function is a member. The lexical parent is
- * the place where the declaration actually occurs in the source code; in this
- * case, the definition occurs in the translation unit. In general, the
- * lexical parent for a given entity can change without affecting the semantics
- * of the program, and the lexical parent of different declarations of the
- * same entity may be different. Changing the semantic parent of a declaration,
- * on the other hand, can have a major impact on semantics, and redeclarations
- * of a particular entity should all have the same semantic context.
- *
- * In the example above, both declarations of \c C::f have \c C as their
- * semantic context, while the lexical context of the first \c C::f is \c C
- * and the lexical context of the second \c C::f is the translation unit.
- *
- * For declarations written in the global scope, the lexical parent is
- * the translation unit.
- */
-fn CXCursor getCursorLexicalParent(
-  CXCursor cursor) 
-@extern("clang_getCursorLexicalParent");
+extern fn CXCursor getCursorLexicalParent(
+  CXCursor cursor)
+@cname("clang_getCursorLexicalParent");
 
-/**
- * Determine the set of methods that are overridden by the given
- * method.
- *
- * In both Objective-C and C++, a method (aka virtual member function,
- * in C++) can override a virtual method in a base class. For
- * Objective-C, a method is said to override any method in the class's
- * base class, its protocols, or its categories' protocols, that has the same
- * selector and is of the same kind (class or instance).
- * If no such method exists, the search continues to the class's superclass,
- * its protocols, and its categories, and so on. A method from an Objective-C
- * implementation is considered to override the same methods as its
- * corresponding method in the interface.
- *
- * For C++, a virtual member function overrides any virtual member
- * function with the same signature that occurs in its base
- * classes. With multiple inheritance, a virtual member function can
- * override several virtual member functions coming from different
- * base classes.
- *
- * In all cases, this function determines the immediate overridden
- * method, rather than all of the overridden methods. For example, if
- * a method is originally declared in a class A, then overridden in B
- * (which in inherits from A) and also in C (which inherited from B),
- * then the only overridden method returned from this function when
- * invoked on C's method will be B's method. The client may then
- * invoke this function again, given the previously-found overridden
- * methods, to map out the complete method-override set.
- *
- * \param cursor A cursor representing an Objective-C or C++
- * method. This routine will compute the set of methods that this
- * method overrides.
- *
- * \param overridden A pointer whose pointee will be replaced with a
- * pointer to an array of cursors, representing the set of overridden
- * methods. If there are no overridden methods, the pointee will be
- * set to NULL. The pointee must be freed via a call to
- * \c clang_disposeOverriddenCursors().
- *
- * \param num_overridden A pointer to the number of overridden
- * functions, will be set to the number of overridden functions in the
- * array pointed to by \p overridden.
- */
-fn void getOverriddenCursors(
-  CXCursor cursor, 
-  CXCursor** overridden, 
-  CUInt* num_overridden) 
-@extern("clang_getOverriddenCursors");
+extern fn void getOverriddenCursors(
+  CXCursor cursor,
+  CXCursor** overridden,
+  CUInt* num_overridden)
+@cname("clang_getOverriddenCursors");
 
-/**
- * Free the set of overridden cursors returned by \c
- * clang_getOverriddenCursors().
- */
-fn void disposeOverriddenCursors(
-  CXCursor* overridden) 
-@extern("clang_disposeOverriddenCursors");
+extern fn void disposeOverriddenCursors(
+  CXCursor* overridden)
+@cname("clang_disposeOverriddenCursors");
 
-/**
- * Retrieve the file that is included by the given inclusion directive
- * cursor.
- */
-fn CXFile getIncludedFile(
-  CXCursor cursor) 
-@extern("clang_getIncludedFile");
+extern fn CXFile getIncludedFile(
+  CXCursor cursor)
+@cname("clang_getIncludedFile");
 
-/**
- * Map a source location to the cursor that describes the entity at that
- * location in the source code.
- *
- * clang_getCursor() maps an arbitrary source location within a translation
- * unit down to the most specific cursor that describes the entity at that
- * location. For example, given an expression \c x + y, invoking
- * clang_getCursor() with a source location pointing to "x" will return the
- * cursor for "x"; similarly for "y". If the cursor points anywhere between
- * "x" or "y" (e.g., on the + or the whitespace around it), clang_getCursor()
- * will return a cursor referring to the "+" expression.
- *
- * \returns a cursor representing the entity at the given source location, or
- * a NULL cursor if no such entity can be found.
- */
-fn CXCursor getCursor(
-  CXTranslationUnit tu, 
-  CXSourceLocation source_location) 
-@extern("clang_getCursor");
+extern fn CXCursor getCursor(
+  CXTranslationUnit,
+  CXSourceLocation)
+@cname("clang_getCursor");
 
-/**
- * Retrieve the physical location of the source constructor referenced
- * by the given cursor.
- *
- * The location of a declaration is typically the location of the name of that
- * declaration, where the name of that declaration would occur if it is
- * unnamed, or some keyword that introduces that particular declaration.
- * The location of a reference is where that reference occurs within the
- * source code.
- */
-fn CXSourceLocation getCursorLocation(
-  CXCursor cursor) 
-@extern("clang_getCursorLocation");
+extern fn CXSourceLocation getCursorLocation(
+  CXCursor)
+@cname("clang_getCursorLocation");
 
-/**
- * Retrieve the physical extent of the source construct referenced by
- * the given cursor.
- *
- * The extent of a cursor starts with the file/line/column pointing at the
- * first character within the source construct that the cursor refers to and
- * ends with the last character within that source construct. For a
- * declaration, the extent covers the declaration itself. For a reference,
- * the extent covers the location of the reference (e.g., where the referenced
- * entity was actually used).
- */
-fn CXSourceRange getCursorExtent(
-  CXCursor cursor) 
-@extern("clang_getCursorExtent");
+extern fn CXSourceRange getCursorExtent(
+  CXCursor)
+@cname("clang_getCursorExtent");
 
-/**
- * Describes the kind of type
- */
-typedef CXTypeKind = inline CInt;
+constdef CXTypeKind : CInt {
+  TYPE_INVALID = 0,
+  TYPE_UNEXPOSED = 1,
+  TYPE_VOID = 2,
+  TYPE_BOOL = 3,
+  TYPE_CHAR_U = 4,
+  TYPE_UCHAR = 5,
+  TYPE_CHAR_16 = 6,
+  TYPE_CHAR_32 = 7,
+  TYPE_USHORT = 8,
+  TYPE_UINT = 9,
+  TYPE_ULONG = 10,
+  TYPE_ULONGLONG = 11,
+  TYPE_UINT128 = 12,
+  TYPE_CHARS = 13,
+  TYPE_SCHAR = 14,
+  TYPE_WCHAR = 15,
+  TYPE_SHORT = 16,
+  TYPE_INT = 17,
+  TYPE_LONG = 18,
+  TYPE_LONG_LONG = 19,
+  TYPE_INT_128 = 20,
+  TYPE_FLOAT = 21,
+  TYPE_DOUBLE = 22,
+  TYPE_LONG_DOUBLE = 23,
+  TYPE_NULL_PTR = 24,
+  TYPE_OVERLOAD = 25,
+  TYPE_DEPENDENT = 26,
+  TYPE_OBJ_C_ID = 27,
+  TYPE_OBJ_C_CLASS = 28,
+  TYPE_OBJ_C_SEL = 29,
+  TYPE_FLOAT_128 = 30,
+  TYPE_HALF = 31,
+  TYPE_FLOAT_16 = 32,
+  TYPE_SHORT_ACCUM = 33,
+  TYPE_ACCUM = 34,
+  TYPE_LONG_ACCUM = 35,
+  TYPE_U_SHORT_ACCUM = 36,
+  TYPE_U_ACCUM = 37,
+  TYPE_U_LONG_ACCUM = 38,
+  TYPE_B_FLOAT_16 = 39,
+  TYPE_IBM_128 = 40,
+  TYPE_FIRST_BUILTIN = 2,
+  TYPE_LAST_BUILTIN = 40,
+  TYPE_COMPLEX = 100,
+  TYPE_POINTER = 101,
+  TYPE_BLOCK_POINTER = 102,
+  TYPE_L_VALUE_REFERENCE = 103,
+  TYPE_R_VALUE_REFERENCE = 104,
+  TYPE_RECORD = 105,
+  TYPE_ENUM = 106,
+  TYPE_TYPEDEF = 107,
+  TYPE_OBJ_C_INTERFACE = 108,
+  TYPE_OBJ_C_OBJECT_POINTER = 109,
+  TYPE_FUNCTION_NO_PROTO = 110,
+  TYPE_FUNCTION_PROTO = 111,
+  TYPE_CONSTANT_ARRAY = 112,
+  TYPE_VECTOR = 113,
+  TYPE_INCOMPLETE_ARRAY = 114,
+  TYPE_VARIABLE_ARRAY = 115,
+  TYPE_DEPENDENT_SIZED_ARRAY = 116,
+  TYPE_MEMBER_POINTER = 117,
+  TYPE_AUTO = 118,
+  TYPE_ELABORATED = 119,
+  TYPE_PIPE = 120,
+  TYPE_OCL_IMAGE_1_D_RO = 121,
+  TYPE_OCL_IMAGE_1_D_ARRAY_RO = 122,
+  TYPE_OCL_IMAGE_1_D_BUFFER_RO = 123,
+  TYPE_OCL_IMAGE_2_D_RO = 124,
+  TYPE_OCL_IMAGE_2_D_ARRAY_RO = 125,
+  TYPE_OCL_IMAGE_2_D_DEPTH_RO = 126,
+  TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_RO = 127,
+  TYPE_OCL_IMAGE_2_D_MSAARO = 128,
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAARO = 129,
+  TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_RO = 130,
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_RO = 131,
+  TYPE_OCL_IMAGE_3_D_RO = 132,
+  TYPE_OCL_IMAGE_1_D_WO = 133,
+  TYPE_OCL_IMAGE_1_D_ARRAY_WO = 134,
+  TYPE_OCL_IMAGE_1_D_BUFFER_WO = 135,
+  TYPE_OCL_IMAGE_2_D_WO = 136,
+  TYPE_OCL_IMAGE_2_D_ARRAY_WO = 137,
+  TYPE_OCL_IMAGE_2_D_DEPTH_WO = 138,
+  TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_WO = 139,
+  TYPE_OCL_IMAGE_2_D_MSAAWO = 140,
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAAWO = 141,
+  TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_WO = 142,
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_WO = 143,
+  TYPE_OCL_IMAGE_3_D_WO = 144,
+  TYPE_OCL_IMAGE_1_D_RW = 145,
+  TYPE_OCL_IMAGE_1_D_ARRAY_RW = 146,
+  TYPE_OCL_IMAGE_1_D_BUFFER_RW = 147,
+  TYPE_OCL_IMAGE_2_D_RW = 148,
+  TYPE_OCL_IMAGE_2_D_ARRAY_RW = 149,
+  TYPE_OCL_IMAGE_2_D_DEPTH_RW = 150,
+  TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_RW = 151,
+  TYPE_OCL_IMAGE_2_D_MSAARW = 152,
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAARW = 153,
+  TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_RW = 154,
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_RW = 155,
+  TYPE_OCL_IMAGE_3_D_RW = 156,
+  TYPE_OCL_SAMPLER = 157,
+  TYPE_OCL_EVENT = 158,
+  TYPE_OCL_QUEUE = 159,
+  TYPE_OCL_RESERVE_ID = 160,
+  TYPE_OBJ_C_OBJECT = 161,
+  TYPE_OBJ_C_TYPE_PARAM = 162,
+  TYPE_ATTRIBUTED = 163,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_PAYLOAD = 164,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_PAYLOAD = 165,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_REF_PAYLOAD = 166,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_PAYLOAD = 167,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_RESULT = 168,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT = 169,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_REF_RESULT = 170,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_RESULT = 171,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REFERENCE_STREAMOUT = 172,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REFERENCE_STREAMOUT = 173,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REFERENCE_STREAMIN = 174,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REFERENCE_STREAMIN = 175,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REF_STREAMOUT = 172,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REF_STREAMOUT = 173,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REF_STREAMIN = 174,
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REF_STREAMIN = 175,
+  TYPE_EXT_VECTOR = 176,
+  TYPE_ATOMIC = 177,
+  TYPE_BTF_TAG_ATTRIBUTED = 178,
+  TYPE_HLSL_RESOURCE = 179,
+  TYPE_HLSL_ATTRIBUTED_RESOURCE = 180,
+  TYPE_HLSL_INLINE_SPIRV = 181
+}
 
-/**
- * Represents an invalid type (e.g., where no type is available).
- */
-const CXTypeKind TYPE_INVALID = 0;
+constdef CXCallingConv : CInt {
+  CALLING_CONV_DEFAULT = 0,
+  CALLING_CONV_C = 1,
+  CALLING_CONV_X86_STD_CALL = 2,
+  CALLING_CONV_X86_FAST_CALL = 3,
+  CALLING_CONV_X86_THIS_CALL = 4,
+  CALLING_CONV_X86_PASCAL = 5,
+  CALLING_CONV_AAPCS = 6,
+  CALLING_CONV_AAPCS_VFP = 7,
+  CALLING_CONV_X86_REG_CALL = 8,
+  CALLING_CONV_INTEL_OCL_BICC = 9,
+  CALLING_CONV_WIN_64 = 10,
+  CALLING_CONV_X86_64_WIN_64 = 10,
+  CALLING_CONV_X86_64_SYS_V = 11,
+  CALLING_CONV_X86_VECTOR_CALL = 12,
+  CALLING_CONV_SWIFT = 13,
+  CALLING_CONV_PRESERVE_MOST = 14,
+  CALLING_CONV_PRESERVE_ALL = 15,
+  CALLING_CONV_A_ARCH_64_VECTOR_CALL = 16,
+  CALLING_CONV_SWIFT_ASYNC = 17,
+  CALLING_CONV_A_ARCH_64_SVEPCS = 18,
+  CALLING_CONV_M68_K_RTD = 19,
+  CALLING_CONV_PRESERVE_NONE = 20,
+  CALLING_CONV_RISCV_VECTOR_CALL = 21,
+  CALLING_CONV_RISCVVLS_CALL_32 = 22,
+  CALLING_CONV_RISCVVLS_CALL_64 = 23,
+  CALLING_CONV_RISCVVLS_CALL_128 = 24,
+  CALLING_CONV_RISCVVLS_CALL_256 = 25,
+  CALLING_CONV_RISCVVLS_CALL_512 = 26,
+  CALLING_CONV_RISCVVLS_CALL_1024 = 27,
+  CALLING_CONV_RISCVVLS_CALL_2048 = 28,
+  CALLING_CONV_RISCVVLS_CALL_4096 = 29,
+  CALLING_CONV_RISCVVLS_CALL_8192 = 30,
+  CALLING_CONV_RISCVVLS_CALL_16384 = 31,
+  CALLING_CONV_RISCVVLS_CALL_32768 = 32,
+  CALLING_CONV_RISCVVLS_CALL_65536 = 33,
+  CALLING_CONV_INVALID = 100,
+  CALLING_CONV_UNEXPOSED = 200
+}
 
-/**
- * A type whose specific kind is not exposed via this
- * interface.
- */
-const CXTypeKind TYPE_UNEXPOSED = 1;
-
-/* Builtin types */
-const CXTypeKind TYPE_VOID = 2;
-const CXTypeKind TYPE_BOOL = 3;
-const CXTypeKind TYPE_CHAR_U = 4;
-const CXTypeKind TYPE_UCHAR = 5;
-const CXTypeKind TYPE_CHAR16 = 6;
-const CXTypeKind TYPE_CHAR32 = 7;
-const CXTypeKind TYPE_USHORT = 8;
-const CXTypeKind TYPE_UINT = 9;
-const CXTypeKind TYPE_ULONG = 10;
-const CXTypeKind TYPE_ULONGLONG = 11;
-const CXTypeKind TYPE_UINT128 = 12;
-const CXTypeKind TYPE_CHAR_S = 13;
-const CXTypeKind TYPE_SCHAR = 14;
-const CXTypeKind TYPE_WCHAR = 15;
-const CXTypeKind TYPE_SHORT = 16;
-const CXTypeKind TYPE_INT = 17;
-const CXTypeKind TYPE_LONG = 18;
-const CXTypeKind TYPE_LONGLONG = 19;
-const CXTypeKind TYPE_INT128 = 20;
-const CXTypeKind TYPE_FLOAT = 21;
-const CXTypeKind TYPE_DOUBLE = 22;
-const CXTypeKind TYPE_LONGDOUBLE = 23;
-const CXTypeKind TYPE_NULLPTR = 24;
-const CXTypeKind TYPE_OVERLOAD = 25;
-const CXTypeKind TYPE_DEPENDENT = 26;
-const CXTypeKind TYPE_OBJC_ID = 27;
-const CXTypeKind TYPE_OBJC_CLASS = 28;
-const CXTypeKind TYPE_OBJC_SEL = 29;
-const CXTypeKind TYPE_FLOAT128 = 30;
-const CXTypeKind TYPE_HALF = 31;
-const CXTypeKind TYPE_FLOAT16 = 32;
-const CXTypeKind TYPE_SHORT_ACCUM = 33;
-const CXTypeKind TYPE_ACCUM = 34;
-const CXTypeKind TYPE_LONG_ACCUM = 35;
-const CXTypeKind TYPE_USHORT_ACCUM = 36;
-const CXTypeKind TYPE_UACCUM = 37;
-const CXTypeKind TYPE_ULONG_ACCUM = 38;
-const CXTypeKind TYPE_BFLOAT16 = 39;
-const CXTypeKind TYPE_IBM128 = 40;
-const CXTypeKind TYPE_FIRST_BUILTIN = TYPE_VOID;
-const CXTypeKind TYPE_LAST_BUILTIN = TYPE_IBM128;
-
-const CXTypeKind TYPE_COMPLEX = 100;
-const CXTypeKind TYPE_POINTER = 101;
-const CXTypeKind TYPE_BLOCKPOINTER = 102;
-const CXTypeKind TYPE_LVALUE_REFERENCE = 103;
-const CXTypeKind TYPE_RVALUE_REFERENCE = 104;
-const CXTypeKind TYPE_RECORD = 105;
-const CXTypeKind TYPE_ENUM = 106;
-const CXTypeKind TYPE_TYPEDEF = 107;
-const CXTypeKind TYPE_OBJC_INTERFACE = 108;
-const CXTypeKind TYPE_OBJC_OBJECT_POINTER = 109;
-const CXTypeKind TYPE_FUNCTION_NO_PROTO = 110;
-const CXTypeKind TYPE_FUNCTION_PROTO = 111;
-const CXTypeKind TYPE_CONSTANT_ARRAY = 112;
-const CXTypeKind TYPE_VECTOR = 113;
-const CXTypeKind TYPE_INCOMPLETE_ARRAY = 114;
-const CXTypeKind TYPE_VARIABLE_ARRAY = 115;
-const CXTypeKind TYPE_DEPENDENT_SIZED_ARRAY = 116;
-const CXTypeKind TYPE_MEMBER_POINTER = 117;
-const CXTypeKind TYPE_AUTO = 118;
-
-/**
- * Represents a type that was referred to using an elaborated type keyword.
- *
- * E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
- */
-const CXTypeKind TYPE_ELABORATED = 119;
-
-/* OpenCL PipeType. */
-const CXTypeKind TYPE_PIPE = 120;
-
-/* OpenCL builtin types. */
-const CXTypeKind TYPE_OCL_IMAGE_1D_RO = 121;
-const CXTypeKind TYPE_OCL_IMAGE_1D_ARRAY_RO = 122;
-const CXTypeKind TYPE_OCL_IMAGE_1D_BUFFER_RO = 123;
-const CXTypeKind TYPE_OCL_IMAGE_2D_RO = 124;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_RO = 125;
-const CXTypeKind TYPE_OCL_IMAGE_2D_DEPTH_RO = 126;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_DEPTH_RO = 127;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_RO = 128;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_RO = 129;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_DEPTH_RO = 130;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_DEPTH_RO = 131;
-const CXTypeKind TYPE_OCL_IMAGE_3D_RO = 132;
-const CXTypeKind TYPE_OCL_IMAGE_1D_WO = 133;
-const CXTypeKind TYPE_OCL_IMAGE_1D_ARRAY_WO = 134;
-const CXTypeKind TYPE_OCL_IMAGE_1D_BUFFER_WO = 135;
-const CXTypeKind TYPE_OCL_IMAGE_2D_WO = 136;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_WO = 137;
-const CXTypeKind TYPE_OCL_IMAGE_2D_DEPTH_WO = 138;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_DEPTH_WO = 139;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_WO = 140;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_WO = 141;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_DEPTH_WO = 142;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_DEPTH_WO = 143;
-const CXTypeKind TYPE_OCL_IMAGE_3D_WO = 144;
-const CXTypeKind TYPE_OCL_IMAGE_1D_RW = 145;
-const CXTypeKind TYPE_OCL_IMAGE_1D_ARRAY_RW = 146;
-const CXTypeKind TYPE_OCL_IMAGE_1D_BUFFER_RW = 147;
-const CXTypeKind TYPE_OCL_IMAGE_2D_RW = 148;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_RW = 149;
-const CXTypeKind TYPE_OCL_IMAGE_2D_DEPTH_RW = 150;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_DEPTH_RW = 151;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_RW = 152;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_RW = 153;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_DEPTH_RW = 154;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_DEPTH_RW = 155;
-const CXTypeKind TYPE_OCL_IMAGE_3D_RW = 156;
-const CXTypeKind TYPE_OCL_SAMPLER = 157;
-const CXTypeKind TYPE_OCL_EVENT = 158;
-const CXTypeKind TYPE_OCL_QUEUE = 159;
-const CXTypeKind TYPE_OCL_RESERVE_ID = 160;
-
-const CXTypeKind TYPE_OBJC_OBJECT = 161;
-const CXTypeKind TYPE_OBJC_TYPE_PARAM = 162;
-const CXTypeKind TYPE_ATTRIBUTED = 163;
-
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_PAYLOAD = 164;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_PAYLOAD = 165;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_REF_PAYLOAD = 166;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_PAYLOAD = 167;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_RESULT = 168;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT = 169;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_REF_RESULT = 170;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_RESULT = 171;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REFERENCE_STREAMOUT = 172;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REFERENCE_STREAMOUT = 173;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REFERENCE_STREAMIN = 174;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REFERENCE_STREAMIN = 175;
-
-/* Old aliases for AVC OpenCL extension types. */
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REF_STREAMOUT = 172;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REF_STREAMOUT = 173;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REF_STREAMIN = 174;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REF_STREAMIN = 175;
-
-const CXTypeKind TYPE_EXT_VECTOR = 176;
-const CXTypeKind TYPE_ATOMIC = 177;
-const CXTypeKind TYPE_BTF_TAG_ATTRIBUTED = 17;
-
-/**
- * Describes the calling convention of a function type
- */
-typedef CXCallingConv = inline CInt;
-
-const CXCallingConv CALLING_CONV_DEFAULT = 0;
-const CXCallingConv CALLING_CONV_C = 1;
-const CXCallingConv CALLING_CONV_X86_STD_CALL = 2;
-const CXCallingConv CALLING_CONV_X86_FAST_CALL = 3;
-const CXCallingConv CALLING_CONV_X86_THIS_CALL = 4;
-const CXCallingConv CALLING_CONV_X86_PASCAL = 5;
-const CXCallingConv CALLING_CONV_AAPCS = 6;
-const CXCallingConv CALLING_CONV_AAPCS_VFP = 7;
-const CXCallingConv CALLING_CONV_X86REGCALL = 8;
-const CXCallingConv CALLING_CONV_INTEL_OCL_BICC = 9;
-const CXCallingConv CALLING_CONV_WIN64 = 10;
-/* Alias for compatibility with older versions of API. */
-const CXCallingConv CALLING_CONV_X86_64_WIN64 = CALLING_CONV_WIN64;
-const CXCallingConv CALLING_CONV_X86_64_SYSV = 11;
-const CXCallingConv CALLING_CONV_X86_VECTOR_CALL = 12;
-const CXCallingConv CALLING_CONV_SWIFT = 13;
-const CXCallingConv CALLING_CONV_PRESERVE_MOST = 14;
-const CXCallingConv CALLING_CONV_PRESERVE_ALL = 15;
-const CXCallingConv CALLING_CONV_AARCH64_VECTOR_CALL = 16;
-const CXCallingConv CALLING_CONV_SWIFT_ASYNC = 17;
-const CXCallingConv CALLING_CONV_AARCH64_SVEPCS = 18;
-const CXCallingConv CALLING_CONV_M68K_RTD = 19;
-
-const CXCallingConv CALLING_CONV_INVALID = 100;
-const CXCallingConv CALLING_CONV_UNEXPOSED = 200;
-
-/**
- * The type of an element in the abstract syntax tree.
- *
- */
 struct CXType {
   CXTypeKind kind;
   void*[2] data;
 }
 
-/**
- * Retrieve the type of a CXCursor (if any).
- */
-fn CXType getCursorType(
-  CXCursor cursor) 
-@extern("clang_getCursorType");
-
-/**
- * Pretty-print the underlying type using the rules of the
- * language of the translation unit from which it came.
- *
- * If the type is invalid, an empty string is returned.
- */
-fn CXString getTypeSpelling(
-  CXType ct) 
-@extern("clang_getTypeSpelling");
-
-/**
- * Retrieve the underlying type of a typedef declaration.
- *
- * If the cursor does not reference a typedef declaration, an invalid type is
- * returned.
- */
-fn CXType getTypedefDeclUnderlyingType(
-  CXCursor cursor) 
-@extern("clang_getTypedefDeclUnderlyingType");
-
-/**
- * Retrieve the integer type of an enum declaration.
- *
- * If the cursor does not reference an enum declaration, an invalid type is
- * returned.
- */
-fn CXType getEnumDeclIntegerType(
-  CXCursor c) 
-@extern("clang_getEnumDeclIntegerType");
-
-/**
- * Retrieve the integer value of an enum constant declaration as a signed
- *  CLongLong.
- *
- * If the cursor does not reference an enum constant declaration, LLONG_MIN is
- * returned. Since this is also potentially a valid constant value, the kind of
- * the cursor must be verified before calling this function.
- */
-fn CLongLong getEnumConstantDeclValue(
-  CXCursor c) 
-@extern("clang_getEnumConstantDeclValue");
-
-/**
- * Retrieve the integer value of an enum constant declaration as an CUInt
- *  CLongLong.
- *
- * If the cursor does not reference an enum constant declaration, ULLONG_MAX is
- * returned. Since this is also potentially a valid constant value, the kind of
- * the cursor must be verified before calling this function.
- */
-fn CULongLong getEnumConstantDeclUnsignedValue(
-  CXCursor c) 
-@extern("clang_getEnumConstantDeclUnsignedValue");
-
-/**
- * Returns non-zero if the cursor specifies a Record member that is a bit-field.
- */
-fn CUInt isBitField_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isBitField");
-
-/**
- * Retrieve the bit width of a bit-field declaration as an integer.
- *
- * If the cursor does not reference a bit-field, or if the bit-field's width
- * expression cannot be evaluated, -1 is returned.
- *
- * For example:
- * \code
- * if (clang_Cursor_isBitField(Cursor)) {
- *   CInt Width = clang_getFieldDeclBitWidth(Cursor);
- *   if (Width != -1) {
- *     // The bit-field width is not value-dependent.
- *   }
- * }
- * \endcode
- */
-fn CInt getFieldDeclBitWidth(
-  CXCursor c) 
-@extern("clang_getFieldDeclBitWidth");
-
-/**
- * Retrieve the number of non-variadic arguments associated with a given
- * cursor.
- *
- * The number of arguments can be determined for calls as well as for
- * declarations of functions or methods. For other cursors -1 is returned.
- */
-fn CInt getNumArguments_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getNumArguments");
-
-/**
- * Retrieve the argument cursor of a function or method.
- *
- * The argument cursor can be determined for calls as well as for declarations
- * of functions or methods. For other cursors and for invalid indices, an
- * invalid cursor is returned.
- */
-fn CXCursor getArgument_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getArgument");
-
-/**
- * Describes the kind of a template argument.
- *
- * See the definition of llvm::clang::TemplateArgument::ArgKind for full
- * element descriptions.
- */
-typedef CXTemplateArgumentKind = inline CInt;
-
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_NULL = 0;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_TYPE = 1;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_DECLARATION = 2;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_NULLPTR = 3;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_INTEGRAL = 4;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_TEMPLATE = 5;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_TEMPLATEEXPANSION = 6;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_EXPRESSION = 7;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_PACK = 8;
-/* Indicates an error case, preventing the kind from being deduced. */
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_INVALID = 9;
-
-/**
- * Returns the number of template args of a function, struct, or class decl
- * representing a template specialization.
- *
- * If the argument cursor cannot be converted into a template function
- * declaration, -1 is returned.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, -7, true>();
- *
- * The value 3 would be returned from this call.
- */
-fn CInt getNumTemplateArguments_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getNumTemplateArguments");
-
-/**
- * Retrieve the kind of the I'th template argument of the CXCursor C.
- *
- * If the argument CXCursor does not represent a FunctionDecl, StructDecl, or
- * ClassTemplatePartialSpecialization, an invalid template argument kind is
- * returned.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, -7, true>();
- *
- * For I = 0, 1, and 2, Type, Integral, and Integral will be returned,
- * respectively.
- */
-fn CXTemplateArgumentKind getTemplateArgumentKind_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getTemplateArgumentKind");
-
-/**
- * Retrieve a CXType representing the type of a TemplateArgument of a
- *  function decl representing a template specialization.
- *
- * If the argument CXCursor does not represent a FunctionDecl, StructDecl,
- * ClassDecl or ClassTemplatePartialSpecialization whose I'th template argument
- * has a kind of CXTemplateArgKind_Integral, an invalid type is returned.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, -7, true>();
- *
- * If called with I = 0, "float", will be returned.
- * Invalid types will be returned for I == 1 or 2.
- */
-fn CXType getTemplateArgumentType_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getTemplateArgumentType");
-
-/**
- * Retrieve the value of an Integral TemplateArgument (of a function
- *  decl representing a template specialization) as a signed CLongLong.
- *
- * It is undefined to call this function on a CXCursor that does not represent a
- * FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization
- * whose I'th template argument is not an integral value.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, -7, true>();
- *
- * If called with I = 1 or 2, -7 or true will be returned, respectively.
- * For I == 0, this function's behavior is undefined.
- */
-fn CLongLong getTemplateArgumentValue_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getTemplateArgumentValue");
-
-/**
- * Retrieve the value of an Integral TemplateArgument (of a function
- *  decl representing a template specialization) as an CUInt CLongLong.
- *
- * It is undefined to call this function on a CXCursor that does not represent a
- * FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization or
- * whose I'th template argument is not an integral value.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, 2147483649, true>();
- *
- * If called with I = 1 or 2, 2147483649 or true will be returned, respectively.
- * For I == 0, this function's behavior is undefined.
- */
-fn CULongLong getTemplateArgumentUnsignedValue_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getTemplateArgumentUnsignedValue");
-
-/**
- * Determine whether two CXTypes represent the same type.
- *
- * \returns non-zero if the CXTypes represent the same type and
- *          zero otherwise.
- */
-fn CUInt equalTypes(
-  CXType a, 
-  CXType b) 
-@extern("clang_equalTypes");
-
-/**
- * Return the canonical type for a CXType.
- *
- * Clang's type system explicitly models typedefs and all the ways
- * a specific type can be represented.  The canonical type is the underlying
- * type with all the "sugar" removed.  For example, if 'T' is a typedef
- * for 'CInt', the canonical type for 'T' would be 'CInt'.
- */
-fn CXType getCanonicalType(
-  CXType t) 
-@extern("clang_getCanonicalType");
-
-/**
- * Determine whether a CXType has the "const" qualifier set,
- * without looking through typedefs that may have added "const" at a
- * different level.
- */
-fn CUInt isConstQualifiedType(
-  CXType t) 
-@extern("clang_isConstQualifiedType");
-
-/**
- * Determine whether a  CXCursor that is a macro, is
- * function like.
- */
-fn CUInt isMacroFunctionLike_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isMacroFunctionLike");
-
-/**
- * Determine whether a  CXCursor that is a macro, is a
- * builtin one.
- */
-fn CUInt isMacroBuiltin_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isMacroBuiltin");
-
-/**
- * Determine whether a  CXCursor that is a function declaration, is an
- * inline declaration.
- */
-fn CUInt isFunctionInlined_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isFunctionInlined");
-
-/**
- * Determine whether a CXType has the "volatile" qualifier set,
- * without looking through typedefs that may have added "volatile" at
- * a different level.
- */
-fn CUInt isVolatileQualifiedType(
-  CXType t) 
-@extern("clang_isVolatileQualifiedType");
-
-/**
- * Determine whether a CXType has the "restrict" qualifier set,
- * without looking through typedefs that may have added "restrict" at a
- * different level.
- */
-fn CUInt isRestrictQualifiedType(
-  CXType t) 
-@extern("clang_isRestrictQualifiedType");
-
-/**
- * Returns the address space of the given type.
- */
-fn CUInt getAddressSpace(
-  CXType t) 
-@extern("clang_getAddressSpace");
-
-/**
- * Returns the typedef name of the given type.
- */
-fn CXString getTypedefName(
-  CXType ct) 
-@extern("clang_getTypedefName");
-
-/**
- * For pointer types, returns the type of the pointee.
- */
-fn CXType getPointeeType(
-  CXType t) 
-@extern("clang_getPointeeType");
-
-/**
- * Retrieve the unqualified variant of the given type, removing as
- * little sugar as possible.
- *
- * For example, given the following series of typedefs:
- *
- * \code
- * typedef CInt Integer;
- * typedef const Integer CInteger;
- * typedef CInteger DifferenceType;
- * \endcode
- *
- * Executing \c clang_getUnqualifiedType() on a \c CXType that
- * represents \c DifferenceType, will desugar to a type representing
- * \c Integer, that has no qualifiers.
- *
- * And, executing \c clang_getUnqualifiedType() on the type of the
- * first argument of the following function declaration:
- *
- * \code
- * void foo(const CInt);
- * \endcode
- *
- * Will return a type representing \c CInt, removing the \c const
- * qualifier.
- *
- * Sugar over array types is not desugared.
- *
- * A type can be checked for qualifiers with \c
- * clang_isConstQualifiedType(), \c clang_isVolatileQualifiedType()
- * and \c clang_isRestrictQualifiedType().
- *
- * A type that resulted from a call to \c clang_getUnqualifiedType
- * will return \c false for all of the above calls.
- */
-fn CXType getUnqualifiedType(
-  CXType ct) 
-@extern("clang_getUnqualifiedType");
-
-/**
- * For reference types (e.g., "const CInt&"), returns the type that the
- * reference refers to (e.g "const CInt").
- *
- * Otherwise, returns the type itself.
- *
- * A type that has kind \c CXType_LValueReference or
- * \c CXType_RValueReference is a reference type.
- */
-fn CXType getNonReferenceType(
-  CXType ct) 
-@extern("clang_getNonReferenceType");
-
-/**
- * Return the cursor for the declaration of the given type.
- */
-fn CXCursor getTypeDeclaration(
-  CXType t) 
-@extern("clang_getTypeDeclaration");
-
-/**
- * Returns the Objective-C type encoding for the specified declaration.
- */
-fn CXString getDeclObjCTypeEncoding(
-  CXCursor c) 
-@extern("clang_getDeclObjCTypeEncoding");
-
-/**
- * Returns the Objective-C type encoding for the specified CXType.
- */
-fn CXString getObjCEncoding_Type(
-  CXType type) 
-@extern("clang_Type_getObjCEncoding");
-
-/**
- * Retrieve the spelling of a given CXTypeKind.
- */
-fn CXString getTypeKindSpelling(
-  CXTypeKind k) 
-@extern("clang_getTypeKindSpelling");
-
-/**
- * Retrieve the calling convention associated with a function type.
- *
- * If a non-function type is passed in, CXCallingConv_Invalid is returned.
- */
-fn CXCallingConv getFunctionTypeCallingConv(
-  CXType t) 
-@extern("clang_getFunctionTypeCallingConv");
-
-/**
- * Retrieve the return type associated with a function type.
- *
- * If a non-function type is passed in, an invalid type is returned.
- */
-fn CXType getResultType(
-  CXType t) 
-@extern("clang_getResultType");
-
-/**
- * Retrieve the exception specification type associated with a function type.
- * This is a value of type CXCursor_ExceptionSpecificationKind.
- *
- * If a non-function type is passed in, an error code of -1 is returned.
- */
-fn CInt getExceptionSpecificationType(
-  CXType t) 
-@extern("clang_getExceptionSpecificationType");
-
-/**
- * Retrieve the number of non-variadic parameters associated with a
- * function type.
- *
- * If a non-function type is passed in, -1 is returned.
- */
-fn CInt getNumArgTypes(
-  CXType t) 
-@extern("clang_getNumArgTypes");
-
-/**
- * Retrieve the type of a parameter of a function type.
- *
- * If a non-function type is passed in or the function does not have enough
- * parameters, an invalid type is returned.
- */
-fn CXType getArgType(
-  CXType t, 
-  CUInt i) 
-@extern("clang_getArgType");
-
-/**
- * Retrieves the base type of the ObjCObjectType.
- *
- * If the type is not an ObjC object, an invalid type is returned.
- */
-fn CXType getObjCObjectBaseType_Type(
-  CXType t) 
-@extern("clang_Type_getObjCObjectBaseType");
-
-/**
- * Retrieve the number of protocol references associated with an ObjC object/id.
- *
- * If the type is not an ObjC object, 0 is returned.
- */
-fn CUInt getNumObjCProtocolRefs_Type(
-  CXType t) 
-@extern("clang_Type_getNumObjCProtocolRefs");
-
-/**
- * Retrieve the decl for a protocol reference for an ObjC object/id.
- *
- * If the type is not an ObjC object or there are not enough protocol
- * references, an invalid cursor is returned.
- */
-fn CXCursor getObjCProtocolDecl_Type(
-  CXType t, 
-  CUInt i) 
-@extern("clang_Type_getObjCProtocolDecl");
-
-/**
- * Retrieve the number of type arguments associated with an ObjC object.
- *
- * If the type is not an ObjC object, 0 is returned.
- */
-fn CUInt getNumObjCTypeArgs_Type(
-  CXType t) 
-@extern("clang_Type_getNumObjCTypeArgs");
-
-/**
- * Retrieve a type argument associated with an ObjC object.
- *
- * If the type is not an ObjC or the index is not valid,
- * an invalid type is returned.
- */
-fn CXType getObjCTypeArg_Type(
-  CXType t, 
-  CUInt i) 
-@extern("clang_Type_getObjCTypeArg");
-
-/**
- * Return 1 if the CXType is a variadic function type, and 0 otherwise.
- */
-fn CUInt isFunctionTypeVariadic(
-  CXType t) 
-@extern("clang_isFunctionTypeVariadic");
-
-/**
- * Retrieve the return type associated with a given cursor.
- *
- * This only returns a valid type if the cursor refers to a function or method.
- */
-fn CXType getCursorResultType(
-  CXCursor c) 
-@extern("clang_getCursorResultType");
-
-/**
- * Retrieve the exception specification type associated with a given cursor.
- * This is a value of type CXCursor_ExceptionSpecificationKind.
- *
- * This only returns a valid result if the cursor refers to a function or
- * method.
- */
-fn CInt getCursorExceptionSpecificationType(
-  CXCursor c) 
-@extern("clang_getCursorExceptionSpecificationType");
-
-/**
- * Return 1 if the CXType is a POD (plain old data) type, and 0
- *  otherwise.
- */
-fn CUInt isPODType(
-  CXType t) 
-@extern("clang_isPODType");
-
-/**
- * Return the element type of an array, complex, or vector type.
- *
- * If a type is passed in that is not an array, complex, or vector type,
- * an invalid type is returned.
- */
-fn CXType getElementType(
-  CXType t) 
-@extern("clang_getElementType");
-
-/**
- * Return the number of elements of an array or vector type.
- *
- * If a type is passed in that is not an array or vector type,
- * -1 is returned.
- */
-fn CLongLong getNumElements(
-  CXType t) 
-@extern("clang_getNumElements");
-
-/**
- * Return the element type of an array type.
- *
- * If a non-array type is passed in, an invalid type is returned.
- */
-fn CXType getArrayElementType(
-  CXType t) 
-@extern("clang_getArrayElementType");
-
-/**
- * Return the array size of a constant array.
- *
- * If a non-array type is passed in, -1 is returned.
- */
-fn CLongLong getArraySize(
-  CXType t) 
-@extern("clang_getArraySize");
-
-/**
- * Retrieve the type named by the qualified-id.
- *
- * If a non-elaborated type is passed in, an invalid type is returned.
- */
-fn CXType getNamedType_Type(
-  CXType t) 
-@extern("clang_Type_getNamedType");
-
-/**
- * Determine if a typedef is 'transparent' tag.
- *
- * A typedef is considered 'transparent' if it shares a name and spelling
- * location with its underlying tag type, as is the case with the NS_ENUM macro.
- *
- * \returns non-zero if transparent and zero otherwise.
- */
-fn CUInt isTransparentTagTypedef_Type(
-  CXType t) 
-@extern("clang_Type_isTransparentTagTypedef");
-
-typedef CXTypeNullabilityKind = inline CInt;
-/**
- * Values of this type can never be null.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_NON_NULL = 0;
-/**
- * Values of this type can be null.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_NULLABLE = 1;
-/**
- * Whether values of this type can be null is (explicitly)
- * unspecified. This captures a (fairly rare) case where we
- * can't conclude anything about the nullability of the type even
- * though it has been considered.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_UNSPECIFIED = 2;
-/**
- * Nullability is not applicable to this type.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_INVALID = 3;
-
-/**
- * Generally behaves like Nullable, except when used in a block parameter that
- * was imported into a swift async method. There, swift will assume that the
- * parameter can get null even if no error occurred. _Nullable parameters are
- * assumed to only get null on error.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_NULLABLE_RESULT = 4;
-
-/**
- * Retrieve the nullability kind of a pointer type.
- */
-fn CXTypeNullabilityKind getNullability_Type(
-  CXType t) 
-@extern("clang_Type_getNullability");
-
-/**
- * List the possible error codes for \c clang_Type_getSizeOf,
- *   \c clang_Type_getAlignOf, \c clang_Type_getOffsetOf and
- *   \c clang_Cursor_getOffsetOf.
- *
- * A value of this enumeration type can be returned if the target type is not
- * a valid argument to sizeof, alignof or offsetof.
- */
-typedef CXTypeLayoutError = inline CInt;
-
-/**
- * Type is of kind CXType_Invalid.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_INVALID = -1;
-/**
- * The type is an incomplete Type.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_INCOMPLETE = -2;
-/**
- * The type is a dependent Type.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_DEPENDENT = -3;
-/**
- * The type is not a constant size type.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_NOT_CONSTANT_SIZE = -4;
-/**
- * The Field name is not valid for this record.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_INVALID_FIELD_NAME = -5;
-/**
- * The type is undeduced.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_UNDEDUCED = -6;
-
-/**
- * Return the alignment of a type in bytes as per C++[expr.alignof]
- *   standard.
- *
- * If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
- * If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
- *   is returned.
- * If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
- *   returned.
- * If the type declaration is not a constant size type,
- *   CXTypeLayoutError_NotConstantSize is returned.
- */
-fn CLongLong getAlignOf_Type(
-  CXType t) 
-@extern("clang_Type_getAlignOf");
-
-/**
- * Return the class type of an member pointer type.
- *
- * If a non-member-pointer type is passed in, an invalid type is returned.
- */
-fn CXType getClassType_Type(
-  CXType t) 
-@extern("clang_Type_getClassType");
-
-/**
- * Return the size of a type in bytes as per C++[expr.sizeof] standard.
- *
- * If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
- * If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
- *   is returned.
- * If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
- *   returned.
- */
-fn CLongLong getSizeOf_Type(
-  CXType t) 
-@extern("clang_Type_getSizeOf");
-
-/**
- * Return the offset of a field named S in a record of type T in bits
- *   as it would be returned by __offsetof__ as per C++11[18.2p4]
- *
- * If the cursor is not a record field declaration, CXTypeLayoutError_Invalid
- *   is returned.
- * If the field's type declaration is an incomplete type,
- *   CXTypeLayoutError_Incomplete is returned.
- * If the field's type declaration is a dependent type,
- *   CXTypeLayoutError_Dependent is returned.
- * If the field's name S is not found,
- *   CXTypeLayoutError_InvalidFieldName is returned.
- */
-fn CLongLong getOffsetOf_Type(
-  CXType t, 
-  ZString s) 
-@extern("clang_Type_getOffsetOf");
-
-/**
- * Return the type that was modified by this attributed type.
- *
- * If the type is not an attributed type, an invalid type is returned.
- */
-fn CXType getModifiedType_Type(
-  CXType t) 
-@extern("clang_Type_getModifiedType");
-
-/**
- * If a non-atomic type is passed in, an invalid type is returned.
- */
-fn CXType getValueType_Type(
-  CXType ct) 
-@extern("clang_Type_getValueType");
-
-/**
- * Return the offset of the field represented by the Cursor.
- *
- * If the cursor is not a field declaration, -1 is returned.
- * If the cursor semantic parent is not a record field declaration,
- *   CXTypeLayoutError_Invalid is returned.
- * If the field's type declaration is an incomplete type,
- *   CXTypeLayoutError_Incomplete is returned.
- * If the field's type declaration is a dependent type,
- *   CXTypeLayoutError_Dependent is returned.
- * If the field's name S is not found,
- *   CXTypeLayoutError_InvalidFieldName is returned.
- */
-fn CLongLong getOffsetOfField_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getOffsetOfField");
-
-/**
- * Determine whether the given cursor represents an anonymous
- * tag or namespace
- */
-fn CUInt isAnonymous_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isAnonymous");
-
-/**
- * Determine whether the given cursor represents an anonymous record
- * declaration.
- */
-fn CUInt isAnonymousRecordDecl_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isAnonymousRecordDecl");
-
-/**
- * Determine whether the given cursor represents an inline namespace
- * declaration.
- */
-fn CUInt isInlineNamespace_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isInlineNamespace");
-
-typedef CXRefQualifierKind = inline CInt;
-
-/** No ref-qualifier was provided. 
-  */
-const CXRefQualifierKind REF_QUALIFIER_NONE = 0;
-/** An lvalue ref-qualifier was provided (\c &). 
-  */
-const CXRefQualifierKind REF_QUALIFIER_LVALUE = 1;
-/** An rvalue ref-qualifier was provided (\c &&). 
-  */
-const CXRefQualifierKind REF_QUALIFIER_RVALUE = 2;
-
-/**
- * Returns the number of template arguments for given template
- * specialization, or -1 if type \c T is not a template specialization.
- */
-fn CInt getNumTemplateArguments_Type(
-  CXType t) 
-@extern("clang_Type_getNumTemplateArguments");
-
-/**
- * Returns the type template argument of a template class specialization
- * at given index.
- *
- * This function only returns template type arguments and does not handle
- * template template arguments or variadic packs.
- */
-fn CXType getTemplateArgumentAsType_Type(
-  CXType t, 
-  CUInt i) 
-@extern("clang_Type_getTemplateArgumentAsType");
-
-/**
- * Retrieve the ref-qualifier kind of a function or method.
- *
- * The ref-qualifier is returned for C++ functions or methods. For other types
- * or non-C++ declarations, CXRefQualifier_None is returned.
- */
-fn CXRefQualifierKind getCXXRefQualifier_Type(
-  CXType t) 
-@extern("clang_Type_getCXXRefQualifier");
-
-/**
- * Returns 1 if the base class specified by the cursor with kind
- *   CX_CXXBaseSpecifier is virtual.
- */
-fn CUInt isVirtualBase(
-  CXCursor c) 
-@extern("clang_isVirtualBase");
-
-/**
- * Represents the C++ access control level to a base class for a
- * cursor with kind CX_CXXBaseSpecifier.
- */
-typedef CX_CXXAccessSpecifier = inline CInt;
-
-const CX_CXXAccessSpecifier CXX_INVALID_ACCESS_SPECIFIER = 0;
-const CX_CXXAccessSpecifier CXX_PUBLIC = 1;
-const CX_CXXAccessSpecifier CXX_PROTECTED = 2;
-const CX_CXXAccessSpecifier CXX_PRIVATE = 3;
-
-/**
- * Returns the access control level for the referenced object.
- *
- * If the cursor refers to a C++ declaration, its access control level within
- * its parent scope is returned. Otherwise, if the cursor refers to a base
- * specifier or access specifier, the specifier itself is returned.
- */
-fn CX_CXXAccessSpecifier getCXXAccessSpecifier(
-  CXCursor c) 
-@extern("clang_getCXXAccessSpecifier");
-
-/**
- * Represents the storage classes as declared in the source. CX_SC_Invalid
- * was added for the case that the passed cursor in not a declaration.
- */
-typedef CX_StorageClass = inline CInt;
-
-const CX_StorageClass SC_INVALID = 0;
-const CX_StorageClass SC_NONE = 1;
-const CX_StorageClass SC_EXTERN = 2;
-const CX_StorageClass SC_STATIC = 3;
-const CX_StorageClass SC_PRIVATE_EXTERN = 4;
-const CX_StorageClass SC_OPENCL_WORK_GROUP_LOCAL = 5;
-const CX_StorageClass SC_AUTO = 6;
-const CX_StorageClass SC_REGISTER = 7;
-
-/**
- * Returns the storage class for a function or variable declaration.
- *
- * If the passed in Cursor is not a function or variable declaration,
- * CX_SC_Invalid is returned else the storage class.
- */
-fn CX_StorageClass getStorageClass_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getStorageClass");
-
-/**
- * Determine the number of overloaded declarations referenced by a
- * \c CXCursor_OverloadedDeclRef cursor.
- *
- * \param cursor The cursor whose overloaded declarations are being queried.
- *
- * \returns The number of overloaded declarations referenced by \c cursor. If it
- * is not a \c CXCursor_OverloadedDeclRef cursor, returns 0.
- */
-fn CUInt getNumOverloadedDecls(
-  CXCursor cursor) 
-@extern("clang_getNumOverloadedDecls");
-
-/**
- * Retrieve a cursor for one of the overloaded declarations referenced
- * by a \c CXCursor_OverloadedDeclRef cursor.
- *
- * \param cursor The cursor whose overloaded declarations are being queried.
- *
- * \param index The zero-based index into the set of overloaded declarations in
- * the cursor.
- *
- * \returns A cursor representing the declaration referenced by the given
- * \c cursor at the specified \c index. If the cursor does not have an
- * associated set of overloaded declarations, or if the index is out of bounds,
- * returns \c clang_getNullCursor();
- */
-fn CXCursor getOverloadedDecl(
-  CXCursor cursor, 
-  CUInt index) 
-@extern("clang_getOverloadedDecl");
-
-/**
- * For cursors representing an iboutletcollection attribute,
- *  this function returns the collection element type.
- *
- */
-fn CXType getIBOutletCollectionType(
-  CXCursor c) 
-@extern("clang_getIBOutletCollectionType");
-
-/**
- * Describes how the traversal of the children of a particular
- * cursor should proceed after visiting a particular child cursor.
- *
- * A value of this enumeration type should be returned by each
- * \c CXCursorVisitor to indicate how clang_visitChildren() proceed.
- */
-typedef CXChildVisitResult = inline CInt;
-/**
- * Terminates the cursor traversal.
- */
-const CXChildVisitResult CHILD_VISIT_BREAK = 0;
-/**
- * Continues the cursor traversal with the next sibling of
- * the cursor just visited, without visiting its children.
- */
-const CXChildVisitResult CHILD_VISIT_CONTINUE = 1;
-/**
- * Recursively traverse the children of this cursor, using
- * the same visitor and client data.
- */
-const CXChildVisitResult CHILD_VISIT_RECURSE = 2;
-
-/**
- * Visitor invoked for each cursor found by a traversal.
- *
- * This visitor function will be invoked for each cursor found by
- * clang_visitCursorChildren(). Its first argument is the cursor being
- * visited, its second argument is the parent visitor for that cursor,
- * and its third argument is the client data provided to
- * clang_visitCursorChildren().
- *
- * The visitor should return one of the \c CXChildVisitResult values
- * to direct clang_visitCursorChildren().
- */
+extern fn CXType getCursorType(
+  CXCursor c)
+@cname("clang_getCursorType");
+
+extern fn CXString getTypeSpelling(
+  CXType ct)
+@cname("clang_getTypeSpelling");
+
+extern fn CXType getTypedefDeclUnderlyingType(
+  CXCursor c)
+@cname("clang_getTypedefDeclUnderlyingType");
+
+extern fn CXType getEnumDeclIntegerType(
+  CXCursor c)
+@cname("clang_getEnumDeclIntegerType");
+
+extern fn CLongLong getEnumConstantDeclValue(
+  CXCursor c)
+@cname("clang_getEnumConstantDeclValue");
+
+extern fn CULongLong getEnumConstantDeclUnsignedValue(
+  CXCursor c)
+@cname("clang_getEnumConstantDeclUnsignedValue");
+
+extern fn CUInt cursor_isBitField(
+  CXCursor c)
+@cname("clang_Cursor_isBitField");
+
+extern fn CInt getFieldDeclBitWidth(
+  CXCursor c)
+@cname("clang_getFieldDeclBitWidth");
+
+extern fn CInt cursor_getNumArguments(
+  CXCursor c)
+@cname("clang_Cursor_getNumArguments");
+
+extern fn CXCursor cursor_getArgument(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getArgument");
+
+constdef CXTemplateArgumentKind : CInt {
+  TEMPLATE_ARGUMENT_KIND_NULL = 0,
+  TEMPLATE_ARGUMENT_KIND_TYPE = 1,
+  TEMPLATE_ARGUMENT_KIND_DECLARATION = 2,
+  TEMPLATE_ARGUMENT_KIND_NULL_PTR = 3,
+  TEMPLATE_ARGUMENT_KIND_INTEGRAL = 4,
+  TEMPLATE_ARGUMENT_KIND_TEMPLATE = 5,
+  TEMPLATE_ARGUMENT_KIND_TEMPLATE_EXPANSION = 6,
+  TEMPLATE_ARGUMENT_KIND_EXPRESSION = 7,
+  TEMPLATE_ARGUMENT_KIND_PACK = 8,
+  TEMPLATE_ARGUMENT_KIND_INVALID = 9
+}
+
+extern fn CInt cursor_getNumTemplateArguments(
+  CXCursor c)
+@cname("clang_Cursor_getNumTemplateArguments");
+
+extern fn CXTemplateArgumentKind cursor_getTemplateArgumentKind(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getTemplateArgumentKind");
+
+extern fn CXType cursor_getTemplateArgumentType(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getTemplateArgumentType");
+
+extern fn CLongLong cursor_getTemplateArgumentValue(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getTemplateArgumentValue");
+
+extern fn CULongLong cursor_getTemplateArgumentUnsignedValue(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getTemplateArgumentUnsignedValue");
+
+extern fn CUInt equalTypes(
+  CXType a,
+  CXType b)
+@cname("clang_equalTypes");
+
+extern fn CXType getCanonicalType(
+  CXType t)
+@cname("clang_getCanonicalType");
+
+extern fn CUInt isConstQualifiedType(
+  CXType t)
+@cname("clang_isConstQualifiedType");
+
+extern fn CUInt cursor_isMacroFunctionLike(
+  CXCursor c)
+@cname("clang_Cursor_isMacroFunctionLike");
+
+extern fn CUInt cursor_isMacroBuiltin(
+  CXCursor c)
+@cname("clang_Cursor_isMacroBuiltin");
+
+extern fn CUInt cursor_isFunctionInlined(
+  CXCursor c)
+@cname("clang_Cursor_isFunctionInlined");
+
+extern fn CUInt isVolatileQualifiedType(
+  CXType t)
+@cname("clang_isVolatileQualifiedType");
+
+extern fn CUInt isRestrictQualifiedType(
+  CXType t)
+@cname("clang_isRestrictQualifiedType");
+
+extern fn CUInt getAddressSpace(
+  CXType t)
+@cname("clang_getAddressSpace");
+
+extern fn CXString getTypedefName(
+  CXType ct)
+@cname("clang_getTypedefName");
+
+extern fn CXType getPointeeType(
+  CXType t)
+@cname("clang_getPointeeType");
+
+extern fn CXType getUnqualifiedType(
+  CXType ct)
+@cname("clang_getUnqualifiedType");
+
+extern fn CXType getNonReferenceType(
+  CXType ct)
+@cname("clang_getNonReferenceType");
+
+extern fn CXCursor getTypeDeclaration(
+  CXType t)
+@cname("clang_getTypeDeclaration");
+
+extern fn CXString getDeclObjCTypeEncoding(
+  CXCursor c)
+@cname("clang_getDeclObjCTypeEncoding");
+
+extern fn CXString type_getObjCEncoding(
+  CXType type)
+@cname("clang_Type_getObjCEncoding");
+
+extern fn CXString getTypeKindSpelling(
+  CXTypeKind k)
+@cname("clang_getTypeKindSpelling");
+
+extern fn CXCallingConv getFunctionTypeCallingConv(
+  CXType t)
+@cname("clang_getFunctionTypeCallingConv");
+
+extern fn CXType getResultType(
+  CXType t)
+@cname("clang_getResultType");
+
+extern fn CInt getExceptionSpecificationType(
+  CXType t)
+@cname("clang_getExceptionSpecificationType");
+
+extern fn CInt getNumArgTypes(
+  CXType t)
+@cname("clang_getNumArgTypes");
+
+extern fn CXType getArgType(
+  CXType t,
+  CUInt i)
+@cname("clang_getArgType");
+
+extern fn CXType type_getObjCObjectBaseType(
+  CXType t)
+@cname("clang_Type_getObjCObjectBaseType");
+
+extern fn CUInt type_getNumObjCProtocolRefs(
+  CXType t)
+@cname("clang_Type_getNumObjCProtocolRefs");
+
+extern fn CXCursor type_getObjCProtocolDecl(
+  CXType t,
+  CUInt i)
+@cname("clang_Type_getObjCProtocolDecl");
+
+extern fn CUInt type_getNumObjCTypeArgs(
+  CXType t)
+@cname("clang_Type_getNumObjCTypeArgs");
+
+extern fn CXType type_getObjCTypeArg(
+  CXType t,
+  CUInt i)
+@cname("clang_Type_getObjCTypeArg");
+
+extern fn CUInt isFunctionTypeVariadic(
+  CXType t)
+@cname("clang_isFunctionTypeVariadic");
+
+extern fn CXType getCursorResultType(
+  CXCursor c)
+@cname("clang_getCursorResultType");
+
+extern fn CInt getCursorExceptionSpecificationType(
+  CXCursor c)
+@cname("clang_getCursorExceptionSpecificationType");
+
+extern fn CUInt isPODType(
+  CXType t)
+@cname("clang_isPODType");
+
+extern fn CXType getElementType(
+  CXType t)
+@cname("clang_getElementType");
+
+extern fn CLongLong getNumElements(
+  CXType t)
+@cname("clang_getNumElements");
+
+extern fn CXType getArrayElementType(
+  CXType t)
+@cname("clang_getArrayElementType");
+
+extern fn CLongLong getArraySize(
+  CXType t)
+@cname("clang_getArraySize");
+
+extern fn CXType type_getNamedType(
+  CXType t)
+@cname("clang_Type_getNamedType");
+
+extern fn CUInt type_isTransparentTagTypedef(
+  CXType t)
+@cname("clang_Type_isTransparentTagTypedef");
+
+constdef CXTypeNullabilityKind : CInt {
+  TYPE_NULLABILITY_NON_NULL = 0,
+  TYPE_NULLABILITY_NULLABLE = 1,
+  TYPE_NULLABILITY_UNSPECIFIED = 2,
+  TYPE_NULLABILITY_INVALID = 3,
+  TYPE_NULLABILITY_NULLABLE_RESULT = 4
+}
+
+extern fn CXTypeNullabilityKind type_getNullability(
+  CXType t)
+@cname("clang_Type_getNullability");
+
+constdef CXTypeLayoutError : CInt {
+  TYPE_LAYOUT_ERROR_INVALID = -1,
+  TYPE_LAYOUT_ERROR_INCOMPLETE = -2,
+  TYPE_LAYOUT_ERROR_DEPENDENT = -3,
+  TYPE_LAYOUT_ERROR_NOT_CONSTANT_SIZE = -4,
+  TYPE_LAYOUT_ERROR_INVALID_FIELD_NAME = -5,
+  TYPE_LAYOUT_ERROR_UNDEDUCED = -6
+}
+
+extern fn CLongLong type_getAlignOf(
+  CXType t)
+@cname("clang_Type_getAlignOf");
+
+extern fn CXType type_getClassType(
+  CXType t)
+@cname("clang_Type_getClassType");
+
+extern fn CLongLong type_getSizeOf(
+  CXType t)
+@cname("clang_Type_getSizeOf");
+
+extern fn CLongLong type_getOffsetOf(
+  CXType t,
+  ZString s)
+@cname("clang_Type_getOffsetOf");
+
+extern fn CXType type_getModifiedType(
+  CXType t)
+@cname("clang_Type_getModifiedType");
+
+extern fn CXType type_getValueType(
+  CXType ct)
+@cname("clang_Type_getValueType");
+
+extern fn CLongLong cursor_getOffsetOfField(
+  CXCursor c)
+@cname("clang_Cursor_getOffsetOfField");
+
+extern fn CUInt cursor_isAnonymous(
+  CXCursor c)
+@cname("clang_Cursor_isAnonymous");
+
+extern fn CUInt cursor_isAnonymousRecordDecl(
+  CXCursor c)
+@cname("clang_Cursor_isAnonymousRecordDecl");
+
+extern fn CUInt cursor_isInlineNamespace(
+  CXCursor c)
+@cname("clang_Cursor_isInlineNamespace");
+
+constdef CXRefQualifierKind : CInt {
+  REF_QUALIFIER_NONE = 0,
+  REF_QUALIFIER_L_VALUE = 1,
+  REF_QUALIFIER_R_VALUE = 2
+}
+
+extern fn CInt type_getNumTemplateArguments(
+  CXType t)
+@cname("clang_Type_getNumTemplateArguments");
+
+extern fn CXType type_getTemplateArgumentAsType(
+  CXType t,
+  CUInt i)
+@cname("clang_Type_getTemplateArgumentAsType");
+
+extern fn CXRefQualifierKind type_getCXXRefQualifier(
+  CXType t)
+@cname("clang_Type_getCXXRefQualifier");
+
+extern fn CUInt isVirtualBase(
+  CXCursor)
+@cname("clang_isVirtualBase");
+
+extern fn CLongLong getOffsetOfBase(
+  CXCursor parent,
+  CXCursor base)
+@cname("clang_getOffsetOfBase");
+
+constdef CX_CXXAccessSpecifier : CInt {
+  _CXX_INVALID_ACCESS_SPECIFIER = 0,
+  _CXX_PUBLIC = 1,
+  _CXX_PROTECTED = 2,
+  _CXX_PRIVATE = 3
+}
+
+extern fn CX_CXXAccessSpecifier getCXXAccessSpecifier(
+  CXCursor)
+@cname("clang_getCXXAccessSpecifier");
+
+constdef CX_StorageClass : CInt {
+  _SC_INVALID = 0,
+  _SC_NONE = 1,
+  _SC_EXTERN = 2,
+  _SC_STATIC = 3,
+  _SC_PRIVATE_EXTERN = 4,
+  _SC_OPEN_CL_WORK_GROUP_LOCAL = 5,
+  _SC_AUTO = 6,
+  _SC_REGISTER = 7
+}
+
+constdef CX_BinaryOperatorKind : CInt {
+  _BO_INVALID = 0,
+  _BO_PTR_MEM_D = 1,
+  _BO_PTR_MEM_I = 2,
+  _BO_MUL = 3,
+  _BO_DIV = 4,
+  _BO_REM = 5,
+  _BO_ADD = 6,
+  _BO_SUB = 7,
+  _BO_SHL = 8,
+  _BO_SHR = 9,
+  _BO_CMP = 10,
+  _BO_LT = 11,
+  _BO_GT = 12,
+  _BO_LE = 13,
+  _BO_GE = 14,
+  _BO_EQ = 15,
+  _BO_NE = 16,
+  _BO_AND = 17,
+  _BO_XOR = 18,
+  _BO_OR = 19,
+  _BO_L_AND = 20,
+  _BO_L_OR = 21,
+  _BO_ASSIGN = 22,
+  _BO_MUL_ASSIGN = 23,
+  _BO_DIV_ASSIGN = 24,
+  _BO_REM_ASSIGN = 25,
+  _BO_ADD_ASSIGN = 26,
+  _BO_SUB_ASSIGN = 27,
+  _BO_SHL_ASSIGN = 28,
+  _BO_SHR_ASSIGN = 29,
+  _BO_AND_ASSIGN = 30,
+  _BO_XOR_ASSIGN = 31,
+  _BO_OR_ASSIGN = 32,
+  _BO_COMMA = 33,
+  _BO_LAST = 33
+}
+
+extern fn CX_BinaryOperatorKind cursor_getBinaryOpcode(
+  CXCursor c)
+@cname("clang_Cursor_getBinaryOpcode");
+
+extern fn CXString cursor_getBinaryOpcodeStr(
+  CX_BinaryOperatorKind op)
+@cname("clang_Cursor_getBinaryOpcodeStr");
+
+extern fn CX_StorageClass cursor_getStorageClass(
+  CXCursor)
+@cname("clang_Cursor_getStorageClass");
+
+extern fn CUInt getNumOverloadedDecls(
+  CXCursor cursor)
+@cname("clang_getNumOverloadedDecls");
+
+extern fn CXCursor getOverloadedDecl(
+  CXCursor cursor,
+  CUInt index)
+@cname("clang_getOverloadedDecl");
+
+extern fn CXType getIBOutletCollectionType(
+  CXCursor)
+@cname("clang_getIBOutletCollectionType");
+
+constdef CXChildVisitResult : CInt {
+  CHILD_VISIT_BREAK = 0,
+  CHILD_VISIT_CONTINUE = 1,
+  CHILD_VISIT_RECURSE = 2
+}
+
 alias CXCursorVisitor = fn CXChildVisitResult(
-  CXCursor cursor, 
-  CXCursor parent, 
+  CXCursor cursor,
+  CXCursor parent,
   CXClientData client_data);
 
-/**
- * Visit the children of a particular cursor.
- *
- * This function visits all the direct children of the given cursor,
- * invoking the given \p visitor function with the cursors of each
- * visited child. The traversal may be recursive, if the visitor returns
- * \c CXChildVisit_Recurse. The traversal may also be ended prematurely, if
- * the visitor returns \c CXChildVisit_Break.
- *
- * \param parent the cursor whose child may be visited. All kinds of
- * cursors can be visited, including invalid cursors (which, by
- * definition, have no children).
- *
- * \param visitor the visitor function that will be invoked for each
- * child of \p parent.
- *
- * \param client_data pointer data supplied by the client, which will
- * be passed to the visitor each time it is invoked.
- *
- * \returns a non-zero value if the traversal was terminated
- * prematurely by the visitor returning \c CXChildVisit_Break.
- */
-fn CUInt visitChildren(
-  CXCursor parent, 
-  CXCursorVisitor visitor, 
-  CXClientData client_data) 
-@extern("clang_visitChildren");
-
-/**
- * Visitor invoked for each cursor found by a traversal.
- *
- * This visitor block will be invoked for each cursor found by
- * clang_visitChildrenWithBlock(). Its first argument is the cursor being
- * visited, its second argument is the parent visitor for that cursor.
- *
- * The visitor should return one of the \c CXChildVisitResult values
- * to direct clang_visitChildrenWithBlock().
- */
-typedef CXCursorVisitorBlock = void*;
-
-/**
- * Visits the children of a cursor using the specified block.  Behaves
- * identically to clang_visitChildren() in all other respects.
- */
-fn CUInt visitChildrenWithBlock(
-  CXCursor parent, 
-  CXCursorVisitorBlock block) 
-@extern("clang_visitChildrenWithBlock");
-
-/**
- * Retrieve a Unified Symbol Resolution (USR) for the entity referenced
- * by the given cursor.
- *
- * A Unified Symbol Resolution (USR) is a string that identifies a particular
- * entity (function, class, variable, etc.) within a program. USRs can be
- * compared across translation units to determine, e.g., when references in
- * one translation refer to an entity defined in another translation unit.
- */
-fn CXString getCursorUSR(
-  CXCursor c) 
-@extern("clang_getCursorUSR");
-
-/**
- * Construct a USR for a specified Objective-C class.
- */
-fn CXString constructUSR_ObjCClass(
-  ZString class_name) 
-@extern("clang_constructUSR_ObjCClass");
-
-/**
- * Construct a USR for a specified Objective-C category.
- */
-fn CXString constructUSR_ObjCCategory(
-  ZString class_name, 
-  ZString category_name) 
-@extern("clang_constructUSR_ObjCCategory");
-
-/**
- * Construct a USR for a specified Objective-C protocol.
- */
-fn CXString constructUSR_ObjCProtocol(
-  ZString protocol_name) 
-@extern("clang_constructUSR_ObjCProtocol");
-
-/**
- * Construct a USR for a specified Objective-C instance variable and
- *   the USR for its containing class.
- */
-fn CXString constructUSR_ObjCIvar(
-  ZString name, 
-  CXString classUSR) 
-@extern("clang_constructUSR_ObjCIvar");
-
-/**
- * Construct a USR for a specified Objective-C method and
- *   the USR for its containing class.
- */
-fn CXString constructUSR_ObjCMethod(
-  ZString name, 
-  CUInt is_instance_method, 
-  CXString classUSR) 
-@extern("clang_constructUSR_ObjCMethod");
-
-/**
- * Construct a USR for a specified Objective-C property and the USR
- *  for its containing class.
- */
-fn CXString constructUSR_ObjCProperty(
-  ZString property, 
-  CXString classUSR) 
-@extern("clang_constructUSR_ObjCProperty");
-
-/**
- * Retrieve a name for the entity referenced by this cursor.
- */
-fn CXString getCursorSpelling(
-  CXCursor cursor) 
-@extern("clang_getCursorSpelling");
-
-/**
- * Retrieve a range for a piece that forms the cursors spelling name.
- * Most of the times there is only one range for the complete spelling but for
- * Objective-C methods and Objective-C message expressions, there are multiple
- * pieces for each selector identifier.
- *
- * \param pieceIndex the index of the spelling name piece. If this is greater
- * than the actual number of pieces, it will return a NULL (invalid) range.
- *
- * \param options Reserved.
- */
-fn CXSourceRange getSpellingNameRange_Cursor(
-  CXCursor cursor, 
-  CUInt piece_index, 
-  CUInt options) 
-@extern("clang_Cursor_getSpellingNameRange");
-
-/**
- * Opaque pointer representing a policy that controls pretty printing
- * for \c clang_getCursorPrettyPrinted.
- */
-typedef CXPrintingPolicy = inline void*;
-
-/**
- * Properties for the printing policy.
- *
- * See \c clang::PrintingPolicy for more information.
- */
-typedef CXPrintingPolicyProperty = inline CInt;
-
-const CXPrintingPolicyProperty PRINTING_POLICY_INDENTATION = 0;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_SPECIFIERS = 1;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_TAG_KEYWORD = 2;
-const CXPrintingPolicyProperty PRINTING_POLICY_INCLUDE_TAG_DEFINITION = 3;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_SCOPE = 4;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_UNWRITTEN_SCOPE = 5;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_INITIALIZERS = 6;
-const CXPrintingPolicyProperty PRINTING_POLICY_CONSTANT_ARRAY_SIZE_AS_WRITTEN = 7;
-const CXPrintingPolicyProperty PRINTING_POLICY_ANONYMOUS_TAG_LOCATIONS = 8;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_STRONG_LIFETIME = 9;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_LIFETIME_QUALIFIERS = 10;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_TEMPLATE_ARGS_IN_CXX_CONSTRUCTORS = 11;
-const CXPrintingPolicyProperty PRINTING_POLICY_BOOL = 12;
-const CXPrintingPolicyProperty PRINTING_POLICY_RESTRICT = 13;
-const CXPrintingPolicyProperty PRINTING_POLICY_ALIGNOF = 14;
-const CXPrintingPolicyProperty PRINTING_POLICY_UNDERSCORE_ALIGNOF = 15;
-const CXPrintingPolicyProperty PRINTING_POLICY_USE_VOID_FOR_ZERO_PARAMS = 16;
-const CXPrintingPolicyProperty PRINTING_POLICY_TERSE_OUTPUT = 17;
-const CXPrintingPolicyProperty PRINTING_POLICY_POLISH_FOR_DECLARATION = 18;
-const CXPrintingPolicyProperty PRINTING_POLICY_HALF = 19;
-const CXPrintingPolicyProperty PRINTING_POLICY_MS_WCHAR = 20;
-const CXPrintingPolicyProperty PRINTING_POLICY_INCLUDE_NEW_LINES = 21;
-const CXPrintingPolicyProperty PRINTING_POLICY_MSVC_FORMATTING = 22;
-const CXPrintingPolicyProperty PRINTING_POLICY_CONSTANTS_AS_WRITTEN = 23;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_IMPLICIT_BASE = 24;
-const CXPrintingPolicyProperty PRINTING_POLICY_FULLY_QUALIFIED_NAME = 25;
-
-const CXPrintingPolicyProperty PRINTING_POLICY_LAST_PROPERTY = PRINTING_POLICY_FULLY_QUALIFIED_NAME;
-
-/**
- * Get a property value for the given printing policy.
- */
-fn CUInt getProperty_PrintingPolicy(
-  CXPrintingPolicy policy, 
-  CXPrintingPolicyProperty property) 
-@extern("clang_PrintingPolicy_getProperty");
-
-/**
- * Set a property value for the given printing policy.
- */
-fn void setProperty_PrintingPolicy(
-  CXPrintingPolicy policy, 
-  CXPrintingPolicyProperty property, 
-  CUInt value) 
-@extern("clang_PrintingPolicy_setProperty");
-
-/**
- * Retrieve the default policy for the cursor.
- *
- * The policy should be released after use with \c
- * clang_PrintingPolicy_dispose.
- */
-fn CXPrintingPolicy getCursorPrintingPolicy(
-  CXCursor cursor) 
-@extern("clang_getCursorPrintingPolicy");
-
-/**
- * Release a printing policy.
- */
-fn void dispose_PrintingPolicy(
-  CXPrintingPolicy policy) 
-@extern("clang_PrintingPolicy_dispose");
-
-/**
- * Pretty prCInt declarations.
- *
- * \param Cursor The cursor representing a declaration.
- *
- * \param Policy The policy to control the entities being printed. If
- * NULL, a default policy is used.
- *
- * \returns The pretty printed declaration or the empty string for
- * other cursors.
- */
-fn CXString getCursorPrettyPrinted(
-  CXCursor cursor, 
-  CXPrintingPolicy policy) 
-@extern("clang_getCursorPrettyPrinted");
-
-/**
- * Retrieve the display name for the entity referenced by this cursor.
- *
- * The display name contains extra information that helps identify the cursor,
- * such as the parameters of a function or template or the arguments of a
- * class template specialization.
- */
-fn CXString getCursorDisplayName(
-  CXCursor cursor) 
-@extern("clang_getCursorDisplayName");
-
-/** For a cursor that is a reference, retrieve a cursor representing the
- * entity that it references.
- *
- * Reference cursors refer to other entities in the AST. For example, an
- * Objective-C superclass reference cursor refers to an Objective-C class.
- * This function produces the cursor for the Objective-C class from the
- * cursor for the superclass reference. If the input cursor is a declaration or
- * definition, it returns that declaration or definition unchanged.
- * Otherwise, returns the NULL cursor.
- */
-fn CXCursor getCursorReferenced(
-  CXCursor cursor) 
-@extern("clang_getCursorReferenced");
-
-/**
- *  For a cursor that is either a reference to or a declaration
- *  of some entity, retrieve a cursor that describes the definition of
- *  that entity.
- *
- *  Some entities can be declared multiple times within a translation
- *  unit, but only one of those declarations can also be a
- *  definition. For example, given:
- *
- *  \code
- *  CInt f(CInt, CInt);
- *  CInt g(CInt x, CInt y) { return f(x, y); }
- *  CInt f(CInt a, CInt b) { return a + b; }
- *  CInt f(CInt, CInt);
- *  \endcode
- *
- *  there are three declarations of the function "f", but only the
- *  second one is a definition. The clang_getCursorDefinition()
- *  function will take any cursor pointing to a declaration of "f"
- *  (the first or fourth lines of the example) or a cursor referenced
- *  that uses "f" (the call to "f' inside "g") and will return a
- *  declaration cursor pointing to the definition (the second "f"
- *  declaration).
- *
- *  If given a cursor for which there is no corresponding definition,
- *  e.g., because there is no definition of that entity within this
- *  translation unit, returns a NULL cursor.
- */
-fn CXCursor getCursorDefinition(
-  CXCursor cursor) 
-@extern("clang_getCursorDefinition");
-
-/**
- * Determine whether the declaration pointed to by this cursor
- * is also a definition of that entity.
- */
-fn CUInt isCursorDefinition(
-  CXCursor cursor) 
-@extern("clang_isCursorDefinition");
-
-/**
- * Retrieve the canonical cursor corresponding to the given cursor.
- *
- * In the C family of languages, many kinds of entities can be declared several
- * times within a single translation unit. For example, a structure type can
- * be forward-declared (possibly multiple times) and later defined:
- *
- * \code
- * struct X;
- * struct X;
- * struct X {
- *   CInt member;
- * };
- * \endcode
- *
- * The declarations and the definition of \c X are represented by three
- * different cursors, all of which are declarations of the same underlying
- * entity. One of these cursor is considered the "canonical" cursor, which
- * is effectively the representative for the underlying entity. One can
- * determine if two cursors are declarations of the same underlying entity by
- * comparing their canonical cursors.
- *
- * \returns The canonical cursor for the entity referred to by the given cursor.
- */
-fn CXCursor getCanonicalCursor(
-  CXCursor cursor) 
-@extern("clang_getCanonicalCursor");
-
-/**
- * If the cursor points to a selector identifier in an Objective-C
- * method or message expression, this returns the selector index.
- *
- * After getting a cursor with #clang_getCursor, this can be called to
- * determine if the location points to a selector identifier.
- *
- * \returns The selector index if the cursor is an Objective-C method or message
- * expression and the cursor is pointing to a selector identifier, or -1
- * otherwise.
- */
-fn CInt getObjCSelectorIndex_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_getObjCSelectorIndex");
-
-/**
- * Given a cursor pointing to a C++ method call or an Objective-C
- * message, returns non-zero if the method/message is "dynamic", meaning:
- *
- * For a C++ method: the call is virtual.
- * For an Objective-C message: the receiver is an object instance, not 'super'
- * or a specific class.
- *
- * If the method/message is "static" or the cursor does not poCInt to a
- * method/message, it will return zero.
- */
-fn CInt isDynamicCall_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isDynamicCall");
-
-/**
- * Given a cursor pointing to an Objective-C message or property
- * reference, or C++ method call, returns the CXType of the receiver.
- */
-fn CXType getReceiverType_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getReceiverType");
-
-/**
- * Property attributes for a \c CXCursor_ObjCPropertyDecl.
- */
-typedef CXObjCPropertyAttrKind = inline CInt;
-
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_NOATTR = 0x00;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_READONLY = 0x01;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_GETTER = 0x02;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_ASSIGN = 0x04;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_READWRITE = 0x08;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_RETAIN = 0x10;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_COPY = 0x20;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_NONATOMIC = 0x40;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_SETTER = 0x80;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_ATOMIC = 0x100;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_WEAK = 0x200;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_STRONG = 0x400;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_UNSAFE_UNRETAINED = 0x800;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_CLASS = 0x1000;
-
-/**
- * Given a cursor that represents a property declaration, return the
- * associated property attributes. The bits are formed from
- * \c CXObjCPropertyAttrKind.
- *
- * \param reserved Reserved for future use, pass 0.
- */
-fn CUInt getObjCPropertyAttributes_Cursor(
-  CXCursor c, 
-  CUInt reserved) 
-@extern("clang_Cursor_getObjCPropertyAttributes");
-
-/**
- * Given a cursor that represents a property declaration, return the
- * name of the method that implements the getter.
- */
-fn CXString getObjCPropertyGetterName_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getObjCPropertyGetterName");
-
-/**
- * Given a cursor that represents a property declaration, return the
- * name of the method that implements the setter, if any.
- */
-fn CXString getObjCPropertySetterName_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getObjCPropertySetterName");
-
-/**
- * 'Qualifiers' written next to the return and parameter types in
- * Objective-C method declarations.
- */
-typedef CXObjCDeclQualifierKind = inline CInt;
-
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_NONE = 0x0;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_IN = 0x1;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_INOUT = 0x2;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_OUT = 0x4;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_BYCOPY = 0x8;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_BYREF = 0x10;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_ONEWAY = 0x20;
-
-/**
- * Given a cursor that represents an Objective-C method or parameter
- * declaration, return the associated Objective-C qualifiers for the return
- * type or the parameter respectively. The bits are formed from
- * CXObjCDeclQualifierKind.
- */
-fn CUInt getObjCDeclQualifiers_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getObjCDeclQualifiers");
-
-/**
- * Given a cursor that represents an Objective-C method or property
- * declaration, return non-zero if the declaration was affected by "\@optional".
- * Returns zero if the cursor is not such a declaration or it is "\@required".
- */
-fn CUInt isObjCOptional_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isObjCOptional");
-
-/**
- * Returns non-zero if the given cursor is a variadic function or method.
- */
-fn CUInt isVariadic_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isVariadic");
-
-/**
- * Returns non-zero if the given cursor points to a symbol marked with
- * external_source_symbol attribute.
- *
- * \param language If non-NULL, and the attribute is present, will be set to
- * the 'language' string from the attribute.
- *
- * \param definedIn If non-NULL, and the attribute is present, will be set to
- * the 'definedIn' string from the attribute.
- *
- * \param isGenerated If non-NULL, and the attribute is present, will be set to
- * non-zero if the 'generated_declaration' is set in the attribute.
- */
-fn CUInt isExternalSymbol_Cursor(
-  CXCursor c, 
-  CXString* language, 
-  CXString* definedIn, 
-  CUInt* isGenerated) 
-@extern("clang_Cursor_isExternalSymbol");
-
-/**
- * Given a cursor that represents a declaration, return the associated
- * comment's source range.  The range may include multiple consecutive comments
- * with whitespace in between.
- */
-fn CXSourceRange getCommentRange_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getCommentRange");
-
-/**
- * Given a cursor that represents a declaration, return the associated
- * comment text, including comment markers.
- */
-fn CXString getRawCommentText_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getRawCommentText");
-
-/**
- * Given a cursor that represents a documentable entity (e.g.,
- * declaration), return the associated \paragraph; otherwise return the
- * first paragraph.
- */
-fn CXString getBriefCommentText_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getBriefCommentText");
-
-/**
- * Retrieve the CXString representing the mangled name of the cursor.
- */
-fn CXString getMangling_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getMangling");
-
-/**
- * Retrieve the CXStrings representing the mangled symbols of the C++
- * constructor or destructor at the cursor.
- */
-fn CXStringSet* getCXXManglings_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getCXXManglings");
-
-/**
- * Retrieve the CXStrings representing the mangled symbols of the ObjC
- * class interface or implementation at the cursor.
- */
-fn CXStringSet* getObjCManglings_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getObjCManglings");
-
-typedef CXModule = inline void*;
-
-/**
- * Given a CXCursor_ModuleImportDecl cursor, return the associated module.
- */
-fn CXModule getModule_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getModule");
-
-/**
- * Given a CXFile header file, return the module that contains it, if one
- * exists.
- */
-fn CXModule getModuleForFile(
-  CXTranslationUnit tu, 
-  CXFile file) 
-@extern("clang_getModuleForFile");
-
-/**
- * \param Module a module object.
- *
- * \returns the module file where the provided module object came from.
- */
-fn CXFile getASTFile_Module(
-  CXModule mod) 
-@extern("clang_Module_getASTFile");
-
-/**
- * \param Module a module object.
- *
- * \returns the parent of a sub-module or NULL if the given module is top-level,
- * e.g. for 'std.vector' it will return the 'std' module.
- */
-fn CXModule getParent_Module(
-  CXModule mod) 
-@extern("clang_Module_getParent");
-
-/**
- * \param Module a module object.
- *
- * \returns the name of the module, e.g. for the 'std.vector' sub-module it
- * will return "vector".
- */
-fn CXString getName_Module(
-  CXModule mod) 
-@extern("clang_Module_getName");
-
-/**
- * \param Module a module object.
- *
- * \returns the full name of the module, e.g. "std.vector".
- */
-fn CXString getFullName_Module(
-  CXModule mod) 
-@extern("clang_Module_getFullName");
-
-/**
- * \param Module a module object.
- *
- * \returns non-zero if the module is a system one.
- */
-fn CInt isSystem_Module(
-  CXModule mod) 
-@extern("clang_Module_isSystem");
-
-/**
- * \param Module a module object.
- *
- * \returns the number of top level headers associated with this module.
- */
-fn CUInt getNumTopLevelHeaders_Module(
-  CXModule mod, 
-  CXTranslationUnit tu)
-@extern("clang_Module_getNumTopLevelHeaders");
-
-/**
- * \param Module a module object.
- *
- * \param Index top level header index (zero-based).
- *
- * \returns the specified top level header associated with the module.
- */
-fn CXFile getTopLevelHeader_Module(
-  CXModule mod, 
-  CXTranslationUnit tu, 
-  CUInt index) 
-@extern("clang_Module_getTopLevelHeader");
-
-/**
- * Determine if a C++ constructor is a converting constructor.
- */
-fn CUInt isConvertingConstructor_CXXConstructor(
-  CXCursor c) 
-@extern("clang_CXXConstructor_isConvertingConstructor");
-
-/**
- * Determine if a C++ constructor is a copy constructor.
- */
-fn CUInt isCopyConstructor_CXXConstructor(
-  CXCursor c) 
-@extern("clang_CXXConstructor_isCopyConstructor");
-
-/**
- * Determine if a C++ constructor is the default constructor.
- */
-fn CUInt isDefaultConstructor_CXXConstructor(
-  CXCursor c) 
-@extern("clang_CXXConstructor_isDefaultConstructor");
-
-/**
- * Determine if a C++ constructor is a move constructor.
- */
-fn CUInt isMoveConstructor_CXXConstructor(
-  CXCursor c) 
-@extern("clang_CXXConstructor_isMoveConstructor");
-
-/**
- * Determine if a C++ field is declared 'mutable'.
- */
-fn CUInt isMutable_CXXField(
-  CXCursor c) 
-@extern("clang_CXXField_isMutable");
-
-/**
- * Determine if a C++ method is declared '= default'.
- */
-fn CUInt isDefaulted_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isDefaulted");
-
-/**
- * Determine if a C++ method is declared '= delete'.
- */
-fn CUInt isDeleted_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isDeleted");
-
-/**
- * Determine if a C++ member function or member function template is
- * pure virtual.
- */
-fn CUInt isPureVirtual_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isPureVirtual");
-
-/**
- * Determine if a C++ member function or member function template is
- * declared 'static'.
- */
-fn CUInt isStatic_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isStatic");
-
-/**
- * Determine if a C++ member function or member function template is
- * explicitly declared 'virtual' or if it overrides a virtual method from
- * one of the base classes.
- */
-fn CUInt isVirtual_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isVirtual");
-
-/**
- * Determine if a C++ member function is a copy-assignment operator,
- * returning 1 if such is the case and 0 otherwise.
- *
- * > A copy-assignment operator `X::operator=` is a non-static,
- * > non-template member function of _class_ `X` with exactly one
- * > parameter of type `X`, `X&`, `const X&`, `volatile X&` or `const
- * > volatile X&`.
- *
- * That is, for example, the `operator=` in:
- *
- *    class Foo {
- *        bool operator=(const volatile Foo&);
- *    };
- *
- * Is a copy-assignment operator, while the `operator=` in:
- *
- *    class Bar {
- *        bool operator=(const CInt&);
- *    };
- *
- * Is not.
- */
-fn CUInt isCopyAssignmentOperator_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isCopyAssignmentOperator");
-
-/**
- * Determine if a C++ member function is a move-assignment operator,
- * returning 1 if such is the case and 0 otherwise.
- *
- * > A move-assignment operator `X::operator=` is a non-static,
- * > non-template member function of _class_ `X` with exactly one
- * > parameter of type `X&&`, `const X&&`, `volatile X&&` or `const
- * > volatile X&&`.
- *
- * That is, for example, the `operator=` in:
- *
- *    class Foo {
- *        bool operator=(const volatile Foo&&);
- *    };
- *
- * Is a move-assignment operator, while the `operator=` in:
- *
- *    class Bar {
- *        bool operator=(const CInt&&);
- *    };
- *
- * Is not.
- */
-fn CUInt isMoveAssignmentOperator_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isMoveAssignmentOperator");
-
-/**
- * Determines if a C++ constructor or conversion function was declared
- * explicit, returning 1 if such is the case and 0 otherwise.
- *
- * Constructors or conversion functions are declared explicit through
- * the use of the explicit specifier.
- *
- * For example, the following constructor and conversion function are
- * not explicit as they lack the explicit specifier:
- *
- *     class Foo {
- *         Foo();
- *         operator CInt();
- *     };
- *
- * While the following constructor and conversion function are
- * explicit as they are declared with the explicit specifier.
- *
- *     class Foo {
- *         explicit Foo();
- *         explicit operator CInt();
- *     };
- *
- * This function will return 0 when given a cursor pointing to one of
- * the former declarations and it will return 1 for a cursor pointing
- * to the latter declarations.
- *
- * The explicit specifier allows the user to specify a
- * conditional compile-time expression whose value decides
- * whether the marked element is explicit or not.
- *
- * For example:
- *
- *     constexpr bool foo(CInt i) { return i % 2 == 0; }
- *
- *     class Foo {
- *          explicit(foo(1)) Foo();
- *          explicit(foo(2)) operator CInt();
- *     }
- *
- * This function will return 0 for the constructor and 1 for
- * the conversion function.
- */
-fn CUInt isExplicit_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isExplicit");
-
-/**
- * Determine if a C++ record is abstract, i.e. whether a class or struct
- * has a pure virtual member function.
- */
-fn CUInt isAbstract_CXXRecord(
-  CXCursor c) 
-@extern("clang_CXXRecord_isAbstract");
-
-/**
- * Determine if an enum declaration refers to a scoped enum.
- */
-fn CUInt isScopedEnumDecl(
+extern fn CUInt visitChildren(
+  CXCursor parent,
+  CXCursorVisitor visitor,
+  CXClientData client_data)
+@cname("clang_visitChildren");
+
+alias CXCursorVisitorBlock = void*;
+
+extern fn CUInt visitChildrenWithBlock(
+  CXCursor parent,
+  CXCursorVisitorBlock block)
+@cname("clang_visitChildrenWithBlock");
+
+extern fn CXString getCursorUSR(
+  CXCursor)
+@cname("clang_getCursorUSR");
+
+extern fn CXString constructUSR_ObjCClass(
+  ZString class_name)
+@cname("clang_constructUSR_ObjCClass");
+
+extern fn CXString constructUSR_ObjCCategory(
+  ZString class_name,
+  ZString category_name)
+@cname("clang_constructUSR_ObjCCategory");
+
+extern fn CXString constructUSR_ObjCProtocol(
+  ZString protocol_name)
+@cname("clang_constructUSR_ObjCProtocol");
+
+extern fn CXString constructUSR_ObjCIvar(
+  ZString name,
+  CXString class_usr)
+@cname("clang_constructUSR_ObjCIvar");
+
+extern fn CXString constructUSR_ObjCMethod(
+  ZString name,
+  CUInt is_instance_method,
+  CXString class_usr)
+@cname("clang_constructUSR_ObjCMethod");
+
+extern fn CXString constructUSR_ObjCProperty(
+  ZString property,
+  CXString class_usr)
+@cname("clang_constructUSR_ObjCProperty");
+
+extern fn CXString getCursorSpelling(
+  CXCursor)
+@cname("clang_getCursorSpelling");
+
+extern fn CXSourceRange cursor_getSpellingNameRange(
+  CXCursor,
+  CUInt piece_index,
+  CUInt options)
+@cname("clang_Cursor_getSpellingNameRange");
+
+alias CXPrintingPolicy = void*;
+
+constdef CXPrintingPolicyProperty : CInt {
+  PRINTING_POLICY_INDENTATION = 0,
+  PRINTING_POLICY_SUPPRESS_SPECIFIERS = 1,
+  PRINTING_POLICY_SUPPRESS_TAG_KEYWORD = 2,
+  PRINTING_POLICY_INCLUDE_TAG_DEFINITION = 3,
+  PRINTING_POLICY_SUPPRESS_SCOPE = 4,
+  PRINTING_POLICY_SUPPRESS_UNWRITTEN_SCOPE = 5,
+  PRINTING_POLICY_SUPPRESS_INITIALIZERS = 6,
+  PRINTING_POLICY_CONSTANT_ARRAY_SIZE_AS_WRITTEN = 7,
+  PRINTING_POLICY_ANONYMOUS_TAG_LOCATIONS = 8,
+  PRINTING_POLICY_SUPPRESS_STRONG_LIFETIME = 9,
+  PRINTING_POLICY_SUPPRESS_LIFETIME_QUALIFIERS = 10,
+  PRINTING_POLICY_SUPPRESS_TEMPLATE_ARGS_IN_CXX_CONSTRUCTORS = 11,
+  PRINTING_POLICY_BOOL = 12,
+  PRINTING_POLICY_RESTRICT = 13,
+  PRINTING_POLICY_ALIGNOF = 14,
+  PRINTING_POLICY_UNDERSCORE_ALIGNOF = 15,
+  PRINTING_POLICY_USE_VOID_FOR_ZERO_PARAMS = 16,
+  PRINTING_POLICY_TERSE_OUTPUT = 17,
+  PRINTING_POLICY_POLISH_FOR_DECLARATION = 18,
+  PRINTING_POLICY_HALF = 19,
+  PRINTING_POLICY_MSW_CHAR = 20,
+  PRINTING_POLICY_INCLUDE_NEWLINES = 21,
+  PRINTING_POLICY_MSVC_FORMATTING = 22,
+  PRINTING_POLICY_CONSTANTS_AS_WRITTEN = 23,
+  PRINTING_POLICY_SUPPRESS_IMPLICIT_BASE = 24,
+  PRINTING_POLICY_FULLY_QUALIFIED_NAME = 25,
+  PRINTING_POLICY_LAST_PROPERTY = 25
+}
+
+extern fn CUInt printingPolicy_getProperty(
+  CXPrintingPolicy policy,
+  CXPrintingPolicyProperty property)
+@cname("clang_PrintingPolicy_getProperty");
+
+extern fn void printingPolicy_setProperty(
+  CXPrintingPolicy policy,
+  CXPrintingPolicyProperty property,
+  CUInt value)
+@cname("clang_PrintingPolicy_setProperty");
+
+extern fn CXPrintingPolicy getCursorPrintingPolicy(
+  CXCursor)
+@cname("clang_getCursorPrintingPolicy");
+
+extern fn void printingPolicy_dispose(
+  CXPrintingPolicy policy)
+@cname("clang_PrintingPolicy_dispose");
+
+extern fn CXString getCursorPrettyPrinted(
+  CXCursor cursor,
+  CXPrintingPolicy policy)
+@cname("clang_getCursorPrettyPrinted");
+
+extern fn CXString getTypePrettyPrinted(
+  CXType ct,
+  CXPrintingPolicy cx_policy)
+@cname("clang_getTypePrettyPrinted");
+
+extern fn CXString getFullyQualifiedName(
+  CXType ct,
+  CXPrintingPolicy policy,
+  CUInt with_global_ns_prefix)
+@cname("clang_getFullyQualifiedName");
+
+extern fn CXString getCursorDisplayName(
+  CXCursor)
+@cname("clang_getCursorDisplayName");
+
+extern fn CXCursor getCursorReferenced(
+  CXCursor)
+@cname("clang_getCursorReferenced");
+
+extern fn CXCursor getCursorDefinition(
+  CXCursor)
+@cname("clang_getCursorDefinition");
+
+extern fn CUInt isCursorDefinition(
+  CXCursor)
+@cname("clang_isCursorDefinition");
+
+extern fn CXCursor getCanonicalCursor(
+  CXCursor)
+@cname("clang_getCanonicalCursor");
+
+extern fn CInt cursor_getObjCSelectorIndex(
+  CXCursor)
+@cname("clang_Cursor_getObjCSelectorIndex");
+
+extern fn CInt cursor_isDynamicCall(
   CXCursor c)
-@extern("clang_EnumDecl_isScoped");
+@cname("clang_Cursor_isDynamicCall");
 
-/**
- * Determine if a C++ member function or member function template is
- * declared 'const'.
- */
-fn CUInt isConst_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isConst");
+extern fn CXType cursor_getReceiverType(
+  CXCursor c)
+@cname("clang_Cursor_getReceiverType");
 
-/**
- * Given a cursor that represents a template, determine
- * the cursor kind of the specializations would be generated by instantiating
- * the template.
- *
- * This routine can be used to determine what flavor of function template,
- * class template, or class template partial specialization is stored in the
- * cursor. For example, it can describe whether a class template cursor is
- * declared with "struct", "class" or "union".
- *
- * \param C The cursor to query. This cursor should represent a template
- * declaration.
- *
- * \returns The cursor kind of the specializations that would be generated
- * by instantiating the template \p C. If \p C is not a template, returns
- * \c CXCursor_NoDeclFound.
- */
-fn CXCursorKind getTemplateCursorKind(
-  CXCursor c) 
-@extern("clang_getTemplateCursorKind");
+constdef CXObjCPropertyAttrKind : CInt {
+  OBJ_C_PROPERTY_ATTR_NOATTR = 0,
+  OBJ_C_PROPERTY_ATTR_READONLY = 1,
+  OBJ_C_PROPERTY_ATTR_GETTER = 2,
+  OBJ_C_PROPERTY_ATTR_ASSIGN = 4,
+  OBJ_C_PROPERTY_ATTR_READWRITE = 8,
+  OBJ_C_PROPERTY_ATTR_RETAIN = 16,
+  OBJ_C_PROPERTY_ATTR_COPY = 32,
+  OBJ_C_PROPERTY_ATTR_NONATOMIC = 64,
+  OBJ_C_PROPERTY_ATTR_SETTER = 128,
+  OBJ_C_PROPERTY_ATTR_ATOMIC = 256,
+  OBJ_C_PROPERTY_ATTR_WEAK = 512,
+  OBJ_C_PROPERTY_ATTR_STRONG = 1024,
+  OBJ_C_PROPERTY_ATTR_UNSAFE_UNRETAINED = 2048,
+  OBJ_C_PROPERTY_ATTR_CLASS = 4096
+}
 
-/**
- * Given a cursor that may represent a specialization or instantiation
- * of a template, retrieve the cursor that represents the template that it
- * specializes or from which it was instantiated.
- *
- * This routine determines the template involved both for explicit
- * specializations of templates and for implicit instantiations of the template,
- * both of which are referred to as "specializations". For a class template
- * specialization (e.g., \c std::vector<bool>), this routine will return
- * either the primary template (\c std::vector) or, if the specialization was
- * instantiated from a class template partial specialization, the class template
- * partial specialization. For a class template partial specialization and a
- * function template specialization (including instantiations), this
- * this routine will return the specialized template.
- *
- * For members of a class template (e.g., member functions, member classes, or
- * static data members), returns the specialized or instantiated member.
- * Although not strictly "templates" in the C++ language, members of class
- * templates have the same notions of specializations and instantiations that
- * templates do, so this routine treats them similarly.
- *
- * \param C A cursor that may be a specialization of a template or a member
- * of a template.
- *
- * \returns If the given cursor is a specialization or instantiation of a
- * template or a member thereof, the template or member that it specializes or
- * from which it was instantiated. Otherwise, returns a NULL cursor.
- */
-fn CXCursor getSpecializedCursorTemplate(
-  CXCursor c) 
-@extern("clang_getSpecializedCursorTemplate");
+extern fn CUInt cursor_getObjCPropertyAttributes(
+  CXCursor c,
+  CUInt reserved)
+@cname("clang_Cursor_getObjCPropertyAttributes");
 
-/**
- * Given a cursor that references something else, return the source range
- * covering that reference.
- *
- * \param C A cursor pointing to a member reference, a declaration reference, or
- * an operator call.
- * \param NameFlags A bitset with three independent flags:
- * CXNameRange_WantQualifier, CXNameRange_WantTemplateArgs, and
- * CXNameRange_WantSinglePiece.
- * \param PieceIndex For contiguous names or when passing the flag
- * CXNameRange_WantSinglePiece, only one piece with index 0 is
- * available. When the CXNameRange_WantSinglePiece flag is not passed for a
- * non-contiguous names, this index can be used to retrieve the individual
- * pieces of the name. See also CXNameRange_WantSinglePiece.
- *
- * \returns The piece of the name pointed to by the given cursor. If there is no
- * name, or if the PieceIndex is out-of-range, a null-cursor will be returned.
- */
-fn CXSourceRange getCursorReferenceNameRange(
-  CXCursor c, 
-  CUInt name_flags, 
-  CUInt piece_index) 
-@extern("clang_getCursorReferenceNameRange");
+extern fn CXString cursor_getObjCPropertyGetterName(
+  CXCursor c)
+@cname("clang_Cursor_getObjCPropertyGetterName");
 
-typedef CXNameRefFlags = inline CInt;
+extern fn CXString cursor_getObjCPropertySetterName(
+  CXCursor c)
+@cname("clang_Cursor_getObjCPropertySetterName");
 
-/**
- * Include the nested-name-specifier, e.g. Foo:: in x.Foo::y, in the
- * range.
- */
-const CXNameRefFlags NAME_RANGE_WANT_QUALIFIER = 0x1;
+constdef CXObjCDeclQualifierKind : CInt {
+  OBJ_C_DECL_QUALIFIER_NONE = 0,
+  OBJ_C_DECL_QUALIFIER_IN = 1,
+  OBJ_C_DECL_QUALIFIER_INOUT = 2,
+  OBJ_C_DECL_QUALIFIER_OUT = 4,
+  OBJ_C_DECL_QUALIFIER_BYCOPY = 8,
+  OBJ_C_DECL_QUALIFIER_BYREF = 16,
+  OBJ_C_DECL_QUALIFIER_ONEWAY = 32
+}
 
-/**
- * Include the explicit template arguments, e.g. \<CInt> in x.f<CInt>,
- * in the range.
- */
-const CXNameRefFlags NAME_RANGE_WANT_TEMPLATE_ARGS = 0x2;
+extern fn CUInt cursor_getObjCDeclQualifiers(
+  CXCursor c)
+@cname("clang_Cursor_getObjCDeclQualifiers");
 
-/**
- * If the name is non-contiguous, return the full spanning range.
- *
- * Non-contiguous names occur in Objective-C when a selector with two or more
- * parameters is used, or in C++ when using an operator:
- * \code
- * [object doSomething:here withValue:there]; // Objective-C
- * return some_vector[1]; // C++
- * \endcode
- */
-const CXNameRefFlags NAME_RANGE_WANT_SINGLE_PIECE = 0x4;
+extern fn CUInt cursor_isObjCOptional(
+  CXCursor c)
+@cname("clang_Cursor_isObjCOptional");
 
-/**
- * Describes a kind of token.
- */
-typedef CXTokenKind = inline CInt;
+extern fn CUInt cursor_isVariadic(
+  CXCursor c)
+@cname("clang_Cursor_isVariadic");
 
-/**
- * A token that contains some kind of punctuation.
- */
-const CXTokenKind TOKEN_PUNCTUATION = 0;
+extern fn CUInt cursor_isExternalSymbol(
+  CXCursor c,
+  CXString* language,
+  CXString* defined_in,
+  CUInt* is_generated)
+@cname("clang_Cursor_isExternalSymbol");
 
-/**
- * A language keyword.
- */
-const CXTokenKind TOKEN_KEYWORD = 1;
+extern fn CXSourceRange cursor_getCommentRange(
+  CXCursor c)
+@cname("clang_Cursor_getCommentRange");
 
-/**
- * An identifier (that is not a keyword).
- */
-const CXTokenKind TOKEN_IDENTIFIER = 2;
+extern fn CXString cursor_getRawCommentText(
+  CXCursor c)
+@cname("clang_Cursor_getRawCommentText");
 
-/**
- * A numeric, string, or character literal.
- */
-const CXTokenKind TOKEN_LITERAL = 3;
+extern fn CXString cursor_getBriefCommentText(
+  CXCursor c)
+@cname("clang_Cursor_getBriefCommentText");
 
-/**
- * A comment.
- */
-const CXTokenKind TOKEN_COMMENT = 4;
+extern fn CXString cursor_getMangling(
+  CXCursor)
+@cname("clang_Cursor_getMangling");
 
+extern fn CXStringSet* cursor_getCXXManglings(
+  CXCursor)
+@cname("clang_Cursor_getCXXManglings");
 
-/**
- * Describes a single preprocessing token.
- */
+extern fn CXStringSet* cursor_getObjCManglings(
+  CXCursor)
+@cname("clang_Cursor_getObjCManglings");
+
+extern fn CXString cursor_getGCCAssemblyTemplate(
+  CXCursor)
+@cname("clang_Cursor_getGCCAssemblyTemplate");
+
+extern fn CUInt cursor_isGCCAssemblyHasGoto(
+  CXCursor)
+@cname("clang_Cursor_isGCCAssemblyHasGoto");
+
+extern fn CUInt cursor_getGCCAssemblyNumOutputs(
+  CXCursor)
+@cname("clang_Cursor_getGCCAssemblyNumOutputs");
+
+extern fn CUInt cursor_getGCCAssemblyNumInputs(
+  CXCursor)
+@cname("clang_Cursor_getGCCAssemblyNumInputs");
+
+extern fn CUInt cursor_getGCCAssemblyInput(
+  CXCursor cursor,
+  CUInt index,
+  CXString* constraint,
+  CXCursor* expr)
+@cname("clang_Cursor_getGCCAssemblyInput");
+
+extern fn CUInt cursor_getGCCAssemblyOutput(
+  CXCursor cursor,
+  CUInt index,
+  CXString* constraint,
+  CXCursor* expr)
+@cname("clang_Cursor_getGCCAssemblyOutput");
+
+extern fn CUInt cursor_getGCCAssemblyNumClobbers(
+  CXCursor cursor)
+@cname("clang_Cursor_getGCCAssemblyNumClobbers");
+
+extern fn CXString cursor_getGCCAssemblyClobber(
+  CXCursor cursor,
+  CUInt index)
+@cname("clang_Cursor_getGCCAssemblyClobber");
+
+extern fn CUInt cursor_isGCCAssemblyVolatile(
+  CXCursor cursor)
+@cname("clang_Cursor_isGCCAssemblyVolatile");
+
+alias CXModule = void*;
+
+extern fn CXModule cursor_getModule(
+  CXCursor c)
+@cname("clang_Cursor_getModule");
+
+extern fn CXModule getModuleForFile(
+  CXTranslationUnit,
+  CXFile)
+@cname("clang_getModuleForFile");
+
+extern fn CXFile module_getASTFile(
+  CXModule mod)
+@cname("clang_Module_getASTFile");
+
+extern fn CXModule module_getParent(
+  CXModule mod)
+@cname("clang_Module_getParent");
+
+extern fn CXString module_getName(
+  CXModule mod)
+@cname("clang_Module_getName");
+
+extern fn CXString module_getFullName(
+  CXModule mod)
+@cname("clang_Module_getFullName");
+
+extern fn CInt module_isSystem(
+  CXModule mod)
+@cname("clang_Module_isSystem");
+
+extern fn CUInt module_getNumTopLevelHeaders(
+  CXTranslationUnit,
+  CXModule mod)
+@cname("clang_Module_getNumTopLevelHeaders");
+
+extern fn CXFile module_getTopLevelHeader(
+  CXTranslationUnit,
+  CXModule mod,
+  CUInt index)
+@cname("clang_Module_getTopLevelHeader");
+
+extern fn CUInt cXXConstructor_isConvertingConstructor(
+  CXCursor c)
+@cname("clang_CXXConstructor_isConvertingConstructor");
+
+extern fn CUInt cXXConstructor_isCopyConstructor(
+  CXCursor c)
+@cname("clang_CXXConstructor_isCopyConstructor");
+
+extern fn CUInt cXXConstructor_isDefaultConstructor(
+  CXCursor c)
+@cname("clang_CXXConstructor_isDefaultConstructor");
+
+extern fn CUInt cXXConstructor_isMoveConstructor(
+  CXCursor c)
+@cname("clang_CXXConstructor_isMoveConstructor");
+
+extern fn CUInt cXXField_isMutable(
+  CXCursor c)
+@cname("clang_CXXField_isMutable");
+
+extern fn CUInt cXXMethod_isDefaulted(
+  CXCursor c)
+@cname("clang_CXXMethod_isDefaulted");
+
+extern fn CUInt cXXMethod_isDeleted(
+  CXCursor c)
+@cname("clang_CXXMethod_isDeleted");
+
+extern fn CUInt cXXMethod_isPureVirtual(
+  CXCursor c)
+@cname("clang_CXXMethod_isPureVirtual");
+
+extern fn CUInt cXXMethod_isStatic(
+  CXCursor c)
+@cname("clang_CXXMethod_isStatic");
+
+extern fn CUInt cXXMethod_isVirtual(
+  CXCursor c)
+@cname("clang_CXXMethod_isVirtual");
+
+extern fn CUInt cXXMethod_isCopyAssignmentOperator(
+  CXCursor c)
+@cname("clang_CXXMethod_isCopyAssignmentOperator");
+
+extern fn CUInt cXXMethod_isMoveAssignmentOperator(
+  CXCursor c)
+@cname("clang_CXXMethod_isMoveAssignmentOperator");
+
+extern fn CUInt cXXMethod_isExplicit(
+  CXCursor c)
+@cname("clang_CXXMethod_isExplicit");
+
+extern fn CUInt cXXRecord_isAbstract(
+  CXCursor c)
+@cname("clang_CXXRecord_isAbstract");
+
+extern fn CUInt enumDecl_isScoped(
+  CXCursor c)
+@cname("clang_EnumDecl_isScoped");
+
+extern fn CUInt cXXMethod_isConst(
+  CXCursor c)
+@cname("clang_CXXMethod_isConst");
+
+extern fn CXCursorKind getTemplateCursorKind(
+  CXCursor c)
+@cname("clang_getTemplateCursorKind");
+
+extern fn CXCursor getSpecializedCursorTemplate(
+  CXCursor c)
+@cname("clang_getSpecializedCursorTemplate");
+
+extern fn CXSourceRange getCursorReferenceNameRange(
+  CXCursor c,
+  CUInt name_flags,
+  CUInt piece_index)
+@cname("clang_getCursorReferenceNameRange");
+
+constdef CXNameRefFlags : CInt {
+  NAME_RANGE_WANT_QUALIFIER = 1,
+  NAME_RANGE_WANT_TEMPLATE_ARGS = 2,
+  NAME_RANGE_WANT_SINGLE_PIECE = 4
+}
+
+constdef CXTokenKind : CInt {
+  TOKEN_PUNCTUATION = 0,
+  TOKEN_KEYWORD = 1,
+  TOKEN_IDENTIFIER = 2,
+  TOKEN_LITERAL = 3,
+  TOKEN_COMMENT = 4
+}
+
 struct CXToken {
   CUInt[4] int_data;
   void* ptr_data;
 }
 
-/**
- * Get the raw lexical token starting with the given location.
- *
- * \param TU the translation unit whose text is being tokenized.
- *
- * \param Location the source location with which the token starts.
- *
- * \returns The token starting with the given location or NULL if no such token
- * exist. The returned pointer must be freed with clang_disposeTokens before the
- * translation unit is destroyed.
- */
-fn CXToken* getToken(
-  CXTranslationUnit tu, 
-  CXSourceLocation location) 
-@extern("clang_getToken");
-
-/**
- * Determine the kind of the given token.
- */
-fn CXTokenKind getTokenKind(
-  CXToken token) 
-@extern("clang_getTokenKind");
-
-/**
- * Determine the spelling of the given token.
- *
- * The spelling of a token is the textual representation of that token, e.g.,
- * the text of an identifier or keyword.
- */
-fn CXString getTokenSpelling(
-  CXTranslationUnit tu, 
-  CXToken token) 
-@extern("clang_getTokenSpelling");
-
-/**
- * Retrieve the source location of the given token.
- */
-fn CXSourceLocation getTokenLocation(
-  CXTranslationUnit tu, 
-  CXToken token) 
-@extern("clang_getTokenLocation");
-
-/**
- * Retrieve a source range that covers the given token.
- */
-fn CXSourceRange getTokenExtent(
+extern fn CXToken* getToken(
   CXTranslationUnit tu,
-  CXToken token)
-@extern("clang_getTokenExtent");
+  CXSourceLocation location)
+@cname("clang_getToken");
 
-/**
- * Tokenize the source code described by the given range into raw
- * lexical tokens.
- *
- * \param TU the translation unit whose text is being tokenized.
- *
- * \param Range the source range in which text should be tokenized. All of the
- * tokens produced by tokenization will fall within this source range,
- *
- * \param Tokens this pointer will be set to poCInt to the array of tokens
- * that occur within the given source range. The returned pointer must be
- * freed with clang_disposeTokens() before the translation unit is destroyed.
- *
- * \param NumTokens will be set to the number of tokens in the \c *Tokens
- * array.
- *
- */
-fn void tokenize(
-  CXTranslationUnit tu, 
-  CXSourceRange range, 
-  CXToken** tokens, 
-  CUInt* num_tokens) 
-@extern("clang_tokenize");
+extern fn CXTokenKind getTokenKind(
+  CXToken)
+@cname("clang_getTokenKind");
 
-/**
- * Annotate the given set of tokens by providing cursors for each token
- * that can be mapped to a specific entity within the abstract syntax tree.
- *
- * This token-annotation routine is equivalent to invoking
- * clang_getCursor() for the source locations of each of the
- * tokens. The cursors provided are filtered, so that only those
- * cursors that have a direct correspondence to the token are
- * accepted. For example, given a function call \c f(x),
- * clang_getCursor() would provide the following cursors:
- *
- *   * when the cursor is over the 'f', a DeclRefExpr cursor referring to 'f'.
- *   * when the cursor is over the '(' or the ')', a CallExpr referring to 'f'.
- *   * when the cursor is over the 'x', a DeclRefExpr cursor referring to 'x'.
- *
- * Only the first and last of these cursors will occur within the
- * annotate, since the tokens "f" and "x' directly refer to a function
- * and a variable, respectively, but the parentheses are just a small
- * part of the full syntax of the function call expression, which is
- * not provided as an annotation.
- *
- * \param TU the translation unit that owns the given tokens.
- *
- * \param Tokens the set of tokens to annotate.
- *
- * \param NumTokens the number of tokens in \p Tokens.
- *
- * \param Cursors an array of \p NumTokens cursors, whose contents will be
- * replaced with the cursors corresponding to each token.
- */
-fn void annotateTokens(
-  CXTranslationUnit tu, 
-  CXToken* tokens, 
-  CUInt num_tokens, 
-  CXCursor* cursors) 
-@extern("clang_annotateTokens");
+extern fn CXString getTokenSpelling(
+  CXTranslationUnit,
+  CXToken)
+@cname("clang_getTokenSpelling");
 
-/**
- * Free the given set of tokens.
- */
-fn void disposeTokens(
-  CXTranslationUnit tu, 
-  CXToken* tokens, 
-  CUInt num_tokens) 
-@extern("clang_disposeTokens");
+extern fn CXSourceLocation getTokenLocation(
+  CXTranslationUnit,
+  CXToken)
+@cname("clang_getTokenLocation");
 
-/* for debug/testing */
-fn CXString getCursorKindSpelling(
-  CXCursorKind kind) 
-@extern("clang_getCursorKindSpelling");
+extern fn CXSourceRange getTokenExtent(
+  CXTranslationUnit,
+  CXToken)
+@cname("clang_getTokenExtent");
 
-fn void getDefinitionSpellingAndExtent(
-  CXCursor cursor, 
-  ZString* startBuf, 
-  ZString* endBuf, 
-  CUInt* startLine, 
-  CUInt* startColumn, 
-  CUInt* endLine, 
-  CUInt* endColumn) 
-@extern("clang_getDefinitionSpellingAndExtent");
+extern fn void tokenize(
+  CXTranslationUnit tu,
+  CXSourceRange range,
+  CXToken** tokens,
+  CUInt* num_tokens)
+@cname("clang_tokenize");
 
-fn void enableStackTraces() 
-@extern("clang_enableStackTraces");
+extern fn void annotateTokens(
+  CXTranslationUnit tu,
+  CXToken* tokens,
+  CUInt num_tokens,
+  CXCursor* cursors)
+@cname("clang_annotateTokens");
 
-alias VoidPtrCallback @private = fn void(void*);
+extern fn void disposeTokens(
+  CXTranslationUnit tu,
+  CXToken* tokens,
+  CUInt num_tokens)
+@cname("clang_disposeTokens");
 
-fn void executeOnThread(
-  VoidPtrCallback func, 
-  void* user_data, 
-  CUInt stack_size) 
-@extern("clang_executeOnThread");
+extern fn CXString getCursorKindSpelling(
+  CXCursorKind kind)
+@cname("clang_getCursorKindSpelling");
 
-/**
- * A semantic string that describes a code-completion result.
- *
- * A semantic string that describes the formatting of a code-completion
- * result as a single "template" of text that should be inserted into the
- * source buffer when a particular code-completion result is selected.
- * Each semantic string is made up of some number of "chunks", each of which
- * contains some text along with a description of what that text means, e.g.,
- * the name of the entity being referenced, whether the text chunk is part of
- * the template, or whether it is a "placeholder" that the user should replace
- * with actual code,of a specific kind. See \c CXCompletionChunkKind for a
- * description of the different kinds of chunks.
- */
-typedef CXCompletionString = inline void*;
+extern fn void getDefinitionSpellingAndExtent(
+  CXCursor,
+  CChar** start_buf,
+  CChar** end_buf,
+  CUInt* start_line,
+  CUInt* start_column,
+  CUInt* end_line,
+  CUInt* end_column)
+@cname("clang_getDefinitionSpellingAndExtent");
 
-/**
- * A single result of code completion.
- */
+extern fn void enableStackTraces()
+@cname("clang_enableStackTraces");
+
+alias UnnamedPFN1 @private = fn void(
+  void*);
+
+extern fn void executeOnThread(
+  UnnamedPFN1 func,
+  void* user_data,
+  CUInt stack_size)
+@cname("clang_executeOnThread");
+
+alias CXCompletionString = void*;
+
 struct CXCompletionResult {
-  /*
-   * The kind of entity that this completion refers to.
-   *
-   * The cursor kind will be a macro, keyword, or a declaration (one of the
-   * *Decl cursor kinds), describing the entity that the completion is
-   * referring to.
-   *
-   * \todo In the future, we would like to provide a full cursor, to allow
-   * the client to extract additional information from declaration.
-   */
   CXCursorKind cursor_kind;
-
-  /*
-   * The code-completion string that describes how to insert this
-   * code-completion result into the editing buffer.
-   */
   CXCompletionString completion_string;
 }
 
-/**
- * Describes a single piece of text within a code-completion string.
- *
- * Each "chunk" within a code-completion string (\c CXCompletionString) is
- * either a piece of text with a specific "kind" that describes how that text
- * should be interpreted by the client or is another completion string.
- */
-typedef CXCompletionChunkKind = inline CInt;
+constdef CXCompletionChunkKind : CInt {
+  COMPLETION_CHUNK_OPTIONAL = 0,
+  COMPLETION_CHUNK_TYPED_TEXT = 1,
+  COMPLETION_CHUNK_TEXT = 2,
+  COMPLETION_CHUNK_PLACEHOLDER = 3,
+  COMPLETION_CHUNK_INFORMATIVE = 4,
+  COMPLETION_CHUNK_CURRENT_PARAMETER = 5,
+  COMPLETION_CHUNK_LEFT_PAREN = 6,
+  COMPLETION_CHUNK_RIGHT_PAREN = 7,
+  COMPLETION_CHUNK_LEFT_BRACKET = 8,
+  COMPLETION_CHUNK_RIGHT_BRACKET = 9,
+  COMPLETION_CHUNK_LEFT_BRACE = 10,
+  COMPLETION_CHUNK_RIGHT_BRACE = 11,
+  COMPLETION_CHUNK_LEFT_ANGLE = 12,
+  COMPLETION_CHUNK_RIGHT_ANGLE = 13,
+  COMPLETION_CHUNK_COMMA = 14,
+  COMPLETION_CHUNK_RESULT_TYPE = 15,
+  COMPLETION_CHUNK_COLON = 16,
+  COMPLETION_CHUNK_SEMI_COLON = 17,
+  COMPLETION_CHUNK_EQUAL = 18,
+  COMPLETION_CHUNK_HORIZONTAL_SPACE = 19,
+  COMPLETION_CHUNK_VERTICAL_SPACE = 20
+}
 
-/**
- * A code-completion string that describes "optional" text that
- * could be a part of the template (but is not required).
- *
- * The Optional chunk is the only kind of chunk that has a code-completion
- * string for its representation, which is accessible via
- * \c clang_getCompletionChunkCompletionString(). The code-completion string
- * describes an additional part of the template that is completely optional.
- * For example, optional chunks can be used to describe the placeholders for
- * arguments that match up with defaulted function parameters, e.g. given:
- *
- * \code
- * void f(CInt x, float y = 3.14, double z = 2.71828);
- * \endcode
- *
- * The code-completion string for this function would contain:
- *   - a TypedText chunk for "f".
- *   - a LeftParen chunk for "(".
- *   - a Placeholder chunk for "CInt x"
- *   - an Optional chunk containing the remaining defaulted arguments, e.g.,
- *       - a Comma chunk for ","
- *       - a Placeholder chunk for "float y"
- *       - an Optional chunk containing the last defaulted argument:
- *           - a Comma chunk for ","
- *           - a Placeholder chunk for "double z"
- *   - a RightParen chunk for ")"
- *
- * There are many ways to handle Optional chunks. Two simple approaches are:
- *   - Completely ignore optional chunks, in which case the template for the
- *     function "f" would only include the first parameter ("CInt x").
- *   - Fully expand all optional chunks, in which case the template for the
- *     function "f" would have all of the parameters.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_OPTIONAL = 0;
-/**
- * Text that a user would be expected to type to get this
- * code-completion result.
- *
- * There will be exactly one "typed text" chunk in a semantic string, which
- * will typically provide the spelling of a keyword or the name of a
- * declaration that could be used at the current code point. Clients are
- * expected to filter the code-completion results based on the text in this
- * chunk.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_TYPED_TEXT = 1;
-/**
- * Text that should be inserted as part of a code-completion result.
- *
- * A "text" chunk represents text that is part of the template to be
- * inserted into user code should this particular code-completion result
- * be selected.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_TEXT = 2;
-/**
- * Placeholder text that should be replaced by the user.
- *
- * A "placeholder" chunk marks a place where the user should insert text
- * into the code-completion template. For example, placeholders might mark
- * the function parameters for a function declaration, to indicate that the
- * user should provide arguments for each of those parameters. The actual
- * text in a placeholder is a suggestion for the text to display before
- * the user replaces the placeholder with real code.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_PLACEHOLDER = 3;
-/**
- * Informative text that should be displayed but never inserted as
- * part of the template.
- *
- * An "informative" chunk contains annotations that can be displayed to
- * help the user decide whether a particular code-completion result is the
- * right option, but which is not part of the actual template to be inserted
- * by code completion.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_INFORMATIVE = 4;
-/**
- * Text that describes the current parameter when code-completion is
- * referring to function call, message send, or template specialization.
- *
- * A "current parameter" chunk occurs when code-completion is providing
- * information about a parameter corresponding to the argument at the
- * code-completion point. For example, given a function
- *
- * \code
- * CInt add(CInt x, CInt y);
- * \endcode
- *
- * and the source code \c add(, where the code-completion poCInt is after the
- * "(", the code-completion string will contain a "current parameter" chunk
- * for "CInt x", indicating that the current argument will initialize that
- * parameter. After typing further, to \c add(17, (where the code-completion
- * poCInt is after the ","), the code-completion string will contain a
- * "current parameter" chunk to "CInt y".
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_CURRENT_PARAMETER = 5;
-/**
- * A left parenthesis ('('), used to initiate a function call or
- * signal the beginning of a function parameter list.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_LEFT_PAREN = 6;
-/**
- * A right parenthesis (')'), used to finish a function call or
- * signal the end of a function parameter list.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RIGHT_PAREN = 7;
-/**
- * A left bracket ('[').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_LEFT_BRACKE = 8;
-/**
- * A right bracket (']').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RIGHT_BRACKET = 9;
-/**
- * A left brace ('{').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_LEFT_BRACE = 10;
-/**
- * A right brace ('}').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RIGHT_BRACE = 11;
-/**
- * A left angle bracket ('<').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_LEFT_ANGLE = 12;
-/**
- * A right angle bracket ('>').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RIGHT_ANGLE = 13;
-/**
- * A comma separator (',').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_COMMA = 14;
-/**
- * Text that specifies the result type of a given result.
- *
- * This special kind of informative chunk is not meant to be inserted into
- * the text buffer. Rather, it is meant to illustrate the type that an
- * expression using the given completion string would have.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RESULT_TYPE = 15;
-/**
- * A colon (':').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_COLON = 16;
-/**
- * A semicolon (';').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_SEMI_COLON = 17;
-/**
- * An '=' sign.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_EQUAL = 18;
-/**
- * Horizontal space (' ').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_HORIZONTAL_SPACE = 19;
-/**
- * Vertical space ('\\n'), after which it is generally a good idea to
- * perform indentation.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_VERTICAL_SPACE = 20;
+extern fn CXCompletionChunkKind getCompletionChunkKind(
+  CXCompletionString completion_string,
+  CUInt chunk_number)
+@cname("clang_getCompletionChunkKind");
 
-/**
- * Determine the kind of a particular chunk within a completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \param chunk_number the 0-based index of the chunk in the completion string.
- *
- * \returns the kind of the chunk at the index \c chunk_number.
- */
-fn CXCompletionChunkKind getCompletionChunkKind(
-  CXCompletionString completion_string, 
-  CUInt chunk_number) 
-@extern("clang_getCompletionChunkKind");
+extern fn CXString getCompletionChunkText(
+  CXCompletionString completion_string,
+  CUInt chunk_number)
+@cname("clang_getCompletionChunkText");
 
-/**
- * Retrieve the text associated with a particular chunk within a
- * completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \param chunk_number the 0-based index of the chunk in the completion string.
- *
- * \returns the text associated with the chunk at index \c chunk_number.
- */
-fn CXString getCompletionChunkText(
-  CXCompletionString completion_string, 
-  CUInt chunk_number) 
-@extern("clang_getCompletionChunkText");
+extern fn CXCompletionString getCompletionChunkCompletionString(
+  CXCompletionString completion_string,
+  CUInt chunk_number)
+@cname("clang_getCompletionChunkCompletionString");
 
-/**
- * Retrieve the completion string associated with a particular chunk
- * within a completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \param chunk_number the 0-based index of the chunk in the completion string.
- *
- * \returns the completion string associated with the chunk at index
- * \c chunk_number.
- */
-fn CXCompletionString getCompletionChunkCompletionString(
-  CXCompletionString completion_string, 
-  CUInt chunk_number) 
-@extern("clang_getCompletionChunkCompletionString");
+extern fn CUInt getNumCompletionChunks(
+  CXCompletionString completion_string)
+@cname("clang_getNumCompletionChunks");
 
-/**
- * Retrieve the number of chunks in the given code-completion string.
- */
-fn CUInt getNumCompletionChunks(
-  CXCompletionString completion_string) 
-@extern("clang_getNumCompletionChunks");
+extern fn CUInt getCompletionPriority(
+  CXCompletionString completion_string)
+@cname("clang_getCompletionPriority");
 
-/**
- * Determine the priority of this code completion.
- *
- * The priority of a code completion indicates how likely it is that this
- * particular completion is the completion that the user will select. The
- * priority is selected by various internal heuristics.
- *
- * \param completion_string The completion string to query.
- *
- * \returns The priority of this completion string. Smaller values indicate
- * higher-priority (more likely) completions.
- */
-fn CUInt getCompletionPriority(
-  CXCompletionString completion_string) 
-@extern("clang_getCompletionPriority");
+extern fn CXAvailabilityKind getCompletionAvailability(
+  CXCompletionString completion_string)
+@cname("clang_getCompletionAvailability");
 
-/**
- * Determine the availability of the entity that this code-completion
- * string refers to.
- *
- * \param completion_string The completion string to query.
- *
- * \returns The availability of the completion string.
- */
-fn CXAvailabilityKind getCompletionAvailability(
-  CXCompletionString completion_string) 
-@extern("clang_getCompletionAvailability");
+extern fn CUInt getCompletionNumAnnotations(
+  CXCompletionString completion_string)
+@cname("clang_getCompletionNumAnnotations");
 
-/**
- * Retrieve the number of annotations associated with the given
- * completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \returns the number of annotations associated with the given completion
- * string.
- */
-fn CUInt getCompletionNumAnnotations(
-  CXCompletionString completion_string) 
-@extern("clang_getCompletionNumAnnotations");
+extern fn CXString getCompletionAnnotation(
+  CXCompletionString completion_string,
+  CUInt annotation_number)
+@cname("clang_getCompletionAnnotation");
 
-/**
- * Retrieve the annotation associated with the given completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \param annotation_number the 0-based index of the annotation of the
- * completion string.
- *
- * \returns annotation string associated with the completion at index
- * \c annotation_number, or a NULL string if that annotation is not available.
- */
-fn CXString getCompletionAnnotation(
-  CXCompletionString completion_string, 
-  CUInt annotation_number) 
-@extern("clang_getCompletionAnnotation");
+extern fn CXString getCompletionParent(
+  CXCompletionString completion_string,
+  CXCursorKind* kind)
+@cname("clang_getCompletionParent");
 
-/**
- * Retrieve the parent context of the given completion string.
- *
- * The parent context of a completion string is the semantic parent of
- * the declaration (if any) that the code completion represents. For example,
- * a code completion for an Objective-C method would have the method's class
- * or protocol as its context.
- *
- * \param completion_string The code completion string whose parent is
- * being queried.
- *
- * \param kind DEPRECATED: always set to CXCursor_NotImplemented if non-NULL.
- *
- * \returns The name of the completion parent, e.g., "NSObject" if
- * the completion string represents a method in the NSObject class.
- */
-fn CXString getCompletionParent(
-  CXCompletionString completion_string, 
-  CXCursorKind* kind) 
-@extern("clang_getCompletionParent");
+extern fn CXString getCompletionBriefComment(
+  CXCompletionString completion_string)
+@cname("clang_getCompletionBriefComment");
 
-/**
- * Retrieve the brief documentation comment attached to the declaration
- * that corresponds to the given completion string.
- */
-fn CXString getCompletionBriefComment(
-  CXCompletionString completion_string) 
-@extern("clang_getCompletionBriefComment");
+extern fn CXCompletionString getCursorCompletionString(
+  CXCursor cursor)
+@cname("clang_getCursorCompletionString");
 
-/**
- * Retrieve a completion string for an arbitrary declaration or macro
- * definition cursor.
- *
- * \param cursor The cursor to query.
- *
- * \returns A non-context-sensitive completion string for declaration and macro
- * definition cursors, or NULL for other kinds of cursors.
- */
-fn CXCompletionString getCursorCompletionString(
-  CXCursor cursor) 
-@extern("clang_getCursorCompletionString");
-
-/**
- * Contains the results of code-completion.
- *
- * This data structure contains the results of code completion, as
- * produced by \c clang_codeCompleteAt(). Its contents must be freed by
- * \c clang_disposeCodeCompleteResults.
- */
 struct CXCodeCompleteResults {
-  /*
-   * The code-completion results.
-   */
   CXCompletionResult* results;
-
-  /*
-   * The number of code-completion results stored in the
-   * \c Results array.
-   */
   CUInt num_results;
 }
 
-/**
- * Retrieve the number of fix-its for the given completion index.
- *
- * Calling this makes sense only if CXCodeComplete_IncludeCompletionsWithFixIts
- * option was set.
- *
- * \param results The structure keeping all completion results
- *
- * \param completion_index The index of the completion
- *
- * \return The number of fix-its which must be applied before the completion at
- * completion_index can be applied
- */
-fn CUInt getCompletionNumFixIts(
-  CXCodeCompleteResults* results, 
-  CUInt completion_index) 
-@extern("clang_getCompletionNumFixIts");
+extern fn CUInt getCompletionNumFixIts(
+  CXCodeCompleteResults* results,
+  CUInt completion_index)
+@cname("clang_getCompletionNumFixIts");
 
-/**
- * Fix-its that *must* be applied before inserting the text for the
- * corresponding completion.
- *
- * By default, clang_codeCompleteAt() only returns completions with empty
- * fix-its. Extra completions with non-empty fix-its should be explicitly
- * requested by setting CXCodeComplete_IncludeCompletionsWithFixIts.
- *
- * For the clients to be able to compute position of the cursor after applying
- * fix-its, the following conditions are guaranteed to hold for
- * replacement_range of the stored fix-its:
- *  - Ranges in the fix-its are guaranteed to never contain the completion
- *  poCInt (or identifier under completion point, if any) inside them, except
- *  at the start or at the end of the range.
- *  - If a fix-it range starts or ends with completion poCInt (or starts or
- *  ends after the identifier under completion point), it will contain at
- *  least one character. It allows to unambiguously recompute completion
- *  poCInt after applying the fix-it.
- *
- * The intuition is that provided fix-its change code around the identifier we
- * complete, but are not allowed to touch the identifier itself or the
- * completion point. One example of completions with corrections are the ones
- * replacing '.' with '->' and vice versa:
- *
- * std::unique_ptr<std::vector<CInt>> vec_ptr;
- * In 'vec_ptr.^', one of the completions is 'push_back', it requires
- * replacing '.' with '->'.
- * In 'vec_ptr->^', one of the completions is 'release', it requires
- * replacing '->' with '.'.
- *
- * \param results The structure keeping all completion results
- *
- * \param completion_index The index of the completion
- *
- * \param fixit_index The index of the fix-it for the completion at
- * completion_index
- *
- * \param replacement_range The fix-it range that must be replaced before the
- * completion at completion_index can be applied
- *
- * \returns The fix-it string that must replace the code at replacement_range
- * before the completion at completion_index can be applied
- */
-fn CXString getCompletionFixIt(
-  CXCodeCompleteResults* results, 
-  CUInt completion_index, 
-  CUInt fixit_index, 
-  CXSourceRange* replacement_range) 
-@extern("clang_getCompletionFixIt");
+extern fn CXString getCompletionFixIt(
+  CXCodeCompleteResults* results,
+  CUInt completion_index,
+  CUInt fixit_index,
+  CXSourceRange* replacement_range)
+@cname("clang_getCompletionFixIt");
 
-/**
- * Flags that can be passed to \c clang_codeCompleteAt() to
- * modify its behavior.
- *
- * The enumerators in this enumeration can be bitwise-OR'd together to
- * provide multiple options to \c clang_codeCompleteAt().
- */
-typedef CXCodeComplete_Flags = inline CInt;
+constdef CXCodeComplete_Flags : CInt {
+  CODE_COMPLETE_INCLUDE_MACROS = 1,
+  CODE_COMPLETE_INCLUDE_CODE_PATTERNS = 2,
+  CODE_COMPLETE_INCLUDE_BRIEF_COMMENTS = 4,
+  CODE_COMPLETE_SKIP_PREAMBLE = 8,
+  CODE_COMPLETE_INCLUDE_COMPLETIONS_WITH_FIX_ITS = 16
+}
 
-/**
- * Whether to include macros within the set of code
- * completions returned.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_INCLUDE_MACROS = 0x01;
+constdef CXCompletionContext : CInt {
+  COMPLETION_CONTEXT_UNEXPOSED = 0,
+  COMPLETION_CONTEXT_ANY_TYPE = 1,
+  COMPLETION_CONTEXT_ANY_VALUE = 2,
+  COMPLETION_CONTEXT_OBJ_C_OBJECT_VALUE = 4,
+  COMPLETION_CONTEXT_OBJ_C_SELECTOR_VALUE = 8,
+  COMPLETION_CONTEXT_CXX_CLASS_TYPE_VALUE = 16,
+  COMPLETION_CONTEXT_DOT_MEMBER_ACCESS = 32,
+  COMPLETION_CONTEXT_ARROW_MEMBER_ACCESS = 64,
+  COMPLETION_CONTEXT_OBJ_C_PROPERTY_ACCESS = 128,
+  COMPLETION_CONTEXT_ENUM_TAG = 256,
+  COMPLETION_CONTEXT_UNION_TAG = 512,
+  COMPLETION_CONTEXT_STRUCT_TAG = 1024,
+  COMPLETION_CONTEXT_CLASS_TAG = 2048,
+  COMPLETION_CONTEXT_NAMESPACE = 4096,
+  COMPLETION_CONTEXT_NESTED_NAME_SPECIFIER = 8192,
+  COMPLETION_CONTEXT_OBJ_C_INTERFACE = 16384,
+  COMPLETION_CONTEXT_OBJ_C_PROTOCOL = 32768,
+  COMPLETION_CONTEXT_OBJ_C_CATEGORY = 65536,
+  COMPLETION_CONTEXT_OBJ_C_INSTANCE_MESSAGE = 131072,
+  COMPLETION_CONTEXT_OBJ_C_CLASS_MESSAGE = 262144,
+  COMPLETION_CONTEXT_OBJ_C_SELECTOR_NAME = 524288,
+  COMPLETION_CONTEXT_MACRO_NAME = 1048576,
+  COMPLETION_CONTEXT_NATURAL_LANGUAGE = 2097152,
+  COMPLETION_CONTEXT_INCLUDED_FILE = 4194304,
+  COMPLETION_CONTEXT_UNKNOWN = 8388607
+}
 
-/**
- * Whether to include code patterns for language constructs
- * within the set of code completions, e.g., for loops.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_INCLUDE_CODE_PATTERNS = 0x02;
+extern fn CUInt defaultCodeCompleteOptions()
+@cname("clang_defaultCodeCompleteOptions");
 
-/**
- * Whether to include brief documentation within the set of code
- * completions returned.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_INCLUDE_BRIEF_COMMENTS = 0x04;
+extern fn CXCodeCompleteResults* codeCompleteAt(
+  CXTranslationUnit tu,
+  ZString complete_filename,
+  CUInt complete_line,
+  CUInt complete_column,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CUInt options)
+@cname("clang_codeCompleteAt");
 
-/**
- * Whether to speed up completion by omitting top- or namespace-level entities
- * defined in the preamble. There's no guarantee any particular entity is
- * omitted. This may be useful if the headers are indexed externally.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_SKIP_PREAMBLE = 0x08;
+extern fn void sortCodeCompletionResults(
+  CXCompletionResult* results,
+  CUInt num_results)
+@cname("clang_sortCodeCompletionResults");
 
-/**
- * Whether to include completions with small
- * fix-its, e.g. change '.' to '->' on member access, etc.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_INCLUDE_COMPLETION_SWITH_FIX_ITS = 0x10;
+extern fn void disposeCodeCompleteResults(
+  CXCodeCompleteResults* results)
+@cname("clang_disposeCodeCompleteResults");
 
-/**
- * Bits that represent the context under which completion is occurring.
- *
- * The enumerators in this enumeration may be bitwise-OR'd together if multiple
- * contexts are occurring simultaneously.
- */
-typedef CXCompletionContext = inline CInt;
+extern fn CUInt codeCompleteGetNumDiagnostics(
+  CXCodeCompleteResults* results)
+@cname("clang_codeCompleteGetNumDiagnostics");
 
-/**
- * The context for completions is unexposed, as only Clang results
- * should be included. (This is equivalent to having no context bits set.)
- */
-const CXCompletionContext COMPLETION_CONTEXT_UNEXPOSED = 0;
-/**
- * Completions for any possible type should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_ANY_TYPE = 1 << 0;
-/**
- * Completions for any possible value (variables, function calls, etc.)
- * should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_ANY_VALUE = 1 << 1;
-/**
- * Completions for values that resolve to an Objective-C object should
- * be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_OBJECT_VALUE = 1 << 2;
-/**
- * Completions for values that resolve to an Objective-C selector
- * should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_SELECT_OR_VALUE = 1 << 3;
-/**
- * Completions for values that resolve to a C++ class type should be
- * included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_CXX_CLASS_TYPE_VALUE = 1 << 4;
-/**
- * Completions for fields of the member being accessed using the dot
- * operator should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_DOT_MEMBER_ACCESS = 1 << 5;
-/**
- * Completions for fields of the member being accessed using the arrow
- * operator should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_ARROW_MEMBER_ACCESS = 1 << 6;
-/**
- * Completions for properties of the Objective-C object being accessed
- * using the dot operator should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_PROPERTY_ACCESS = 1 << 7;
-/**
- * Completions for enum tags should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_ENUM_TAG = 1 << 8;
-/**
- * Completions for union tags should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_UNION_TAG = 1 << 9;
-/**
- * Completions for struct tags should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_STRUCT_TAG = 1 << 10;
+extern fn CXDiagnostic codeCompleteGetDiagnostic(
+  CXCodeCompleteResults* results,
+  CUInt index)
+@cname("clang_codeCompleteGetDiagnostic");
 
-/**
- * Completions for C++ class names should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_CLASS_TAG = 1 << 11;
-/**
- * Completions for C++ namespaces and namespace aliases should be
- * included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_NAMESPACE = 1 << 12;
-/**
- * Completions for C++ nested name specifiers should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_NESTED_NAME_SPECIFIER = 1 << 13;
-/**
- * Completions for Objective-C interfaces (classes) should be included
- * in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_INTERFACE = 1 << 14;
-/**
- * Completions for Objective-C protocols should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_PROTOCOL = 1 << 15;
-/**
- * Completions for Objective-C categories should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_CATEGORY = 1 << 16;
-/**
- * Completions for Objective-C instance messages should be included
- * in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_INSTANCE_MESSAGE = 1 << 17;
-/**
- * Completions for Objective-C class messages should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_CLASS_MESSAGE = 1 << 18;
-/**
- * Completions for Objective-C selector names should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_SELECTOR_NAME = 1 << 19;
-/**
- * Completions for preprocessor macro names should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_MACRO_NAME = 1 << 20;
-/**
- * Natural language completions should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_NATURAL_LANGUAGE = 1 << 21;
-/**
- * #include file completions should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_INCLUDED_FILE = 1 << 22;
-/**
- * The current context is unknown, so set all contexts.
- */
-const CXCompletionContext COMPLETION_CONTEXT_UNKNOWN = ((1 << 23) - 1);
+extern fn CULongLong codeCompleteGetContexts(
+  CXCodeCompleteResults* results)
+@cname("clang_codeCompleteGetContexts");
 
-/**
- * Returns a default set of code-completion options that can be
- * passed to\c clang_codeCompleteAt().
- */
-fn CUInt defaultCodeCompleteOptions() 
-@extern("clang_defaultCodeCompleteOptions");
+extern fn CXCursorKind codeCompleteGetContainerKind(
+  CXCodeCompleteResults* results,
+  CUInt* is_incomplete)
+@cname("clang_codeCompleteGetContainerKind");
 
-/**
- * Perform code completion at a given location in a translation unit.
- *
- * This function performs code completion at a particular file, line, and
- * column within source code, providing results that suggest potential
- * code snippets based on the context of the completion. The basic model
- * for code completion is that Clang will parse a complete source file,
- * performing syntax checking up to the location where code-completion has
- * been requested. At that point, a special code-completion token is passed
- * to the parser, which recognizes this token and determines, based on the
- * current location in the C/Objective-C/C++ grammar and the state of
- * semantic analysis, what completions to provide. These completions are
- * returned via a new \c CXCodeCompleteResults structure.
- *
- * Code completion itself is meant to be triggered by the client when the
- * user types punctuation characters or whitespace, at which poCInt the
- * code-completion location will coincide with the cursor. For example, if \c p
- * is a pointer, code-completion might be triggered after the "-" and then
- * after the ">" in \c p->. When the code-completion location is after the ">",
- * the completion results will provide, e.g., the members of the struct that
- * "p" points to. The client is responsible for placing the cursor at the
- * beginning of the token currently being typed, then filtering the results
- * based on the contents of the token. For example, when code-completing for
- * the expression \c p->get, the client should provide the location just after
- * the ">" (e.g., pointing at the "g") to this code-completion hook. Then, the
- * client can filter the results based on the current token text ("get"), only
- * showing those results that start with "get". The intent of this interface
- * is to separate the relatively high-latency acquisition of code-completion
- * results from the filtering of results on a per-character basis, which must
- * have a lower latency.
- *
- * \param TU The translation unit in which code-completion should
- * occur. The source files for this translation unit need not be
- * completely up-to-date (and the contents of those source files may
- * be overridden via \p unsaved_files). Cursors referring into the
- * translation unit may be invalidated by this invocation.
- *
- * \param complete_filename The name of the source file where code
- * completion should be performed. This filename may be any file
- * included in the translation unit.
- *
- * \param complete_line The line at which code-completion should occur.
- *
- * \param complete_column The column at which code-completion should occur.
- * Note that the column should poCInt just after the syntactic construct that
- * initiated code completion, and not in the middle of a lexical token.
- *
- * \param unsaved_files the Files that have not yet been saved to disk
- * but may be required for parsing or code completion, including the
- * contents of those files.  The contents and name of these files (as
- * specified by CXUnsavedFile) are copied when necessary, so the
- * client only needs to guarantee their validity until the call to
- * this function returns.
- *
- * \param num_unsaved_files The number of unsaved file entries in \p
- * unsaved_files.
- *
- * \param options Extra options that control the behavior of code
- * completion, expressed as a bitwise OR of the enumerators of the
- * CXCodeComplete_Flags enumeration. The
- * \c clang_defaultCodeCompleteOptions() function returns a default set
- * of code-completion options.
- *
- * \returns If successful, a new \c CXCodeCompleteResults structure
- * containing code-completion results, which should eventually be
- * freed with \c clang_disposeCodeCompleteResults(). If code
- * completion fails, returns NULL.
- */
-fn CXCodeCompleteResults* codeCompleteAt(
-  CXTranslationUnit tu, 
-  ZString complete_filename, 
-  CUInt complete_line, 
-  CUInt complete_column, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CUInt options) 
-@extern("clang_codeCompleteAt");
+extern fn CXString codeCompleteGetContainerUSR(
+  CXCodeCompleteResults* results)
+@cname("clang_codeCompleteGetContainerUSR");
 
-/**
- * Sort the code-completion results in case-insensitive alphabetical
- * order.
- *
- * \param Results The set of results to sort.
- * \param NumResults The number of results in \p Results.
- */
-fn void sortCodeCompletionResults(
-  CXCompletionResult* results, 
-  CUInt num_results) 
-@extern("clang_sortCodeCompletionResults");
+extern fn CXString codeCompleteGetObjCSelector(
+  CXCodeCompleteResults* results)
+@cname("clang_codeCompleteGetObjCSelector");
 
-/**
- * Free the given set of code-completion results.
- */
-fn void disposeCodeCompleteResults(
-  CXCodeCompleteResults *results) 
-@extern("clang_disposeCodeCompleteResults");
+extern fn CXString getClangVersion()
+@cname("clang_getClangVersion");
 
-/**
- * Determine the number of diagnostics produced prior to the
- * location where code completion was performed.
- */
-fn CUInt codeCompleteGetNumDiagnostics(
-  CXCodeCompleteResults* results) 
-@extern("clang_codeCompleteGetNumDiagnostics");
+extern fn void toggleCrashRecovery(
+  CUInt is_enabled)
+@cname("clang_toggleCrashRecovery");
 
-/**
- * Retrieve a diagnostic associated with the given code completion.
- *
- * \param Results the code completion results to query.
- * \param Index the zero-based diagnostic number to retrieve.
- *
- * \returns the requested diagnostic. This diagnostic must be freed
- * via a call to \c clang_disposeDiagnostic().
- */
-fn CXDiagnostic codeCompleteGetDiagnostic(
-  CXCodeCompleteResults* results, 
-  CUInt index) 
-@extern("clang_codeCompleteGetDiagnostic");
-
-/**
- * Determines what completions are appropriate for the context
- * the given code completion.
- *
- * \param Results the code completion results to query
- *
- * \returns the kinds of completions that are appropriate for use
- * along with the given code completion results.
- */
-fn CULongLong codeCompleteGetContexts(
-  CXCodeCompleteResults* results) 
-@extern("clang_codeCompleteGetContexts");
-
-/**
- * Returns the cursor kind for the container for the current code
- * completion context. The container is only guaranteed to be set for
- * contexts where a container exists (i.e. member accesses or Objective-C
- * message sends); if there is not a container, this function will return
- * CXCursor_InvalidCode.
- *
- * \param Results the code completion results to query
- *
- * \param IsIncomplete on return, this value will be false if Clang has complete
- * information about the container. If Clang does not have complete
- * information, this value will be true.
- *
- * \returns the container kind, or CXCursor_InvalidCode if there is not a
- * container
- */
-fn CXCursorKind codeCompleteGetContainerKind(
-  CXCodeCompleteResults* results, 
-  CUInt* is_incomplete) 
-@extern("clang_codeCompleteGetContainerKind");
-
-/**
- * Returns the USR for the container for the current code completion
- * context. If there is not a container for the current context, this
- * function will return the empty string.
- *
- * \param Results the code completion results to query
- *
- * \returns the USR for the container
- */
-fn CXString codeCompleteGetContainerUSR(
-  CXCodeCompleteResults* results) 
-@extern("clang_codeCompleteGetContainerUSR");
-
-/**
- * Returns the currently-entered selector for an Objective-C message
- * send, formatted like "initWithFoo:bar:". Only guaranteed to return a
- * non-empty string for CXCompletionContext_ObjCInstanceMessage and
- * CXCompletionContext_ObjCClassMessage.
- *
- * \param Results the code completion results to query
- *
- * \returns the selector (or partial selector) that has been entered thus far
- * for an Objective-C message send.
- */
-fn CXString codeCompleteGetObjCSelector(
-  CXCodeCompleteResults* results) 
-@extern("clang_codeCompleteGetObjCSelector");
-
-/**
- * Return a version string, suitable for showing to a user, but not
- *        intended to be parsed (the format is not guaranteed to be stable).
- */
-fn CXString getClangVersion() 
-@extern("clang_getClangVersion");
-
-/**
- * Enable/disable crash recovery.
- *
- * \param isEnabled Flag to indicate if crash recovery is enabled.  A non-zero
- *        value enables crash recovery, while 0 disables it.
- */
-fn void toggleCrashRecovery(
-  CUInt is_enabled) 
-@extern("clang_toggleCrashRecovery");
-
-/**
- * Visitor invoked for each file in a translation unit
- *        (used with clang_getInclusions()).
- *
- * This visitor function will be invoked by clang_getInclusions() for each
- * file included (either at the top-level or by \#include directives) within
- * a translation unit.  The first argument is the file being included, and
- * the second and third arguments provide the inclusion stack.  The
- * array is sorted in order of immediate inclusion.  For example,
- * the first element refers to the location that included 'included_file'.
- */
 alias CXInclusionVisitor = fn void(
   CXFile included_file,
   CXSourceLocation* inclusion_stack,
   CUInt include_len,
   CXClientData client_data);
 
-/**
- * Visit the set of preprocessor inclusions in a translation unit.
- *   The visitor function is called with the provided data for every included
- *   file.  This does not include headers included by the PCH file (unless one
- *   is inspecting the inclusions in the PCH file itself).
- */
-fn void getInclusions(
-  CXTranslationUnit tu, 
-  CXInclusionVisitor visitor, 
-  CXClientData client_data) 
-@extern("clang_getInclusions");
+extern fn void getInclusions(
+  CXTranslationUnit tu,
+  CXInclusionVisitor visitor,
+  CXClientData client_data)
+@cname("clang_getInclusions");
 
-typedef CXEvalResultKind = inline CInt;
-
-const CXEvalResultKind EVAL_INT = 1;
-const CXEvalResultKind EVAL_FLOAT = 2;
-const CXEvalResultKind EVAL_OBJC_STR_LITERAL = 3;
-const CXEvalResultKind EVAL_STR_LITERAL = 4;
-const CXEvalResultKind EVAL_CF_STR = 5;
-const CXEvalResultKind EVAL_OTHER = 6;
-
-const CXEvalResultKind EVAL_UNEXPOSED = 0;
-
-/**
- * Evaluation result of a cursor
- */
-typedef CXEvalResult = inline void*;
-
-/**
- * If cursor is a statement declaration tries to evaluate the
- * statement and if its variable, tries to evaluate its initializer,
- * into its corresponding type.
- * If it's an expression, tries to evaluate the expression.
- */
-fn CXEvalResult evaluate_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_Evaluate");
-
-/**
- * Returns the kind of the evaluated result.
- */
-fn CXEvalResultKind getKind_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getKind");
-
-/**
- * Returns the evaluation result as integer if the
- * kind is Int.
- */
-fn CInt getAsInt_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsInt");
-
-/**
- * Returns the evaluation result as a CLongLong integer if the
- * kind is Int. This prevents overflows that may happen if the result is
- * returned with clang_EvalResult_getAsInt.
- */
-fn CLongLong getAsLongLong_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsLongLong");
-
-/**
- * Returns a non-zero value if the kind is Int and the evaluation
- * result resulted in an CUInt integer.
- */
-fn CUInt isUnsignedInt_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_isUnsignedInt");
-
-/**
- * Returns the evaluation result as an CUInt integer if
- * the kind is Int and clang_EvalResult_isUnsignedInt is non-zero.
- */
-fn CULongLong getAsUnsigned_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsUnsigned");
-
-/**
- * Returns the evaluation result as double if the
- * kind is double.
- */
-fn double getAsDouble_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsDouble");
-
-/**
- * Returns the evaluation result as a constant string if the
- * kind is other than Int or float. User must not free this pointer,
- * instead call clang_EvalResult_dispose on the CXEvalResult returned
- * by clang_Cursor_Evaluate.
- */
-fn ZString getAsStr_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsStr");
-
-/**
- * Disposes the created Eval memory.
- */
-fn void dispose_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_dispose");
-
-/**
- * A remapping of original source files and their translated files.
- */
-typedef CXRemapping = inline void*;
-
-/**
- * Retrieve a remapping.
- *
- * \param path the path that contains metadata about remappings.
- *
- * \returns the requested remapping. This remapping must be freed
- * via a call to \c clang_remap_dispose(). Can return NULL if an error occurred.
- */
-fn CXRemapping getRemappings(
-  ZString path) 
-@extern("clang_getRemappings");
-
-/**
- * Retrieve a remapping.
- *
- * \param filePaths pointer to an array of file paths containing remapping info.
- *
- * \param numFiles number of file paths.
- *
- * \returns the requested remapping. This remapping must be freed
- * via a call to \c clang_remap_dispose(). Can return NULL if an error occurred.
- */
-fn CXRemapping getRemappingsFromFileList(
-  ZString* filePaths, 
-  CUInt numFiles) 
-@extern("clang_getRemappingsFromFileList");
-
-/**
- * Determine the number of remappings.
- */
-fn CUInt remap_getNumFiles(
-  CXRemapping remap) 
-@extern("clang_remap_getNumFiles");
-
-/**
- * Get the original and the associated filename from the remapping.
- *
- * \param original If non-NULL, will be set to the original filename.
- *
- * \param transformed If non-NULL, will be set to the filename that the original
- * is associated with.
- */
-fn void remap_getFilenames(
-  CXRemapping remap, 
-  CUInt index, 
-  CXString* original, 
-  CXString* transformed) 
-@extern("clang_remap_getFilenames");
-
-/**
- * Dispose the remapping.
- */
-fn void remap_dispose(
-  CXRemapping remap) 
-@extern("clang_remap_dispose");
-
-typedef CXVisitorResult = inline CInt;
-
-const CXVisitorResult VISIT_BREAK = 0;
-const CXVisitorResult VISIT_CONTINUE = 1;
-
-alias _CXCursorAndRangeVisitor = fn CXVisitorResult(void *context, CXCursor, CXSourceRange);
-struct CXCursorAndRangeVisitor {
-  void* context;
-  _CXCursorAndRangeVisitor visit;
+constdef CXEvalResultKind : CInt {
+  EVAL_INT = 1,
+  EVAL_FLOAT = 2,
+  EVAL_OBJ_C_STR_LITERAL = 3,
+  EVAL_STR_LITERAL = 4,
+  EVAL_CF_STR = 5,
+  EVAL_OTHER = 6,
+  EVAL_UN_EXPOSED = 0
 }
 
-typedef CXResult = inline CInt;
-/**
- * Function returned successfully.
- */
-const CXResult RESULT_SUCCESS = 0;
-/**
- * One of the parameters was invalid for the function.
- */
-const CXResult RESULT_INVALID = 1;
-/**
- * The function was terminated by a callback (e.g. it returned
- * CXVisit_Break)
- */
-const CXResult RESULT_VISIT_BREAK = 2;
+alias CXEvalResult = void*;
 
-/**
- * Find references of a declaration in a specific file.
- *
- * \param cursor pointing to a declaration or a reference of one.
- *
- * \param file to search for references.
- *
- * \param visitor callback that will receive pairs of CXCursor/CXSourceRange for
- * each reference found.
- * The CXSourceRange will poCInt inside the file; if the reference is inside
- * a macro (and not a macro argument) the CXSourceRange will be invalid.
- *
- * \returns one of the CXResult enumerators.
- */
-fn CXResult findReferencesInFile(
-  CXCursor cursor, 
-  CXFile file, 
-  CXCursorAndRangeVisitor visitor) 
-@extern("clang_findReferencesInFile");
+extern fn CXEvalResult cursor_Evaluate(
+  CXCursor c)
+@cname("clang_Cursor_Evaluate");
 
-/**
- * Find #import/#include directives in a specific file.
- *
- * \param TU translation unit containing the file to query.
- *
- * \param file to search for #import/#include directives.
- *
- * \param visitor callback that will receive pairs of CXCursor/CXSourceRange for
- * each directive found.
- *
- * \returns one of the CXResult enumerators.
- */
-fn CXResult findIncludesInFile(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  CXCursorAndRangeVisitor visitor) 
-@extern("clang_findIncludesInFile");
+extern fn CXEvalResultKind evalResult_getKind(
+  CXEvalResult e)
+@cname("clang_EvalResult_getKind");
 
-typedef CXCursorAndRangeVisitorBlock = inline void*;
+extern fn CInt evalResult_getAsInt(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsInt");
 
-fn CXResult findReferencesInFileWithBlock(
-  CXCursor cursor, 
-  CXFile file, 
-  CXCursorAndRangeVisitorBlock visitor_block) 
-@extern("clang_findReferencesInFileWithBlock");
+extern fn CLongLong evalResult_getAsLongLong(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsLongLong");
 
-fn CXResult findIncludesInFileWithBlock(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  CXCursorAndRangeVisitorBlock visitor_block) 
-@extern("clang_findIncludesInFileWithBlock");
+extern fn CUInt evalResult_isUnsignedInt(
+  CXEvalResult e)
+@cname("clang_EvalResult_isUnsignedInt");
 
-/**
- * The client's data object that is associated with a CXFile.
- */
-typedef CXIdxClientFile = inline void*;
+extern fn CULongLong evalResult_getAsUnsigned(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsUnsigned");
 
-/**
- * The client's data object that is associated with a semantic entity.
- */
-typedef CXIdxClientEntity = inline void*;
+extern fn double evalResult_getAsDouble(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsDouble");
 
-/**
- * The client's data object that is associated with a semantic container
- * of entities.
- */
-typedef CXIdxClientContainer = inline void*;
+extern fn ZString evalResult_getAsStr(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsStr");
 
-/**
- * The client's data object that is associated with an AST file (PCH
- * or module).
- */
-typedef CXIdxClientASTFile = inline void*;
+extern fn void evalResult_dispose(
+  CXEvalResult e)
+@cname("clang_EvalResult_dispose");
 
-/**
- * Source location passed to index callbacks.
- */
+constdef CXVisitorResult : CInt {
+  VISIT_BREAK = 0,
+  VISIT_CONTINUE = 1
+}
+
+alias UnnamedPFN2 @private = fn CXVisitorResult(
+  void* context,
+  CXCursor,
+  CXSourceRange);
+
+struct CXCursorAndRangeVisitor {
+  void* context;
+  UnnamedPFN2 visit;
+}
+
+constdef CXResult : CInt {
+  RESULT_SUCCESS = 0,
+  RESULT_INVALID = 1,
+  RESULT_VISIT_BREAK = 2
+}
+
+extern fn CXResult findReferencesInFile(
+  CXCursor cursor,
+  CXFile file,
+  CXCursorAndRangeVisitor visitor)
+@cname("clang_findReferencesInFile");
+
+extern fn CXResult findIncludesInFile(
+  CXTranslationUnit tu,
+  CXFile file,
+  CXCursorAndRangeVisitor visitor)
+@cname("clang_findIncludesInFile");
+
+alias CXCursorAndRangeVisitorBlock = void*;
+
+extern fn CXResult findReferencesInFileWithBlock(
+  CXCursor,
+  CXFile,
+  CXCursorAndRangeVisitorBlock)
+@cname("clang_findReferencesInFileWithBlock");
+
+extern fn CXResult findIncludesInFileWithBlock(
+  CXTranslationUnit,
+  CXFile,
+  CXCursorAndRangeVisitorBlock)
+@cname("clang_findIncludesInFileWithBlock");
+
+alias CXIdxClientFile = void*;
+
+alias CXIdxClientEntity = void*;
+
+alias CXIdxClientContainer = void*;
+
+alias CXIdxClientASTFile = void*;
+
 struct CXIdxLoc {
   void*[2] ptr_data;
   CUInt int_data;
 }
 
-/**
- * Data for ppIncludedFile callback.
- */
 struct CXIdxIncludedFileInfo {
-  /*
-   * Location of '#' in the \#include/\#import directive.
-   */
   CXIdxLoc hash_loc;
-  /*
-   * Filename as written in the \#include/\#import directive.
-   */
   ZString filename;
-  /*
-   * The actual file that the \#include/\#import directive resolved to.
-   */
   CXFile file;
   CInt is_import;
   CInt is_angled;
-  /*
-   * Non-zero if the directive was automatically turned into a module
-   * import.
-   */
   CInt is_module_import;
 }
 
-/**
- * Data for IndexerCallbacks#importedASTFile.
- */
 struct CXIdxImportedASTFileInfo {
-  /*
-   * Top level AST file containing the imported PCH, module or submodule.
-   */
   CXFile file;
-  /*
-   * The imported module or NULL if the AST file is a PCH.
-   */
   CXModule mod;
-  /*
-   * Location where the file is imported. Applicable only for modules.
-   */
   CXIdxLoc loc;
-  /*
-   * Non-zero if an inclusion directive was automatically turned into
-   * a module import. Applicable only for modules.
-   */
   CInt is_implicit;
 }
 
-typedef CXIdxEntityKind = inline CInt;
+constdef CXIdxEntityKind : CInt {
+  IDX_ENTITY_UNEXPOSED = 0,
+  IDX_ENTITY_TYPEDEF = 1,
+  IDX_ENTITY_FUNCTION = 2,
+  IDX_ENTITY_VARIABLE = 3,
+  IDX_ENTITY_FIELD = 4,
+  IDX_ENTITY_ENUM_CONSTANT = 5,
+  IDX_ENTITY_OBJ_C_CLASS = 6,
+  IDX_ENTITY_OBJ_C_PROTOCOL = 7,
+  IDX_ENTITY_OBJ_C_CATEGORY = 8,
+  IDX_ENTITY_OBJ_C_INSTANCE_METHOD = 9,
+  IDX_ENTITY_OBJ_C_CLASS_METHOD = 10,
+  IDX_ENTITY_OBJ_C_PROPERTY = 11,
+  IDX_ENTITY_OBJ_C_IVAR = 12,
+  IDX_ENTITY_ENUM = 13,
+  IDX_ENTITY_STRUCT = 14,
+  IDX_ENTITY_UNION = 15,
+  IDX_ENTITY_CXX_CLASS = 16,
+  IDX_ENTITY_CXX_NAMESPACE = 17,
+  IDX_ENTITY_CXX_NAMESPACE_ALIAS = 18,
+  IDX_ENTITY_CXX_STATIC_VARIABLE = 19,
+  IDX_ENTITY_CXX_STATIC_METHOD = 20,
+  IDX_ENTITY_CXX_INSTANCE_METHOD = 21,
+  IDX_ENTITY_CXX_CONSTRUCTOR = 22,
+  IDX_ENTITY_CXX_DESTRUCTOR = 23,
+  IDX_ENTITY_CXX_CONVERSION_FUNCTION = 24,
+  IDX_ENTITY_CXX_TYPE_ALIAS = 25,
+  IDX_ENTITY_CXX_INTERFACE = 26,
+  IDX_ENTITY_CXX_CONCEPT = 27
+}
 
-const CXIdxEntityKind IDX_ENTITY_UNEXPOSED = 0;
-const CXIdxEntityKind IDX_ENTITY_TYPEDEF = 1;
-const CXIdxEntityKind IDX_ENTITY_FUNCTION = 2;
-const CXIdxEntityKind IDX_ENTITY_VARIABLE = 3;
-const CXIdxEntityKind IDX_ENTITY_FIELD = 4;
-const CXIdxEntityKind IDX_ENTITY_ENUM_CONSTANT = 5;
+constdef CXIdxEntityLanguage : CInt {
+  IDX_ENTITY_LANG_NONE = 0,
+  IDX_ENTITY_LANG_C = 1,
+  IDX_ENTITY_LANG_OBJ_C = 2,
+  IDX_ENTITY_LANG_CXX = 3,
+  IDX_ENTITY_LANG_SWIFT = 4
+}
 
-const CXIdxEntityKind IDX_ENTITY_OBJC_CLASS = 6;
-const CXIdxEntityKind IDX_ENTITY_OBJC_PROTOCOL = 7;
-const CXIdxEntityKind IDX_ENTITY_OBJC_CATEGORY = 8;
+constdef CXIdxEntityCXXTemplateKind : CInt {
+  IDX_ENTITY_NON_TEMPLATE = 0,
+  IDX_ENTITY_TEMPLATE = 1,
+  IDX_ENTITY_TEMPLATE_PARTIAL_SPECIALIZATION = 2,
+  IDX_ENTITY_TEMPLATE_SPECIALIZATION = 3
+}
 
-const CXIdxEntityKind IDX_ENTITY_OBJC_INSTANCE_METHOD = 9;
-const CXIdxEntityKind IDX_ENTITY_OBJC_CLASS_METHOD = 10;
-const CXIdxEntityKind IDX_ENTITY_OBJC_PROPERTY = 11;
-const CXIdxEntityKind IDX_ENTITY_OBJC_IVAR = 12;
-
-const CXIdxEntityKind IDX_ENTITY_ENUM = 13;
-const CXIdxEntityKind IDX_ENTITY_STRUCT = 14;
-const CXIdxEntityKind IDX_ENTITY_UNION = 15;
-
-const CXIdxEntityKind IDX_ENTITY_CXX_CLASS = 16;
-const CXIdxEntityKind IDX_ENTITY_CXX_NAMESPACE = 17;
-const CXIdxEntityKind IDX_ENTITY_CXX_NAMESPACE_ALIAS = 18;
-const CXIdxEntityKind IDX_ENTITY_CXX_STATIC_VARIABLE = 19;
-const CXIdxEntityKind IDX_ENTITY_CXX_STATIC_METHOD = 20;
-const CXIdxEntityKind IDX_ENTITY_CXX_INSTANCE_METHOD = 21;
-const CXIdxEntityKind IDX_ENTITY_CXX_CONSTRUCTOR = 22;
-const CXIdxEntityKind IDX_ENTITY_CXX_DESTRUCTOR = 23;
-const CXIdxEntityKind IDX_ENTITY_CXX_CONVERSION_FUNCTION = 24;
-const CXIdxEntityKind IDX_ENTITY_CXX_TYPE_ALIAS = 25;
-const CXIdxEntityKind IDX_ENTITY_CXX_INTERFACE = 26;
-const CXIdxEntityKind IDX_ENTITY_CXX_CONCEPT = 27;
-
-typedef CXIdxEntityLanguage = inline CInt;
-
-const CXIdxEntityLanguage IDX_ENTITY_LANG_NONE = 0;
-const CXIdxEntityLanguage IDX_ENTITY_LANG_C = 1;
-const CXIdxEntityLanguage IDX_ENTITY_LANG_OBJC = 2;
-const CXIdxEntityLanguage IDX_ENTITY_LANG_CXX = 3;
-const CXIdxEntityLanguage IDX_ENTITY_LANG_SWIFT = 4;
-
-/**
- * Extra C++ template information for an entity. This can apply to:
- * CXIdxEntity_Function
- * CXIdxEntity_CXXClass
- * CXIdxEntity_CXXStaticMethod
- * CXIdxEntity_CXXInstanceMethod
- * CXIdxEntity_CXXConstructor
- * CXIdxEntity_CXXConversionFunction
- * CXIdxEntity_CXXTypeAlias
- */
-typedef CXIdxEntityCXXTemplateKind = inline CInt;
-
-const CXIdxEntityKind IDX_ENTITY_NON_TEMPLATE = 0;
-const CXIdxEntityKind IDX_ENTITY_TEMPLATE = 1;
-const CXIdxEntityKind IDX_ENTITY_TEMPLATE_PARTIAL_SPECIALIZATION = 2;
-const CXIdxEntityKind IDX_ENTITY_TEMPLATE_SPECIALIZATION = 3;
-
-typedef CXIdxAttrKind = inline CInt;
-
-const CXIdxAttrKind IDX_ATTR_UNEXPOSED = 0;
-const CXIdxAttrKind IDX_ATTR_IB_ACTION = 1;
-const CXIdxAttrKind IDX_ATTR_IB_OUTLET = 2;
-const CXIdxAttrKind IDX_ATTR_IB_OUTLET_COLLECTION = 3;
+constdef CXIdxAttrKind : CInt {
+  IDX_ATTR_UNEXPOSED = 0,
+  IDX_ATTR_IB_ACTION = 1,
+  IDX_ATTR_IB_OUTLET = 2,
+  IDX_ATTR_IB_OUTLET_COLLECTION = 3
+}
 
 struct CXIdxAttrInfo {
   CXIdxAttrKind kind;
@@ -8242,38 +2680,31 @@ struct CXIdxIBOutletCollectionAttrInfo {
   CXIdxLoc class_loc;
 }
 
-typedef CXIdxDeclInfoFlags = inline CInt;
-const CXIdxDeclInfoFlags IDX_DECL_FLAG_SKIPPED = 0x1;
+constdef CXIdxDeclInfoFlags : CInt {
+  IDX_DECL_FLAG_SKIPPED = 1
+}
 
 struct CXIdxDeclInfo {
   CXIdxEntityInfo* entity_info;
   CXCursor cursor;
   CXIdxLoc loc;
   CXIdxContainerInfo* semantic_container;
-  /*
-   * Generally same as #semanticContainer but can be different in
-   * cases like out-of-line C++ member functions.
-   */
   CXIdxContainerInfo* lexical_container;
   CInt is_redeclaration;
   CInt is_definition;
   CInt is_container;
-  CXIdxContainerInfo* declAsContainer;
-  /*
-   * Whether the declaration exists in code or was created implicitly
-   * by the compiler, e.g. implicit Objective-C methods for properties.
-   */
+  CXIdxContainerInfo* decl_as_container;
   CInt is_implicit;
   CXIdxAttrInfo** attributes;
   CUInt num_attributes;
-
   CUInt flags;
 }
 
-typedef CXIdxObjCContainerKind = inline CInt;
-const CXIdxObjCContainerKind IDX_OBJC_CONTAINER_FORWARD_REF = 0;
-const CXIdxObjCContainerKind IDX_OBJC_CONTAINER_INTERFACE = 1;
-const CXIdxObjCContainerKind IDX_OBJC_CONTAINER_IMPLEMENTATION = 2;
+constdef CXIdxObjCContainerKind : CInt {
+  IDX_OBJ_C_CONTAINER_FORWARD_REF = 0,
+  IDX_OBJ_C_CONTAINER_INTERFACE = 1,
+  IDX_OBJ_C_CONTAINER_IMPLEMENTATION = 2
+}
 
 struct CXIdxObjCContainerDeclInfo {
   CXIdxDeclInfo* decl_info;
@@ -8298,8 +2729,8 @@ struct CXIdxObjCProtocolRefListInfo {
 }
 
 struct CXIdxObjCInterfaceDeclInfo {
-  CXIdxObjCContainerDeclInfo* containerInfo;
-  CXIdxBaseClassInfo* superInfo;
+  CXIdxObjCContainerDeclInfo* container_info;
+  CXIdxBaseClassInfo* super_info;
   CXIdxObjCProtocolRefListInfo* protocols;
 }
 
@@ -8323,626 +2754,627 @@ struct CXIdxCXXClassDeclInfo {
   CUInt num_bases;
 }
 
-/**
- * Data for IndexerCallbacks#indexEntityReference.
- *
- * This may be deprecated in a future version as this duplicates
- * the \c CXSymbolRole_Implicit bit in \c CXSymbolRole.
- */
-typedef CXIdxEntityRefKind = inline CInt;
-/**
- * The entity is referenced directly in user's code.
- */
-const CXIdxEntityRefKind IDX_ENTITY_REF_DIRECT = 1;
-/**
- * An implicit reference, e.g. a reference of an Objective-C method
- * via the dot syntax.
- */
-const CXIdxEntityRefKind IDX_ENTITY_REF_IMPLICIT = 2;
+constdef CXIdxEntityRefKind : CInt {
+  IDX_ENTITY_REF_DIRECT = 1,
+  IDX_ENTITY_REF_IMPLICIT = 2
+}
 
-/**
- * Roles that are attributed to symbol occurrences.
- *
- * Internal: this currently mirrors low 9 bits of clang::index::SymbolRole with
- * higher bits zeroed. These high bits may be exposed in the future.
- */
-typedef CXSymbolRole = inline CInt;
-const CXSymbolRole SYMBOL_ROLE_NONE = 0;
-const CXSymbolRole SYMBOL_ROLE_DECLARATION = 1 << 0;
-const CXSymbolRole SYMBOL_ROLE_DEFINITION = 1 << 1;
-const CXSymbolRole SYMBOL_ROLE_REFERENCE = 1 << 2;
-const CXSymbolRole SYMBOL_ROLE_READ = 1 << 3;
-const CXSymbolRole SYMBOL_ROLE_WRITE = 1 << 4;
-const CXSymbolRole SYMBOL_ROLE_CALL = 1 << 5;
-const CXSymbolRole SYMBOL_ROLE_DYNAMIC = 1 << 6;
-const CXSymbolRole SYMBOL_ROLE_ADDRESS_OF = 1 << 7;
-const CXSymbolRole SYMBOL_ROLE_IMPLICIT = 1 << 8;
+constdef CXSymbolRole : CInt {
+  SYMBOL_ROLE_NONE = 0,
+  SYMBOL_ROLE_DECLARATION = 1,
+  SYMBOL_ROLE_DEFINITION = 2,
+  SYMBOL_ROLE_REFERENCE = 4,
+  SYMBOL_ROLE_READ = 8,
+  SYMBOL_ROLE_WRITE = 16,
+  SYMBOL_ROLE_CALL = 32,
+  SYMBOL_ROLE_DYNAMIC = 64,
+  SYMBOL_ROLE_ADDRESS_OF = 128,
+  SYMBOL_ROLE_IMPLICIT = 256
+}
 
-/**
- * Data for IndexerCallbacks#indexEntityReference.
- */
 struct CXIdxEntityRefInfo {
   CXIdxEntityRefKind kind;
-  /*
-   * Reference cursor.
-   */
   CXCursor cursor;
   CXIdxLoc loc;
-  /*
-   * The entity that gets referenced.
-   */
   CXIdxEntityInfo* referenced_entity;
-  /*
-   * Immediate "parent" of the reference. For example:
-   *
-   * \code
-   * Foo *var;
-   * \endcode
-   *
-   * The parent of reference of type 'Foo' is the variable 'var'.
-   * For references inside statement bodies of functions/methods,
-   * the parentEntity will be the function/method.
-   */
   CXIdxEntityInfo* parent_entity;
-  /*
-   * Lexical container context of the reference.
-   */
   CXIdxContainerInfo* container;
-  /*
-   * Sets of symbol roles of the reference.
-   */
   CXSymbolRole role;
 }
 
-module clang @private;
-
-alias _IndexerCallbackAbortQuery = fn CInt(
-  CXClientData client_data, 
+alias UnnamedPFN3 @private = fn CInt(
+  CXClientData client_data,
   void* reserved);
 
-alias _IndexerCallbackDiagnostic = fn void(
-  CXClientData client_data, 
-  CXDiagnosticSet ds, 
+alias UnnamedPFN4 @private = fn void(
+  CXClientData client_data,
+  CXDiagnosticSet,
   void* reserved);
 
-alias _IndexerCallbackEnteredMainFile = fn CXIdxClientFile(
-  CXClientData client_data, 
-  CXFile mainFile, 
+alias UnnamedPFN5 @private = fn CXIdxClientFile(
+  CXClientData client_data,
+  CXFile main_file,
   void* reserved);
 
-alias _IndexerCallbackIncludedFile = fn CXIdxClientFile(
-  CXClientData client_data, 
-  CXIdxIncludedFileInfo* file_info);
+alias UnnamedPFN6 @private = fn CXIdxClientFile(
+  CXClientData client_data,
+  CXIdxIncludedFileInfo*);
 
-alias _IndexerCallbackImportedASTFile = fn CXIdxClientASTFile(
-  CXClientData client_data, 
-  CXIdxImportedASTFileInfo* file_info);
+alias UnnamedPFN7 @private = fn CXIdxClientASTFile(
+  CXClientData client_data,
+  CXIdxImportedASTFileInfo*);
 
-alias _IndexerCallbackStartedTU = fn CXIdxClientContainer(
-  CXClientData client_data, 
+alias UnnamedPFN8 @private = fn CXIdxClientContainer(
+  CXClientData client_data,
   void* reserved);
 
-alias _IndexerCallbackIndexDecl = fn void(
-  CXClientData client_data, 
-  CXIdxDeclInfo* decl_info);
+alias UnnamedPFN9 @private = fn void(
+  CXClientData client_data,
+  CXIdxDeclInfo*);
 
-alias _IndexerCallbackIndexEntityRef = fn void(
-  CXClientData client_data, 
-  CXIdxEntityRefInfo* entity_ref_info);
+alias UnnamedPFN10 @private = fn void(
+  CXClientData client_data,
+  CXIdxEntityRefInfo*);
 
-module clang @public;
-
-/**
- * A group of callbacks used by #clang_indexSourceFile and
- * #clang_indexTranslationUnit.
- */
 struct IndexerCallbacks {
-  /*
-   * Called periodically to check whether indexing should be aborted.
-   * Should return 0 to continue, and non-zero to abort.
-   */
-  _IndexerCallbackAbortQuery abort_query;
-
-  /*
-   * Called at the end of indexing; passes the complete diagnostic set.
-   */
-  _IndexerCallbackDiagnostic diagnostic;
-
-  _IndexerCallbackEnteredMainFile entered_main_file;
-
-  /*
-   * Called when a file gets \#included/\#imported.
-   */
-  _IndexerCallbackIncludedFile pp_included_file;
-
-  /*
-   * Called when a AST file (PCH or module) gets imported.
-   *
-   * AST files will not get indexed (there will not be callbacks to index all
-   * the entities in an AST file). The recommended action is that, if the AST
-   * file is not already indexed, to initiate a new indexing job specific to
-   * the AST file.
-   */
-  _IndexerCallbackImportedASTFile imported_ast_file;
-
-  /*
-   * Called at the beginning of indexing a translation unit.
-   */
-  _IndexerCallbackStartedTU started_translation_unit;
-
-  _IndexerCallbackIndexDecl index_declaration;
-
-  /*
-   * Called to index a reference of an entity.
-   */
-  _IndexerCallbackIndexEntityRef index_entity_reference;
+  UnnamedPFN3 abort_query;
+  UnnamedPFN4 diagnostic;
+  UnnamedPFN5 entered_main_file;
+  UnnamedPFN6 pp_included_file;
+  UnnamedPFN7 imported_ast_file;
+  UnnamedPFN8 started_translation_unit;
+  UnnamedPFN9 index_declaration;
+  UnnamedPFN10 index_entity_reference;
 }
 
-fn CInt index_isEntityObjCContainerKind(
-  CXIdxEntityKind entity_kind) 
-@extern("clang_index_isEntityObjCContainerKind");
+extern fn CInt index_isEntityObjCContainerKind(
+  CXIdxEntityKind)
+@cname("clang_index_isEntityObjCContainerKind");
 
-fn CXIdxObjCContainerDeclInfo* index_getObjCContainerDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCContainerDeclInfo");
+extern fn CXIdxObjCContainerDeclInfo* index_getObjCContainerDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCContainerDeclInfo");
 
-fn CXIdxObjCInterfaceDeclInfo* index_getObjCInterfaceDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCInterfaceDeclInfo");
+extern fn CXIdxObjCInterfaceDeclInfo* index_getObjCInterfaceDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCInterfaceDeclInfo");
 
-fn CXIdxObjCCategoryDeclInfo* index_getObjCCategoryDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCCategoryDeclInfo");
+extern fn CXIdxObjCCategoryDeclInfo* index_getObjCCategoryDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCCategoryDeclInfo");
 
-fn CXIdxObjCProtocolRefListInfo* index_getObjCProtocolRefListInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCProtocolRefListInfo");
+extern fn CXIdxObjCProtocolRefListInfo* index_getObjCProtocolRefListInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCProtocolRefListInfo");
 
-fn CXIdxObjCPropertyDeclInfo* index_getObjCPropertyDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCPropertyDeclInfo");
+extern fn CXIdxObjCPropertyDeclInfo* index_getObjCPropertyDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCPropertyDeclInfo");
 
-fn CXIdxIBOutletCollectionAttrInfo* index_getIBOutletCollectionAttrInfo(
-  CXIdxAttrInfo* attr_info) 
-@extern("clang_index_getIBOutletCollectionAttrInfo");
+extern fn CXIdxIBOutletCollectionAttrInfo* index_getIBOutletCollectionAttrInfo(
+  CXIdxAttrInfo*)
+@cname("clang_index_getIBOutletCollectionAttrInfo");
 
-fn CXIdxCXXClassDeclInfo* index_getCXXClassDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getCXXClassDeclInfo");
+extern fn CXIdxCXXClassDeclInfo* index_getCXXClassDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getCXXClassDeclInfo");
 
-/**
- * For retrieving a custom CXIdxClientContainer attached to a
- * container.
- */
-fn CXIdxClientContainer index_getClientContainer(
-  CXIdxContainerInfo* container_info) 
-@extern("clang_index_getClientContainer");
+extern fn CXIdxClientContainer index_getClientContainer(
+  CXIdxContainerInfo*)
+@cname("clang_index_getClientContainer");
 
-/**
- * For setting a custom CXIdxClientContainer attached to a
- * container.
- */
-fn void index_setClientContainer(
-  CXIdxContainerInfo* container_info, 
-  CXIdxClientContainer client_container) 
-@extern("clang_index_setClientContainer");
+extern fn void index_setClientContainer(
+  CXIdxContainerInfo*,
+  CXIdxClientContainer)
+@cname("clang_index_setClientContainer");
 
-/**
- * For retrieving a custom CXIdxClientEntity attached to an entity.
- */
-fn CXIdxClientEntity index_getClientEntity(
-  CXIdxEntityInfo* entity_info) 
-@extern("clang_index_getClientEntity");
+extern fn CXIdxClientEntity index_getClientEntity(
+  CXIdxEntityInfo*)
+@cname("clang_index_getClientEntity");
 
-/**
- * For setting a custom CXIdxClientEntity attached to an entity.
- */
-fn void index_setClientEntity(
-  CXIdxEntityInfo* entity_info, 
-  CXIdxClientEntity client_entity) 
-@extern("clang_index_setClientEntity");
+extern fn void index_setClientEntity(
+  CXIdxEntityInfo*,
+  CXIdxClientEntity)
+@cname("clang_index_setClientEntity");
 
-/**
- * An indexing action/session, to be applied to one or multiple
- * translation units.
- */
-typedef CXIndexAction = inline void*;
+alias CXIndexAction = void*;
 
-/**
- * An indexing action/session, to be applied to one or multiple
- * translation units.
- *
- * \param CIdx The index object with which the index action will be associated.
- */
-fn CXIndexAction createIndexAction(
-  CXIndex cidx) 
-@extern("clang_IndexAction_create");
+extern fn CXIndexAction indexAction_create(
+  CXIndex c_idx)
+@cname("clang_IndexAction_create");
 
-/**
- * Destroy the given index action.
- *
- * The index action must not be destroyed until all of the translation units
- * created within that index action have been destroyed.
- */
-fn void dispose_IndexAction(
-  CXIndexAction cidx) 
-@extern("clang_IndexAction_dispose");
+extern fn void indexAction_dispose(
+  CXIndexAction)
+@cname("clang_IndexAction_dispose");
 
-typedef CXIndexOptFlags = inline CInt;
-/**
- * Used to indicate that no special indexing options are needed.
- */
-const CXIndexOptFlags INDEX_OPT_NONE = 0x0;
+constdef CXIndexOptFlags : CInt {
+  INDEX_OPT_NONE = 0,
+  INDEX_OPT_SUPPRESS_REDUNDANT_REFS = 1,
+  INDEX_OPT_INDEX_FUNCTION_LOCAL_SYMBOLS = 2,
+  INDEX_OPT_INDEX_IMPLICIT_TEMPLATE_INSTANTIATIONS = 4,
+  INDEX_OPT_SUPPRESS_WARNINGS = 8,
+  INDEX_OPT_SKIP_PARSED_BODIES_IN_SESSION = 16
+}
 
-/**
- * Used to indicate that IndexerCallbacks#indexEntityReference should
- * be invoked for only one reference of an entity per source file that does
- * not also include a declaration/definition of the entity.
- */
-const CXIndexOptFlags INDEX_OPT_SUPPRESS_REDUNDANT_REFS = 0x1;
+extern fn CInt indexSourceFile(
+  CXIndexAction,
+  CXClientData client_data,
+  IndexerCallbacks* index_callbacks,
+  CUInt index_callbacks_size,
+  CUInt index_options,
+  ZString source_filename,
+  CChar** command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CXTranslationUnit* out_tu,
+  CUInt tu_options)
+@cname("clang_indexSourceFile");
 
-/**
- * Function-local symbols should be indexed. If this is not set
- * function-local symbols will be ignored.
- */
-const CXIndexOptFlags INDEX_OPT_INDEX_FUNCTION_LOCAL_SYMBOLS = 0x2;
+extern fn CInt indexSourceFileFullArgv(
+  CXIndexAction,
+  CXClientData client_data,
+  IndexerCallbacks* index_callbacks,
+  CUInt index_callbacks_size,
+  CUInt index_options,
+  ZString source_filename,
+  CChar** command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CXTranslationUnit* out_tu,
+  CUInt tu_options)
+@cname("clang_indexSourceFileFullArgv");
 
-/**
- * Implicit function/class template instantiations should be indexed.
- * If this is not set, implicit instantiations will be ignored.
- */
-const CXIndexOptFlags INDEX_OPT_INDEX_IMPLICIT_TEMPLATE_INSTANTIATIONS = 0x4;
+extern fn CInt indexTranslationUnit(
+  CXIndexAction,
+  CXClientData client_data,
+  IndexerCallbacks* index_callbacks,
+  CUInt index_callbacks_size,
+  CUInt index_options,
+  CXTranslationUnit)
+@cname("clang_indexTranslationUnit");
 
-/**
- * Suppress all compiler warnings when parsing for indexing.
- */
-const CXIndexOptFlags INDEX_OPT_SUPPRESS_WARNINGS = 0x8;
+extern fn void indexLoc_getFileLocation(
+  CXIdxLoc loc,
+  CXIdxClientFile* index_file,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_indexLoc_getFileLocation");
 
-/**
- * Skip a function/method body that was already parsed during an
- * indexing session associated with a \c CXIndexAction object.
- * Bodies in system headers are always skipped.
- */
-const CXIndexOptFlags INDEX_OPT_SKIP_PARSED_BODIES_IN_SESSION = 0x10;
+extern fn CXSourceLocation indexLoc_getCXSourceLocation(
+  CXIdxLoc loc)
+@cname("clang_indexLoc_getCXSourceLocation");
 
-/**
- * Index the given source file and the translation unit corresponding
- * to that file via callbacks implemented through #IndexerCallbacks.
- *
- * \param client_data pointer data supplied by the client, which will
- * be passed to the invoked callbacks.
- *
- * \param index_callbacks Pointer to indexing callbacks that the client
- * implements.
- *
- * \param index_callbacks_size Size of #IndexerCallbacks structure that gets
- * passed in index_callbacks.
- *
- * \param index_options A bitmask of options that affects how indexing is
- * performed. This should be a bitwise OR of the CXIndexOpt_XXX flags.
- *
- * \param[out] out_TU pointer to store a \c CXTranslationUnit that can be
- * reused after indexing is finished. Set to \c NULL if you do not require it.
- *
- * \returns 0 on success or if there were errors from which the compiler could
- * recover.  If there is a failure from which there is no recovery, returns
- * a non-zero \c CXErrorCode.
- *
- * The rest of the parameters are the same as #clang_parseTranslationUnit.
- */
-fn CInt indexSourceFile(
-  CXIndexAction index_action, 
-  CXClientData client_data, 
-  IndexerCallbacks* index_callbacks, 
-  CUInt index_callbacks_size, 
-  CUInt index_options, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CXTranslationUnit* out_TU, 
-  CUInt tu_options) 
-@extern("clang_indexSourceFile");
-
-/**
- * Same as clang_indexSourceFile but requires a full command line
- * for \c command_line_args including argv[0]. This is useful if the standard
- * library paths are relative to the binary.
- */
-fn CInt indexSourceFileFullArgv(
-  CXIndexAction index_action, 
-  CXClientData client_data, 
-  IndexerCallbacks* index_callbacks, 
-  CUInt index_callbacks_size, 
-  CUInt index_options, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CXTranslationUnit* out_TU, 
-  CUInt tu_options) 
-@extern("clang_indexSourceFileFullArgv");
-
-/**
- * Index the given translation unit via callbacks implemented through
- * #IndexerCallbacks.
- *
- * The order of callback invocations is not guaranteed to be the same as
- * when indexing a source file. The high level order will be:
- *
- *   -Preprocessor callbacks invocations
- *   -Declaration/reference callbacks invocations
- *   -Diagnostic callback invocations
- *
- * The parameters are the same as #clang_indexSourceFile.
- *
- * \returns If there is a failure from which there is no recovery, returns
- * non-zero, otherwise returns 0.
- */
-fn CInt indexTranslationUnit(
-  CXIndexAction index_action, 
-  CXClientData client_data, 
-  IndexerCallbacks* index_callbacks, 
-  CUInt index_callbacks_size, 
-  CUInt index_options, 
-  CXTranslationUnit tu) 
-@extern("clang_indexTranslationUnit");
-
-/**
- * Retrieve the CXIdxFile, file, line, column, and offset represented by
- * the given CXIdxLoc.
- *
- * If the location refers into a macro expansion, retrieves the
- * location of the macro expansion and if it refers into a macro argument
- * retrieves the location of the argument.
- */
-fn void indexLoc_getFileLocation(
-  CXIdxLoc loc, 
-  CXIdxClientFile* indexFile, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_indexLoc_getFileLocation");
-
-/**
- * Retrieve the CXSourceLocation represented by the given CXIdxLoc.
- */
-fn CXSourceLocation indexLoc_getCXSourceLocation(
-  CXIdxLoc loc) 
-@extern("clang_indexLoc_getCXSourceLocation");
-
-/**
- * Visitor invoked for each field found by a traversal.
- *
- * This visitor function will be invoked for each field found by
- * \c clang_Type_visitFields. Its first argument is the cursor being
- * visited, its second argument is the client data provided to
- * \c clang_Type_visitFields.
- *
- * The visitor should return one of the \c CXVisitorResult values
- * to direct \c clang_Type_visitFields.
- */
 alias CXFieldVisitor = fn CXVisitorResult(
-  CXCursor c, 
+  CXCursor c,
   CXClientData client_data);
 
-/**
- * Visit the fields of a particular type.
- *
- * This function visits all the direct fields of the given cursor,
- * invoking the given \p visitor function with the cursors of each
- * visited field. The traversal may be ended prematurely, if
- * the visitor returns \c CXFieldVisit_Break.
- *
- * \param T the record type whose field may be visited.
- *
- * \param visitor the visitor function that will be invoked for each
- * field of \p T.
- *
- * \param client_data pointer data supplied by the client, which will
- * be passed to the visitor each time it is invoked.
- *
- * \returns a non-zero value if the traversal was terminated
- * prematurely by the visitor returning \c CXFieldVisit_Break.
- */
-fn CUInt visitFields_Type(
-  CXType t, 
-  CXFieldVisitor visitor, 
-  CXClientData client_data) 
-@extern("clang_Type_visitFields");
+extern fn CUInt type_visitFields(
+  CXType t,
+  CXFieldVisitor visitor,
+  CXClientData client_data)
+@cname("clang_Type_visitFields");
 
-/**
- * Describes the kind of binary operators.
- */
-typedef CXBinaryOperatorKind = inline CInt;
+extern fn CUInt visitCXXBaseClasses(
+  CXType t,
+  CXFieldVisitor visitor,
+  CXClientData client_data)
+@cname("clang_visitCXXBaseClasses");
 
-/** This value describes cursors which are not binary operators. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_INVALID = 0;
-/** C++ Pointer - to - member operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_PTR_MEM_D = 1;
-/** C++ Pointer - to - member operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_PTR_MEM_I = 2;
-/** Multiplication operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_MUL = 3;
-/** Division operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_DIV = 4;
-/** Remainder operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_REM = 5;
-/** Addition operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_ADD = 6;
-/** Subtraction operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SUB = 7;
-/** Bitwise shift left operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SHL = 8;
-/** Bitwise shift right operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SHR = 9;
-/** C++ three-way comparison (spaceship) operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_CMP = 10;
-/** Less than operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_LT = 11;
-/** Greater than operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_GT = 12;
-/** Less or equal operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_LE = 13;
-/** Greater or equal operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_GE = 14;
-/** Equal operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_EQ = 15;
-/** Not equal operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_NE = 16;
-/** Bitwise AND operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_AND = 17;
-/** Bitwise XOR operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_XOR = 18;
-/** Bitwise OR operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_OR = 19;
-/** Logical AND operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_LAND = 20;
-/** Logical OR operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_LOR = 21;
-/** Assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_ASSIGN = 22;
-/** Multiplication assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_MUL_ASSIGN = 23;
-/** Division assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_DIV_ASSIGN = 24;
-/** Remainder assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_REM_ASSIGN = 25;
-/** Addition assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_ADD_ASSIGN = 26;
-/** Subtraction assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SUB_ASSIGN = 27;
-/** Bitwise shift left assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SHL_ASSIGN = 28;
-/** Bitwise shift right assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SHR_ASSIGN = 29;
-/** Bitwise AND assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_AND_ASSIGN = 30;
-/** Bitwise XOR assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_XOR_ASSIGN = 31;
-/** Bitwise OR assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_OR_ASSIGN = 32;
-/** Comma operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_COMMA = 33;
+extern fn CUInt visitCXXMethods(
+  CXType t,
+  CXFieldVisitor visitor,
+  CXClientData client_data)
+@cname("clang_visitCXXMethods");
 
-/**
- * Retrieve the spelling of a given CXBinaryOperatorKind.
- */
-fn CXString getBinaryOperatorKindSpelling(
-  CXBinaryOperatorKind kind) 
-@extern("clang_getBinaryOperatorKindSpelling");
+constdef CXBinaryOperatorKind : CInt {
+  BINARY_OPERATOR_INVALID = 0,
+  BINARY_OPERATOR_PTR_MEM_D = 1,
+  BINARY_OPERATOR_PTR_MEM_I = 2,
+  BINARY_OPERATOR_MUL = 3,
+  BINARY_OPERATOR_DIV = 4,
+  BINARY_OPERATOR_REM = 5,
+  BINARY_OPERATOR_ADD = 6,
+  BINARY_OPERATOR_SUB = 7,
+  BINARY_OPERATOR_SHL = 8,
+  BINARY_OPERATOR_SHR = 9,
+  BINARY_OPERATOR_CMP = 10,
+  BINARY_OPERATOR_LT = 11,
+  BINARY_OPERATOR_GT = 12,
+  BINARY_OPERATOR_LE = 13,
+  BINARY_OPERATOR_GE = 14,
+  BINARY_OPERATOR_EQ = 15,
+  BINARY_OPERATOR_NE = 16,
+  BINARY_OPERATOR_AND = 17,
+  BINARY_OPERATOR_XOR = 18,
+  BINARY_OPERATOR_OR = 19,
+  BINARY_OPERATOR_L_AND = 20,
+  BINARY_OPERATOR_L_OR = 21,
+  BINARY_OPERATOR_ASSIGN = 22,
+  BINARY_OPERATOR_MUL_ASSIGN = 23,
+  BINARY_OPERATOR_DIV_ASSIGN = 24,
+  BINARY_OPERATOR_REM_ASSIGN = 25,
+  BINARY_OPERATOR_ADD_ASSIGN = 26,
+  BINARY_OPERATOR_SUB_ASSIGN = 27,
+  BINARY_OPERATOR_SHL_ASSIGN = 28,
+  BINARY_OPERATOR_SHR_ASSIGN = 29,
+  BINARY_OPERATOR_AND_ASSIGN = 30,
+  BINARY_OPERATOR_XOR_ASSIGN = 31,
+  BINARY_OPERATOR_OR_ASSIGN = 32,
+  BINARY_OPERATOR_COMMA = 33,
+  BINARY_OPERATOR_LAST = 33
+}
 
-/**
- * Retrieve the binary operator kind of this cursor.
- *
- * If this cursor is not a binary operator then returns Invalid.
- */
-fn CXBinaryOperatorKind getCursorBinaryOperatorKind(
-  CXCursor cursor) 
-@extern("clang_getCursorBinaryOperatorKind");
+extern fn CXString getBinaryOperatorKindSpelling(
+  CXBinaryOperatorKind kind)
+@cname("clang_getBinaryOperatorKindSpelling");
 
-/**
- * Describes the kind of unary operators.
- */
-typedef CXUnaryOperatorKind = inline CInt;
+extern fn CXBinaryOperatorKind getCursorBinaryOperatorKind(
+  CXCursor cursor)
+@cname("clang_getCursorBinaryOperatorKind");
 
-/** This value describes cursors which are not unary operators. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_INVALID = 0;
-/** Postfix increment operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_POST_INC = 1;
-/** Postfix decrement operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_POST_DEC = 2;
-/** Prefix increment operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_PRE_INC = 3;
-/** Prefix decrement operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_PRE_DEC = 4;
-/** Address of operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_ADDR_OF = 5;
-/** Dereference operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_DEREF = 6;
-/** Plus operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_PLUS = 7;
-/** Minus operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_MINUS = 8;
-/** Not operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_NOT = 9;
-/** LNot operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_LNOT = 10;
-/** "__real expr" operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_REAL = 11;
-/** "__imag expr" operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_IMAG = 12;
-/** __extension__ marker operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_EXTENSION = 13;
-/** C++ co_await operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_CO_AWAIT = 14;
+constdef CXUnaryOperatorKind : CInt {
+  UNARY_OPERATOR_INVALID = 0,
+  UNARY_OPERATOR_POST_INC = 1,
+  UNARY_OPERATOR_POST_DEC = 2,
+  UNARY_OPERATOR_PRE_INC = 3,
+  UNARY_OPERATOR_PRE_DEC = 4,
+  UNARY_OPERATOR_ADDR_OF = 5,
+  UNARY_OPERATOR_DEREF = 6,
+  UNARY_OPERATOR_PLUS = 7,
+  UNARY_OPERATOR_MINUS = 8,
+  UNARY_OPERATOR_NOT = 9,
+  UNARY_OPERATOR_L_NOT = 10,
+  UNARY_OPERATOR_REAL = 11,
+  UNARY_OPERATOR_IMAG = 12,
+  UNARY_OPERATOR_EXTENSION = 13,
+  UNARY_OPERATOR_COAWAIT = 14
+}
 
-/**
- * Retrieve the spelling of a given CXUnaryOperatorKind.
- */
-fn CXString getUnaryOperatorKindSpelling(
-  CXUnaryOperatorKind kind) 
-@extern("clang_getUnaryOperatorKindSpelling");
+extern fn CXString getUnaryOperatorKindSpelling(
+  CXUnaryOperatorKind kind)
+@cname("clang_getUnaryOperatorKindSpelling");
 
-/**
- * Retrieve the unary operator kind of this cursor.
- *
- * If this cursor is not a unary operator then returns Invalid.
- */
-fn CXUnaryOperatorKind getCursorUnaryOperatorKind(
-  CXCursor cursor) 
-@extern("clang_getCursorUnaryOperatorKind");
+extern fn CXUnaryOperatorKind getCursorUnaryOperatorKind(
+  CXCursor cursor)
+@cname("clang_getCursorUnaryOperatorKind");
 
+alias CXRemapping = void*;
 
+extern fn CXRemapping getRemappings(
+  ZString)
+@cname("clang_getRemappings");
+
+extern fn CXRemapping getRemappingsFromFileList(
+  CChar**,
+  CUInt)
+@cname("clang_getRemappingsFromFileList");
+
+extern fn CUInt remap_getNumFiles(
+  CXRemapping)
+@cname("clang_remap_getNumFiles");
+
+extern fn void remap_getFilenames(
+  CXRemapping,
+  CUInt,
+  CXString*,
+  CXString*)
+@cname("clang_remap_getFilenames");
+
+extern fn void remap_dispose(
+  CXRemapping)
+@cname("clang_remap_dispose");
+
+alias CXCompilationDatabase = void*;
+
+alias CXCompileCommands = void*;
+
+alias CXCompileCommand = void*;
+
+constdef CXCompilationDatabase_Error : CInt {
+  COMPILATION_DATABASE_NO_ERROR = 0,
+  COMPILATION_DATABASE_CAN_NOT_LOAD_DATABASE = 1
+}
+
+extern fn CXCompilationDatabase compilationDatabase_fromDirectory(
+  ZString build_dir,
+  CXCompilationDatabase_Error* error_code)
+@cname("clang_CompilationDatabase_fromDirectory");
+
+extern fn void compilationDatabase_dispose(
+  CXCompilationDatabase)
+@cname("clang_CompilationDatabase_dispose");
+
+extern fn CXCompileCommands compilationDatabase_getCompileCommands(
+  CXCompilationDatabase,
+  ZString complete_file_name)
+@cname("clang_CompilationDatabase_getCompileCommands");
+
+extern fn CXCompileCommands compilationDatabase_getAllCompileCommands(
+  CXCompilationDatabase)
+@cname("clang_CompilationDatabase_getAllCompileCommands");
+
+extern fn void compileCommands_dispose(
+  CXCompileCommands)
+@cname("clang_CompileCommands_dispose");
+
+extern fn CUInt compileCommands_getSize(
+  CXCompileCommands)
+@cname("clang_CompileCommands_getSize");
+
+extern fn CXCompileCommand compileCommands_getCommand(
+  CXCompileCommands,
+  CUInt i)
+@cname("clang_CompileCommands_getCommand");
+
+extern fn CXString compileCommand_getDirectory(
+  CXCompileCommand)
+@cname("clang_CompileCommand_getDirectory");
+
+extern fn CXString compileCommand_getFilename(
+  CXCompileCommand)
+@cname("clang_CompileCommand_getFilename");
+
+extern fn CUInt compileCommand_getNumArgs(
+  CXCompileCommand)
+@cname("clang_CompileCommand_getNumArgs");
+
+extern fn CXString compileCommand_getArg(
+  CXCompileCommand,
+  CUInt i)
+@cname("clang_CompileCommand_getArg");
+
+extern fn CUInt compileCommand_getNumMappedSources(
+  CXCompileCommand)
+@cname("clang_CompileCommand_getNumMappedSources");
+
+extern fn CXString compileCommand_getMappedSourcePath(
+  CXCompileCommand,
+  CUInt i)
+@cname("clang_CompileCommand_getMappedSourcePath");
+
+extern fn CXString compileCommand_getMappedSourceContent(
+  CXCompileCommand,
+  CUInt i)
+@cname("clang_CompileCommand_getMappedSourceContent");
+
+struct CXComment {
+  void* ast_node;
+  CXTranslationUnit translation_unit;
+}
+
+extern fn CXComment cursor_getParsedComment(
+  CXCursor c)
+@cname("clang_Cursor_getParsedComment");
+
+constdef CXCommentKind : CInt {
+  COMMENT_NULL = 0,
+  COMMENT_TEXT = 1,
+  COMMENT_INLINE_COMMAND = 2,
+  COMMENT_HTML_START_TAG = 3,
+  COMMENT_HTML_END_TAG = 4,
+  COMMENT_PARAGRAPH = 5,
+  COMMENT_BLOCK_COMMAND = 6,
+  COMMENT_PARAM_COMMAND = 7,
+  COMMENT_T_PARAM_COMMAND = 8,
+  COMMENT_VERBATIM_BLOCK_COMMAND = 9,
+  COMMENT_VERBATIM_BLOCK_LINE = 10,
+  COMMENT_VERBATIM_LINE = 11,
+  COMMENT_FULL_COMMENT = 12
+}
+
+constdef CXCommentInlineCommandRenderKind : CInt {
+  COMMENT_INLINE_COMMAND_RENDER_KIND_NORMAL = 0,
+  COMMENT_INLINE_COMMAND_RENDER_KIND_BOLD = 1,
+  COMMENT_INLINE_COMMAND_RENDER_KIND_MONOSPACED = 2,
+  COMMENT_INLINE_COMMAND_RENDER_KIND_EMPHASIZED = 3,
+  COMMENT_INLINE_COMMAND_RENDER_KIND_ANCHOR = 4
+}
+
+constdef CXCommentParamPassDirection : CInt {
+  COMMENT_PARAM_PASS_DIRECTION_IN = 0,
+  COMMENT_PARAM_PASS_DIRECTION_OUT = 1,
+  COMMENT_PARAM_PASS_DIRECTION_IN_OUT = 2
+}
+
+extern fn CXCommentKind comment_getKind(
+  CXComment comment)
+@cname("clang_Comment_getKind");
+
+extern fn CUInt comment_getNumChildren(
+  CXComment comment)
+@cname("clang_Comment_getNumChildren");
+
+extern fn CXComment comment_getChild(
+  CXComment comment,
+  CUInt child_idx)
+@cname("clang_Comment_getChild");
+
+extern fn CUInt comment_isWhitespace(
+  CXComment comment)
+@cname("clang_Comment_isWhitespace");
+
+extern fn CUInt inlineContentComment_hasTrailingNewline(
+  CXComment comment)
+@cname("clang_InlineContentComment_hasTrailingNewline");
+
+extern fn CXString textComment_getText(
+  CXComment comment)
+@cname("clang_TextComment_getText");
+
+extern fn CXString inlineCommandComment_getCommandName(
+  CXComment comment)
+@cname("clang_InlineCommandComment_getCommandName");
+
+extern fn CXCommentInlineCommandRenderKind inlineCommandComment_getRenderKind(
+  CXComment comment)
+@cname("clang_InlineCommandComment_getRenderKind");
+
+extern fn CUInt inlineCommandComment_getNumArgs(
+  CXComment comment)
+@cname("clang_InlineCommandComment_getNumArgs");
+
+extern fn CXString inlineCommandComment_getArgText(
+  CXComment comment,
+  CUInt arg_idx)
+@cname("clang_InlineCommandComment_getArgText");
+
+extern fn CXString hTMLTagComment_getTagName(
+  CXComment comment)
+@cname("clang_HTMLTagComment_getTagName");
+
+extern fn CUInt hTMLStartTagComment_isSelfClosing(
+  CXComment comment)
+@cname("clang_HTMLStartTagComment_isSelfClosing");
+
+extern fn CUInt hTMLStartTag_getNumAttrs(
+  CXComment comment)
+@cname("clang_HTMLStartTag_getNumAttrs");
+
+extern fn CXString hTMLStartTag_getAttrName(
+  CXComment comment,
+  CUInt attr_idx)
+@cname("clang_HTMLStartTag_getAttrName");
+
+extern fn CXString hTMLStartTag_getAttrValue(
+  CXComment comment,
+  CUInt attr_idx)
+@cname("clang_HTMLStartTag_getAttrValue");
+
+extern fn CXString blockCommandComment_getCommandName(
+  CXComment comment)
+@cname("clang_BlockCommandComment_getCommandName");
+
+extern fn CUInt blockCommandComment_getNumArgs(
+  CXComment comment)
+@cname("clang_BlockCommandComment_getNumArgs");
+
+extern fn CXString blockCommandComment_getArgText(
+  CXComment comment,
+  CUInt arg_idx)
+@cname("clang_BlockCommandComment_getArgText");
+
+extern fn CXComment blockCommandComment_getParagraph(
+  CXComment comment)
+@cname("clang_BlockCommandComment_getParagraph");
+
+extern fn CXString paramCommandComment_getParamName(
+  CXComment comment)
+@cname("clang_ParamCommandComment_getParamName");
+
+extern fn CUInt paramCommandComment_isParamIndexValid(
+  CXComment comment)
+@cname("clang_ParamCommandComment_isParamIndexValid");
+
+extern fn CUInt paramCommandComment_getParamIndex(
+  CXComment comment)
+@cname("clang_ParamCommandComment_getParamIndex");
+
+extern fn CUInt paramCommandComment_isDirectionExplicit(
+  CXComment comment)
+@cname("clang_ParamCommandComment_isDirectionExplicit");
+
+extern fn CXCommentParamPassDirection paramCommandComment_getDirection(
+  CXComment comment)
+@cname("clang_ParamCommandComment_getDirection");
+
+extern fn CXString tParamCommandComment_getParamName(
+  CXComment comment)
+@cname("clang_TParamCommandComment_getParamName");
+
+extern fn CUInt tParamCommandComment_isParamPositionValid(
+  CXComment comment)
+@cname("clang_TParamCommandComment_isParamPositionValid");
+
+extern fn CUInt tParamCommandComment_getDepth(
+  CXComment comment)
+@cname("clang_TParamCommandComment_getDepth");
+
+extern fn CUInt tParamCommandComment_getIndex(
+  CXComment comment,
+  CUInt depth)
+@cname("clang_TParamCommandComment_getIndex");
+
+extern fn CXString verbatimBlockLineComment_getText(
+  CXComment comment)
+@cname("clang_VerbatimBlockLineComment_getText");
+
+extern fn CXString verbatimLineComment_getText(
+  CXComment comment)
+@cname("clang_VerbatimLineComment_getText");
+
+extern fn CXString hTMLTagComment_getAsString(
+  CXComment comment)
+@cname("clang_HTMLTagComment_getAsString");
+
+extern fn CXString fullComment_getAsHTML(
+  CXComment comment)
+@cname("clang_FullComment_getAsHTML");
+
+extern fn CXString fullComment_getAsXML(
+  CXComment comment)
+@cname("clang_FullComment_getAsXML");
+
+alias CXAPISet = void*;
+
+extern fn CXErrorCode createAPISet(
+  CXTranslationUnit tu,
+  CXAPISet* out_api)
+@cname("clang_createAPISet");
+
+extern fn void disposeAPISet(
+  CXAPISet api)
+@cname("clang_disposeAPISet");
+
+extern fn CXString getSymbolGraphForUSR(
+  ZString usr,
+  CXAPISet api)
+@cname("clang_getSymbolGraphForUSR");
+
+extern fn CXString getSymbolGraphForCursor(
+  CXCursor cursor)
+@cname("clang_getSymbolGraphForCursor");
+
+extern fn void install_aborting_llvm_fatal_error_handler()
+@cname("clang_install_aborting_llvm_fatal_error_handler");
+
+extern fn void uninstall_llvm_fatal_error_handler()
+@cname("clang_uninstall_llvm_fatal_error_handler");
+
+alias CXRewriter = void*;
+
+extern fn CXRewriter cXRewriter_create(
+  CXTranslationUnit tu)
+@cname("clang_CXRewriter_create");
+
+extern fn void cXRewriter_insertTextBefore(
+  CXRewriter rew,
+  CXSourceLocation loc,
+  ZString insert)
+@cname("clang_CXRewriter_insertTextBefore");
+
+extern fn void cXRewriter_replaceText(
+  CXRewriter rew,
+  CXSourceRange to_be_replaced,
+  ZString replacement)
+@cname("clang_CXRewriter_replaceText");
+
+extern fn void cXRewriter_removeText(
+  CXRewriter rew,
+  CXSourceRange to_be_removed)
+@cname("clang_CXRewriter_removeText");
+
+extern fn CInt cXRewriter_overwriteChangedFiles(
+  CXRewriter rew)
+@cname("clang_CXRewriter_overwriteChangedFiles");
+
+extern fn void cXRewriter_writeMainFileToStdOut(
+  CXRewriter rew)
+@cname("clang_CXRewriter_writeMainFileToStdOut");
+
+extern fn void cXRewriter_dispose(
+  CXRewriter rew)
+@cname("clang_CXRewriter_dispose");

--- a/bindgen.c3l/src/data.c3
+++ b/bindgen.c3l/src/data.c3
@@ -18,292 +18,294 @@ import bindgen::bg,
 *>
 enum CFieldKind : char
 {
-  NORMAL,
-  BIT,
-  STRUCT,
-  UNION,
-  ENUM,
+	NORMAL,
+	BIT,
+	STRUCT,
+	UNION,
+	ENUM,
 }
 
 
 <*
- NORMAL - regular field
- BITSTRUCT - inlined bitstruct
- STRUCT - inlined struct
- UNION - inlined union
+	NORMAL - regular field
+	BITSTRUCT - inlined bitstruct
+	STRUCT - inlined struct
+	UNION - inlined union
 *>
 enum C3FieldKind : char
 {
-  NORMAL,
-  BITSTRUCT,
-  STRUCT,
-  UNION
+	NORMAL,
+	BITSTRUCT,
+	STRUCT,
+	UNION
 }
 
 
 <*
- NAME - 'struct' or 'MyType'
- POINTER - *
- SIZED_ARRAY - [10]
- UNSIZED_ARRAY  - []
+	NAME - 'struct' or 'MyType'
+	POINTER - *
+	SIZED_ARRAY - [10]
+	UNSIZED_ARRAY  - []
 *>
 enum CTypeTokenKind : char
 {
-  NAME,
-  POINTER,
-  SIZED_ARRAY,  
-  UNSIZED_ARRAY,
+	NAME,
+	POINTER,
+	SIZED_ARRAY,  
+	UNSIZED_ARRAY,
 }
 
 
 <*
- Represents the C3 declaration kind,
- written to out file
+	Represents the C3 declaration kind,
+	written to out file
 *>
 enum WriteKind
 {
-  ALIAS, TYPEDEF,
-  FUNC, CONST, 
-  UNION, ENUM,
-  MACRO, MODULE,
-  IMPORT, STRUCT,
-  VAR, BITSTRUCT,
+	ALIAS, TYPEDEF,
+	FUNC, CONST, 
+	UNION, ENUM,
+	MACRO, MODULE,
+	IMPORT, STRUCT,
+	VAR, BITSTRUCT,
 }
 
 
 <*
- Represents attributes for C3 declarations
- has_arg - whether an attr
+	Represents attributes for C3 declarations
+	has_arg - whether an attr
 *>
 enum WriteAttrKind : char (String str, bool has_arg)
 {
-  PRIVATE { "@private", false },
-  IF      { "@if",      true },
+	PRIVATE { "@private", false },
+	IF      { "@if",      true },
 }
 
 
 <*
- Types translation table maps CXType to C3 name. 
+	Types translation table maps CXType to C3 name. 
 *>
 alias TypesTable = HashMap{CXType, String};
 
 
 <*
- Represents variable declaration meaning:
- <type> <name>;
+	Represents variable declaration meaning:
+	<type> <name>;
 *>
 struct VarDecl
 {
-  String type;
-  String name;
+	String type;
+	String name;
 }
 
 struct EnumField 
 {
 	String name;
 	String init;
+	String docs;
 }
 
 <*
- Represents bit fields meaning:
- <type> <name> : <width>;
+	Represents bit fields meaning:
+	<type> <name> : <width>;
 *>
 struct CBitField
 {
-  String  type;
-  String  name;
-  usz     width;
+	String  type;
+	String  name;
+	usz     width;
 }
 
 
 <*
- Represents anonymous structure meaning:
+	Represents anonymous structure meaning:
 
- name : "Optional, can be zero string"
+	name : "Optional, can be zero string"
 *>
 struct CInlinedRecord
 {
-  String  name;
-  CFields fields;
+	String  name;
+	CFields fields;
 }
 
 
 <* 
- kinds.len == sum of *.len 
+	kinds.len == sum of *.len
 *>
 struct CFields
 {
-  List{CFieldKind}      kinds;
-  List{VarDecl}         norm;
-  List{CBitField}       bit;
-  List{CInlinedRecord}  structs;
-  List{CInlinedRecord}  unions;
+	List{CFieldKind}      kinds;
+	List{VarDecl}         norm;
+	List{CBitField}       bit;
+	List{CInlinedRecord}  structs;
+	List{CInlinedRecord}  unions;
 }
 
 
 <*
- name : "Optional, can be zero string"
+	name : "Optional, can be zero string"
 *>
 struct C3InlinedRecord
 {
-  C3Fields  fields;
-  String    name;
+	C3Fields  fields;
+	String    name;
 }
 
 
 <*
- under_type : "Underlying type of a bitstruct (bitstruct : under_type { ... })"
+	under_type : "Underlying type of a bitstruct (bitstruct : under_type { ... })"
 *>
 struct C3InlinedBitstruct
 {
-  List{C3BitstructField}  fields;
-  String                  under_type;
+	List{C3BitstructField}  fields;
+	String                  under_type;
 }
 
 
 <*
- from : "Number of starting bit"
- to : "Number of ending bit"
+	from : "Number of starting bit"
+	to : "Number of ending bit"
 *>
 struct C3BitstructField
 {
-  String  type;
-  String  name;
-  usz     from;
-  usz     to;
+	String  type;
+	String  name;
+	usz     from;
+	usz     to;
 }
 
 
 <* 
-  kinds.len == sum of *.len 
+	kinds.len == sum of *.len 
 *>
 struct C3Fields
 {
-  List{C3FieldKind}         kinds;
-  List{VarDecl}             norm;
-  List{C3InlinedBitstruct}  bit;
-  List{C3InlinedRecord}     structs;
-  List{C3InlinedRecord}     unions;
+	List{C3FieldKind}         kinds;
+	List{VarDecl}             norm;
+	List{C3InlinedBitstruct}  bit;
+	List{C3InlinedRecord}     structs;
+	List{C3InlinedRecord}     unions;
 }
 
 
 <*
- strs : "Strings, which are unknown at compile time"
+	strs : "Strings, which are unknown at compile time"
 *>
 struct CTypeTokens
 {
-  List{CTypeTokenKind} kinds;
-  List{String}         strs;
+	List{CTypeTokenKind} kinds;
+	List{String}         strs;
 }
 
 
 
 <*
- Visit data, accesed from any visitor
+	Visit data, accesed from any visitor
 
- cxfile : "Used to ignore nodes from other files "
+	cxfile : "Used to ignore nodes from other files "
 *>
 struct GlobalVisitData
 {
-  BGTransCallbacks  trans_fns;
-  BGGenCallbacks    gen_fns;
-  BGCheckFn         include_file;
-  String            module_name;
-  BGModuleWrap      prev_module_wrap;
+	BGTransCallbacks  trans_fns;
+	BGGenCallbacks    gen_fns;
+	BGCheckFn         include_file;
+	String            module_name;
+	BGModuleWrap      prev_module_wrap;
 
-  TypesTable        types_table;
-  OutStream         out;
-  CXFile            cxfile;
-  usz               anon_fns_counter;
-  WriteState        write_state;
+	TypesTable        types_table;
+	OutStream         out;
+	CXFile            cxfile;
+	usz               anon_fns_counter;
+	WriteState        write_state;
 
-  bitstruct : char
-  {
-    bool            no_verbose;
-  }
+	bitstruct : char
+	{
+		bool no_verbose;
+		bool use_docs;          
+	}
 }
 
 
 <*
- allocator : "All string are allocated via it"
+	allocator : "All string are allocated via it"
 *>
 struct FuncVisitData
 {
-  List{VarDecl}     params;
-  Allocator         allocator;
-  GlobalVisitData*  g;
+	List{VarDecl}     params;
+	Allocator         allocator;
+	GlobalVisitData*  g;
 }
 
 
 <*
- allocator : "All string are allocated via it"
- prev_inline : "Before visiting should be set to clang::getNullCursor()"
+	allocator : "All string are allocated via it"
+	prev_inline : "Before visiting should be set to clang::getNullCursor()"
 *>
 struct FieldsVisitData
 {
-  CXCursor          prev_inline;
-  CFields           fields;
-  Allocator         allocator;
-  GlobalVisitData*  g;
-  usz               current;
+	CXCursor          prev_inline;
+	CFields           fields;
+	Allocator         allocator;
+	GlobalVisitData*  g;
+	usz               current;
 }
 
 
 <*
- is_incomplete : "Whether the underlying type is incomplete"
+	is_incomplete : "Whether the underlying type is incomplete"
 *>
 struct TypedefVisitData
 {
-  GlobalVisitData*  g;
-  CXType            under_type;
-  bool              is_incomplete;
+	GlobalVisitData*  g;
+	CXType            under_type;
+	bool              is_incomplete;
 }
 
 
 <*
- allocator : "val is allocated via it"
+	allocator : "val is allocated via it"
 *>
 struct ConstVisitData
 {
-  String            val;
-  Allocator         allocator;
-  GlobalVisitData*  g;
+	String            val;
+	Allocator         allocator;
+	GlobalVisitData*  g;
 }
 
 
 <*
- allocator : "All string are allocated via it"
+	allocator : "All string are allocated via it"
 *>
 struct EnumVisitData
 {
-  GlobalVisitData*  g;
-  List{EnumField}   fields;
-  Allocator         allocator;
-  String            enum_name;
-  bool              is_unsigned;
+	GlobalVisitData*  g;
+	List{EnumField}   fields;
+	Allocator         allocator;
+	String            enum_name;
+	bool              is_unsigned;
 }
 
 
 <*
- Writing state, passed to the writers
+	Writing state, passed to the writers
 *>
 struct WriteState
 {
-  WriteKind kind;
+	WriteKind kind;
 }
 
 
 <*
- Write attributes represent additional attributes
- for any declaration. There are two types of attributes:
- - String: an attribute has an argument. The attribute is
-           enabled if it's value is not equal to ""
- - bool:   an attribute doesn't have value and is enabled
-           if the bool is true.
+	Write attributes represent additional attributes
+	for any declaration. There are two types of attributes:
+	- String: an attribute has an argument. The attribute is
+			enabled if it's value is not equal to ""
+	- bool:   an attribute doesn't have value and is enabled
+			if the bool is true.
 *>
 struct WriteAttrs (Printable)
 {
-  String if_condition @tag("attr", "@if");
-  bool   private      @tag("attr", "@private");
+	String if_condition @tag("attr", "@if");
+	bool   private      @tag("attr", "@private");
 }
 

--- a/bindgen.c3l/src/data.c3
+++ b/bindgen.c3l/src/data.c3
@@ -113,7 +113,7 @@ struct CBitField
 {
 	String  type;
 	String  name;
-	usz     width;
+	sz     width;
 }
 
 
@@ -170,8 +170,8 @@ struct C3BitstructField
 {
 	String  type;
 	String  name;
-	usz     from;
-	usz     to;
+	sz     from;
+	sz     to;
 }
 
 
@@ -215,7 +215,7 @@ struct GlobalVisitData
 	TypesTable        types_table;
 	OutStream         out;
 	CXFile            cxfile;
-	usz               anon_fns_counter;
+	sz               anon_fns_counter;
 	WriteState        write_state;
 
 	bitstruct : char
@@ -247,7 +247,7 @@ struct FieldsVisitData
 	CFields           fields;
 	Allocator         allocator;
 	GlobalVisitData*  g;
-	usz               current;
+	sz               current;
 }
 
 

--- a/bindgen.c3l/src/data.c3
+++ b/bindgen.c3l/src/data.c3
@@ -98,6 +98,11 @@ struct VarDecl
   String name;
 }
 
+struct EnumField 
+{
+	String name;
+	String init;
+}
 
 <*
  Represents bit fields meaning:
@@ -272,6 +277,8 @@ struct ConstVisitData
 struct EnumVisitData
 {
   GlobalVisitData*  g;
+  List{EnumField}   fields;
+  Allocator         allocator;
   String            enum_name;
   bool              is_unsigned;
 }

--- a/bindgen.c3l/src/data_methods.c3
+++ b/bindgen.c3l/src/data_methods.c3
@@ -23,8 +23,8 @@ macro void CFields.init(
   &self, 
   Allocator alloc)
 {
-  $foreach $member : CFields.membersof:
-    self.$eval($member.nameof).init(alloc);
+  $foreach $member : CFields::members:
+    self.$eval($member.name).init(alloc);
   $endforeach
 }
 
@@ -35,9 +35,9 @@ macro void CFields.init(
 *>
 macro CFields.@foreach(
   &self; 
-  @body(CFieldKind* kind, usz index))
+  @body(CFieldKind* kind, sz index))
 {
-  usz[CFieldKind.values.len] counters;
+  sz[CFieldKind::values.len] counters;
 
   foreach (i, &k : self.kinds) {
     @body(k, counters[k.ordinal]);
@@ -53,8 +53,8 @@ macro void C3Fields.init(
   &self, 
   Allocator alloc)
 {
-  $foreach $member : C3Fields.membersof:
-    self.$eval($member.nameof).init(alloc);
+  $foreach $member : C3Fields::members:
+    self.$eval($member.name).init(alloc);
   $endforeach
 }
 
@@ -65,9 +65,9 @@ macro void C3Fields.init(
 *>
 macro C3Fields.@foreach(
   &self; 
-  @body(C3FieldKind* kind, usz index))
+  @body(C3FieldKind* kind, sz index))
 {
-  usz[C3FieldKind.values.len] counters;
+  sz[C3FieldKind::values.len] counters;
 
   foreach (i, &k : self.kinds)
   {
@@ -103,16 +103,16 @@ macro void CTypeTokens.free(&self)
  Iterates through CTypeTokens in reversed order,
  returning the kind and index of a name string.
  If token is represented with const string,
- sets index to usz.max.
+ sets index to sz.max.
 *>
 macro CTypeTokens.@foreach(
   &self; 
-  @body(CTypeTokenKind kind, usz str_index))
+  @body(CTypeTokenKind kind, sz str_index))
 {
-  usz str_counter;
-  usz str_len = self.strs.len();
+  sz str_counter;
+  sz str_len = self.strs.len();
   foreach_r (k : self.kinds) {
-    usz str_index = usz.max;
+    sz str_index = sz::max;
     switch (k) {
       case NAME:
       case SIZED_ARRAY:
@@ -156,23 +156,23 @@ macro void CTypeTokens.push(
  Information about how the specific attribute is printed,
  must be contained in str @tag of the field.
 *>
-fn usz? WriteAttrs.to_format(
+fn sz? WriteAttrs.to_format(
   &self, 
   Formatter* format) 
   @dynamic
 {
-  usz? acc;
+  sz? acc;
 
-  $foreach $f : WriteAttrs.membersof:
-    assert( $f.has_tagof("attr") );
-    String $attr = $f.tagof("attr");
+  $foreach $f : WriteAttrs::members:
+    assert( $f.has_tag("attr") );
+    String $attr = $f.get_tag("attr");
 
-    $switch $f.typeid:
-      $case String:
+    $switch $f.type.kind:
+      $case String::kind:
         if ($f.get(*self) != "") {
           acc += format.printf(" %s(%s)", $attr, $f.get(*self));
         }
-      $case bool:
+      $case bool::kind:
         if ($f.get(*self)) {
           acc += format.printf(" %s", $attr);
         }
@@ -206,11 +206,11 @@ module std::core::array;
 
 <*
  Returns true if predicate returns true at least one time. Returns false otherwise.
- @require $kindof(arr) == SLICE ||| $kindof(arr) == ARRAY       : "Array must be either slice or array"
- @require $kindof(predicate) == FUNC                              : "Predicate must be a function"
- @require $typeof(predicate).returns == bool.typeid                 : "Predicate must return bool"
- @require $typeof(predicate).paramsof.len == 1                      : "Predicate must have one parameter"
- @require $typeof(predicate).paramsof[0].type == $typeof(arr).inner : "Predicate must have parameter of inner array type"
+ @require $Typeof(arr)::kind == SLICE ||| $kindof(arr) == ARRAY       : "Array must be either slice or array"
+ @require $Typeof(predicate)::kind == FUNC                              : "Predicate must be a function"
+ @require $Typeof(predicate)::returns == bool                 : "Predicate must return bool"
+ @require $Typeof(predicate)::params.len == 1                      : "Predicate must have one parameter"
+ @require $Typeof(predicate)::params[0].type == $Typeof(arr)::inner : "Predicate must have parameter of inner array type"
 *>
 macro has(arr, predicate)
 {

--- a/bindgen.c3l/src/err.c3
+++ b/bindgen.c3l/src/err.c3
@@ -11,9 +11,9 @@ import clang, std::io;
 macro void log(
   String str = "", 
   ..., 
-  usz indent = 0) 
+  sz indent = 0) 
 {
-  for (usz i; i < indent; ++i) {
+  for (sz i; i < indent; ++i) {
     io::eprintf("  ");
   }
   io::eprintf("%s[%s]%s : ", Ansi.GREEN, $$FUNC, Ansi.RESET);
@@ -36,34 +36,34 @@ macro void flog(
 
 
 <*
- If !no_verbose, writes str to stdout
- in warning format
+	If !no_verbose, writes str to stdout
+	in warning format
 *>
 macro void warn(
-  bool no_verbose, 
-  String str = "", 
-  ...) 
+	bool no_verbose, 
+	String str = "", 
+	...) 
 {
-  if (!no_verbose) {
-    io::eprintf("%sWarning%s : ", Ansi.YELLOW, Ansi.RESET);
-    io::eprintfn(str, $vasplat);
-  }
+	if (!no_verbose) {
+		io::eprintf("%sWarning%s : ", Ansi.YELLOW, Ansi.RESET);
+		io::eprintfn(str, ...$vaarg);
+	}
 }
 
 
 <*
- If !no_verbose, writes str to stdout
- in info format
+	If !no_verbose, writes str to stdout
+	in info format
 *>
 macro void info(
-  bool no_verbose,
-  String str = "", 
-  ...) 
+	bool no_verbose,
+	String str = "", 
+	...) 
 {
-  if (!no_verbose) {
-    io::eprintf("%sInfo%s : ", Ansi.GREEN, Ansi.RESET);
-    io::eprintfn(str, $vasplat);
-  }
+	if (!no_verbose) {
+		io::eprintf("%sInfo%s : ", Ansi.GREEN, Ansi.RESET);
+		io::eprintfn(str, ...$vaarg);
+	}
 } 
 
 
@@ -76,7 +76,7 @@ macro void erro(
   ...) 
 {
   io::eprintf("%sError%s : ", Ansi.RED, Ansi.RESET);
-  io::eprintfn(str, $vasplat);
+  io::eprintfn(str, ...$vaarg);
 }
 
 
@@ -92,7 +92,7 @@ macro void diag(
   ...)
 {
   io::eprintf("%sError at %s:%d:%d%s : ", Ansi.RED, file, line, col, Ansi.RESET);
-  io::eprintfn(str, $vasplat);
+  io::eprintfn(str, ...$vaarg);
 }
 
 

--- a/bindgen.c3l/src/misc.c3
+++ b/bindgen.c3l/src/misc.c3
@@ -16,72 +16,136 @@ import bgimpl,
 fn String convStr(CXString s) @inline => clang::getCString(s).str_view();
 
 
-<*
- Detects whether the type is a pointer to function or function
- itself
-*>
-fn bool isTypePFN(CXType type) @inline
-{
-  if (type.kind == TYPE_POINTER) {
-    type = clang::getPointeeType(type);
-  }
-  return type.kind == TYPE_FUNCTION_PROTO || type.kind == TYPE_FUNCTION_NO_PROTO;
+fn String getCursorDoc(CXCursor cursor, Allocator alloc, int indent = 0) {
+    CXString raw = clang::cursor_getRawCommentText(cursor);
+    
+    if (raw.data == null) {
+        return ""; 
+    }
+
+    defer clang::disposeString(raw);
+    String conv_str = misc::convStr(raw).copy(alloc); 
+	return cleanupDoc(alloc, conv_str, indent);
+}
+
+fn String cleanupDoc(Allocator alloc, String raw_doc, int indent_level = 0) => @pool() {
+    if (raw_doc.len == 0) return "";
+
+    DString clean;
+    clean.tinit();
+
+	DString indent_builder;
+    indent_builder.tinit();
+    for (int i = 0; i < indent_level; i++) {
+        indent_builder.append("\t");
+    }
+    String indent = indent_builder.str_view();
+    
+    // Split the raw comment into lines
+    String[] lines = raw_doc.split(tmem, "\n");
+    
+	clean.append(indent);
+    clean.append("<*\n");
+    
+    foreach (line : lines) {
+        String trimmed = line.trim();
+        
+        // Remove comment start, end, and leading asterisks
+        if (trimmed.starts_with("/**")) { 
+			trimmed = trimmed[3..]; 
+		}
+        else if (trimmed.starts_with("/*")) {
+			trimmed = trimmed[2..];
+		}
+        if (trimmed.ends_with("*/")) { 
+			trimmed = trimmed[..trimmed.len - 2];
+		}
+        
+        // Strip the leading '*' if it exists (standard Doxygen style)
+        trimmed = trimmed.trim();
+        if (trimmed.starts_with("*")) {
+            trimmed = trimmed[1..].trim();
+        }
+
+        if (trimmed.len > 0) {
+			clean.append(indent);
+            clean.append("\t"); // Indent for style
+            clean.append(trimmed);
+            clean.append("\n");
+        }
+    }
+    
+	clean.append(indent);
+    clean.append("*>");
+    return clean.copy_str(alloc);
 }
 
 <*
- If the cursor does not represent a definition of that cursor,
- we consider it forwardly declared
+	Detects whether the type is a pointer to function or function
+	itself
+*>
+fn bool isTypePFN(CXType type) @inline
+{
+	if (type.kind == TYPE_POINTER) {
+		type = clang::getPointeeType(type);
+	}
+	return type.kind == TYPE_FUNCTION_PROTO || type.kind == TYPE_FUNCTION_NO_PROTO;
+}
+
+<*
+	If the cursor does not represent a definition of that cursor,
+	we consider it forwardly declared
 *>
 fn bool isCursorForwardDeclared(CXCursor cursor) @inline => !clang::isCursorDefinition(cursor);
 
 
 <*
- Type is incomplete in case when it can't be used directly, without
- a pointer to it
+	Type is incomplete in case when it can't be used directly, without
+	a pointer to it
 *>
 fn bool isTypeIncomplete(CXType type) @inline 
 {
-  // If layout explicitly says it is incomplete, it is incomplete.
-  if ((CInt)clang::type_getSizeOf(type) == (CInt)CXTypeLayoutError.TYPE_LAYOUT_ERROR_INCOMPLETE) {
-    return true;
-  }
+	// If layout explicitly says it is incomplete, it is incomplete.
+	if ((CInt)clang::type_getSizeOf(type) == (CInt)CXTypeLayoutError.TYPE_LAYOUT_ERROR_INCOMPLETE) {
+		return true;
+	}
 
-  // check if the declaration declaration lacks a definition
-  CXCursor declaration = clang::getTypeDeclaration(type);
-  CXCursorKind kind = clang::getCursorKind(declaration);
+	// check if the declaration declaration lacks a definition
+	CXCursor declaration = clang::getTypeDeclaration(type);
+	CXCursorKind kind = clang::getCursorKind(declaration);
 
-  if (kind == CURSOR_STRUCT_DECL || 
-      kind == CURSOR_UNION_DECL || 
-      kind == CURSOR_ENUM_DECL) {
-    return clang::isCursorDefinition(declaration) == 0;
-  }
+	if (kind == CURSOR_STRUCT_DECL || 
+		kind == CURSOR_UNION_DECL || 
+		kind == CURSOR_ENUM_DECL) {
+		return clang::isCursorDefinition(declaration) == 0;
+	}
 
-  return false;
+	return false;
 }
 
 <*
- getTrueCursorExtent returns a source range for the cursor without
- preprocessor 'location jumps' when doing regular clang::getCursorExtent.
- 
- Behaviour of clang::getCursorExtent is a bit weird. If some macro
- is expanded under the following cursor, beginning of the given range
- will point to the macro definition. clang::getExpansionLocation
- fixes that bug as it considers macro expansion part as a regular token,
- without doing these 'location jumps'.
+	getTrueCursorExtent returns a source range for the cursor without
+	preprocessor 'location jumps' when doing regular clang::getCursorExtent.
+	
+	Behaviour of clang::getCursorExtent is a bit weird. If some macro
+	is expanded under the following cursor, beginning of the given range
+	will point to the macro definition. clang::getExpansionLocation
+	fixes that bug as it considers macro expansion part as a regular token,
+	without doing these 'location jumps'.
 *>
 fn CXSourceRange getTrueCursorExtent(
-  CXCursor cursor)
+	CXCursor cursor)
 {
-  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
-  CXSourceRange sr = clang::getCursorExtent(cursor);
-  CXSourceLocation sl_begin = clang::getRangeStart(sr);    
-  CXSourceLocation sl_end = clang::getRangeEnd(sr);
-  CXFile file; CUInt offset; 
-  clang::getExpansionLocation(sl_begin, &file, null, null, &offset);
-  sl_begin = clang::getLocationForOffset(tu, file, offset); 
-  sr = clang::getRange(sl_begin, sl_end);
+	CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
+	CXSourceRange sr = clang::getCursorExtent(cursor);
+	CXSourceLocation sl_begin = clang::getRangeStart(sr);    
+	CXSourceLocation sl_end = clang::getRangeEnd(sr);
+	CXFile file; CUInt offset; 
+	clang::getExpansionLocation(sl_begin, &file, null, null, &offset);
+	sl_begin = clang::getLocationForOffset(tu, file, offset); 
+	sr = clang::getRange(sl_begin, sl_end);
 
-  return sr;
+	return sr;
 }
 
 
@@ -91,46 +155,46 @@ fn CXSourceRange getTrueCursorExtent(
  etc.
 *>
 fn usz getTopChildrenNumber(
-  CXCursor cursor)
+	CXCursor cursor)
 {
-  usz qty;
+	usz qty;
 
-  clang::visitChildren(cursor, 
-    fn (CXCursor cursor, CXCursor parent, CXClientData client_data) {
-      usz* qty = (usz*) client_data;
-      ++*qty;
-      return CHILD_VISIT_CONTINUE;
-    }, (CXClientData) &qty
-  );
+	clang::visitChildren(cursor, 
+		fn (CXCursor cursor, CXCursor parent, CXClientData client_data) {
+		usz* qty = (usz*) client_data;
+		++*qty;
+		return CHILD_VISIT_CONTINUE;
+		}, (CXClientData) &qty
+	);
 
-  return qty;
+	return qty;
 }
 
 
 <*
- If type is a nested pointer or array, gets rid
- of these qualifiers and returns the basic type.
+	If type is a nested pointer or array, gets rid
+	of these qualifiers and returns the basic type.
 *>
 fn CXType getBaseType(
-  CXType type) 
+	CXType type) 
 {
-  CXType base;
+	CXType base;
 
-  while LOOP: (true) {
-    switch (type.kind) {
-      case TYPE_POINTER: 
-        type = clang::getPointeeType(type);
+	while LOOP: (true) {
+		switch (type.kind) {
+		case TYPE_POINTER: 
+			type = clang::getPointeeType(type);
 
-      case TYPE_CONSTANT_ARRAY:
-      case TYPE_INCOMPLETE_ARRAY:
-        type = clang::getElementType(type);
+		case TYPE_CONSTANT_ARRAY:
+		case TYPE_INCOMPLETE_ARRAY:
+			type = clang::getElementType(type);
 
-      default:
-        base = type;
-        break LOOP;
-    }
-  }
+		default:
+			base = type;
+			break LOOP;
+		}
+	}
 
-  return base;
+	return base;
 }
 

--- a/bindgen.c3l/src/misc.c3
+++ b/bindgen.c3l/src/misc.c3
@@ -22,10 +22,10 @@ fn String convStr(CXString s) @inline => clang::getCString(s).str_view();
 *>
 fn bool isTypePFN(CXType type) @inline
 {
-  if (type.kind == clang::TYPE_POINTER) {
+  if (type.kind == TYPE_POINTER) {
     type = clang::getPointeeType(type);
   }
-  return type.kind == clang::TYPE_FUNCTION_PROTO || type.kind == clang::TYPE_FUNCTION_NO_PROTO;
+  return type.kind == TYPE_FUNCTION_PROTO || type.kind == TYPE_FUNCTION_NO_PROTO;
 }
 
 <*
@@ -39,8 +39,25 @@ fn bool isCursorForwardDeclared(CXCursor cursor) @inline => !clang::isCursorDefi
  Type is incomplete in case when it can't be used directly, without
  a pointer to it
 *>
-fn bool isTypeIncomplete(CXType type) @inline => clang::getSizeOf_Type(type) == clang::TYPE_LAYOUT_ERROR_INCOMPLETE;
+fn bool isTypeIncomplete(CXType type) @inline 
+{
+  // If layout explicitly says it is incomplete, it is incomplete.
+  if ((CInt)clang::type_getSizeOf(type) == (CInt)CXTypeLayoutError.TYPE_LAYOUT_ERROR_INCOMPLETE) {
+    return true;
+  }
 
+  // check if the declaration declaration lacks a definition
+  CXCursor declaration = clang::getTypeDeclaration(type);
+  CXCursorKind kind = clang::getCursorKind(declaration);
+
+  if (kind == CURSOR_STRUCT_DECL || 
+      kind == CURSOR_UNION_DECL || 
+      kind == CURSOR_ENUM_DECL) {
+    return clang::isCursorDefinition(declaration) == 0;
+  }
+
+  return false;
+}
 
 <*
  getTrueCursorExtent returns a source range for the cursor without
@@ -55,7 +72,7 @@ fn bool isTypeIncomplete(CXType type) @inline => clang::getSizeOf_Type(type) == 
 fn CXSourceRange getTrueCursorExtent(
   CXCursor cursor)
 {
-  CXTranslationUnit tu = clang::getTranslationUnit_Cursor(cursor);
+  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
   CXSourceRange sr = clang::getCursorExtent(cursor);
   CXSourceLocation sl_begin = clang::getRangeStart(sr);    
   CXSourceLocation sl_end = clang::getRangeEnd(sr);
@@ -82,7 +99,7 @@ fn usz getTopChildrenNumber(
     fn (CXCursor cursor, CXCursor parent, CXClientData client_data) {
       usz* qty = (usz*) client_data;
       ++*qty;
-      return clang::CHILD_VISIT_CONTINUE;
+      return CHILD_VISIT_CONTINUE;
     }, (CXClientData) &qty
   );
 
@@ -101,11 +118,11 @@ fn CXType getBaseType(
 
   while LOOP: (true) {
     switch (type.kind) {
-      case clang::TYPE_POINTER: 
+      case TYPE_POINTER: 
         type = clang::getPointeeType(type);
 
-      case clang::TYPE_CONSTANT_ARRAY:
-      case clang::TYPE_INCOMPLETE_ARRAY:
+      case TYPE_CONSTANT_ARRAY:
+      case TYPE_INCOMPLETE_ARRAY:
         type = clang::getElementType(type);
 
       default:

--- a/bindgen.c3l/src/misc.c3
+++ b/bindgen.c3l/src/misc.c3
@@ -154,14 +154,14 @@ fn CXSourceRange getTrueCursorExtent(
  their quantity. Does not skip attributes, macro expansions,
  etc.
 *>
-fn usz getTopChildrenNumber(
+fn sz getTopChildrenNumber(
 	CXCursor cursor)
 {
-	usz qty;
+	sz qty;
 
 	clang::visitChildren(cursor, 
 		fn (CXCursor cursor, CXCursor parent, CXClientData client_data) {
-		usz* qty = (usz*) client_data;
+		sz* qty = (sz*) client_data;
 		++*qty;
 		return CHILD_VISIT_CONTINUE;
 		}, (CXClientData) &qty

--- a/bindgen.c3l/src/tparse.c3
+++ b/bindgen.c3l/src/tparse.c3
@@ -21,7 +21,7 @@ faultdef INVALID_BITFIELDS;
 fn String convertCTypeTokenToC3(
   CTypeTokenKind kind,
   String[] strs,
-  usz str_index)
+  sz str_index)
   @inline
 {
   switch (kind) {
@@ -70,7 +70,7 @@ fn CTypeTokens getTypeTokens(
         defer clang::disposeString(type_spell);
         String type_str = misc::convStr(type_spell);
 
-        type_str = type_str.strip("const ").strip("struct ").strip("enum ").strip("union ");
+        type_str = type_str.strip_prefix("const ").strip_prefix("struct ").strip_prefix("enum ").strip_prefix("union ");
         tokens.push(NAME, type_str.copy(tmem));
         break LOOP;
     }
@@ -98,13 +98,13 @@ fn C3Fields? getC3Fields(
   C3Fields res;
   res.init(alloc);
 
-  // usz.max means we're not in segment
-  usz bit_widths_acc;
-  usz bit_segment_start = usz.max;
+  // sz.max means we're not in segment
+  sz bit_widths_acc;
+  sz bit_segment_start = sz::max;
   List{C3BitstructField} bit_fields;
   bit_fields.init(alloc);
 
-  cfs.@foreach(; CFieldKind* kind, usz index) {
+  cfs.@foreach(; CFieldKind* kind, sz index) {
     switch (*kind) {
       // TODO: do it without pushes with plain copy 
       // as res.norm practically equals to cfs.norm
@@ -115,7 +115,7 @@ fn C3Fields? getC3Fields(
 
       case BIT:
         CBitField cfield = cfs.bit[index];
-        if (bit_segment_start == usz.max) bit_segment_start = index;
+        if (bit_segment_start == sz::max) bit_segment_start = index;
         bit_fields.push({
           .type = cfield.type, 
           .name = cfield.name, 
@@ -142,7 +142,7 @@ fn C3Fields? getC3Fields(
       }
 
     // Finish bit range and reset things if needed
-    if ((*kind != BIT || index == cfs.bit.len() - 1) && bit_segment_start != usz.max) {
+    if ((*kind != BIT || index == cfs.bit.len() - 1) && bit_segment_start != sz::max) {
       res.kinds.push(BITSTRUCT);
       switch (bit_widths_acc) {
         case 1..8:
@@ -176,7 +176,7 @@ fn C3Fields? getC3Fields(
 
       bit_fields = {};
       bit_fields.init(alloc);
-      bit_segment_start = usz.max;
+      bit_segment_start = sz::max;
     }
   };
 

--- a/bindgen.c3l/src/tparse.c3
+++ b/bindgen.c3l/src/tparse.c3
@@ -51,17 +51,17 @@ fn CTypeTokens getTypeTokens(
 
   while LOOP: (true) {
     switch (type.kind) {
-      case clang::TYPE_POINTER: 
+      case TYPE_POINTER: 
         tokens.push(POINTER);
         type = clang::getPointeeType(type);
 
-      case clang::TYPE_CONSTANT_ARRAY:
+      case TYPE_CONSTANT_ARRAY:
         CLongLong size = clang::getArraySize(type);
         String str = string::format(tmem, "[%d]", size);
         tokens.push(SIZED_ARRAY, str);
         type = clang::getElementType(type);
 
-      case clang::TYPE_INCOMPLETE_ARRAY:
+      case TYPE_INCOMPLETE_ARRAY:
         tokens.push(UNSIZED_ARRAY);
         type = clang::getElementType(type);
 
@@ -193,11 +193,11 @@ fn CFieldKind getCFieldKind(
   CFieldKind kind;
 
   switch (clang::getCursorKind(cursor)) {
-    case clang::CURSOR_STRUCT_DECL: 
+    case CURSOR_STRUCT_DECL: 
       kind = STRUCT;
-    case clang::CURSOR_UNION_DECL: 
+    case CURSOR_UNION_DECL: 
       kind = UNION;
-    case clang::CURSOR_ENUM_DECL:
+    case CURSOR_ENUM_DECL:
       kind = ENUM;
     default: 
       if (clang::getFieldDeclBitWidth(cursor) == -1) {

--- a/bindgen.c3l/src/trans.c3
+++ b/bindgen.c3l/src/trans.c3
@@ -89,7 +89,7 @@ fn String? ctype(
 
 	// We will never check NAME for previous kind
 	CTypeTokenKind prev_kind = NAME;
-	tokens.@foreach(;CTypeTokenKind kind, usz str_index) {
+	tokens.@foreach(;CTypeTokenKind kind, sz str_index) {
 		String str = tparse::convertCTypeTokenToC3(kind, tokens.strs.array_view(), str_index);
 
 		switch (kind) {
@@ -179,7 +179,7 @@ fn String? tokensUnderCursor(
 	// Token number to start iterating from. 
 	// It's needed as sometimes cursor name can be also tokenized, 
 	// e.g. when tokenizing a macro, first token is it's name.
-	usz start_from = kind == CURSOR_MACRO_DEFINITION ? 1 : 0;
+	sz start_from = kind == CURSOR_MACRO_DEFINITION ? 1 : 0;
 	if (tokens_len <= start_from) return trans::EMPTY_MACRO_VAL~;
 
 	DString res;
@@ -202,8 +202,8 @@ fn String? tokensUnderCursor(
 		// 1. Constant (macro)
 		// 2. Functional macro
 		case TOKEN_IDENTIFIER:
-			usz i = token - tokens_ptr;
-			if (i < tokens_len - 1) {
+			sz i = token - tokens_ptr;
+			if (i < (sz)tokens_len - 1) {
 			CXString token_spell_2 = clang::getTokenSpelling(tu, tokens_ptr[i + 1]);
 			defer clang::disposeString(token_spell_2);
 			String token_str_2 = misc::convStr(token_spell_2);
@@ -286,7 +286,7 @@ fn String? basicType(
     case "void":          return "void";
     case "_Bool":         return "bool";
     case "ptrdiff_t":     return "isz";
-    case "size_t":        return "usz";
+    case "size_t":        return "sz";
 
     case "char":          return "CChar";
     case "short":         return "CShort";

--- a/bindgen.c3l/src/trans.c3
+++ b/bindgen.c3l/src/trans.c3
@@ -8,231 +8,237 @@ faultdef EMPTY_MACRO_VAL, NAME_IGNORED, NOT_BASIC_TYPE;
 
 
 <*
- Applies function 'fun' to string 's' and allocate it via 'alloc'.
- @return? trans::NAME_IGNORED
+	Applies function 'fun' to string 's' and allocate it via 'alloc'.
+	@return? trans::NAME_IGNORED
 *>
 fn String? apply(
-  String s, 
-  BGTransFn fun, 
-  Allocator alloc = mem) 
-@inline 
+	String s, 
+	BGTransFn fun, 
+	Allocator alloc = mem) @inline 
 {
-  if (s.len == 0) return "";
-  if (fun == null) return s.copy(alloc);
+	if (s.len == 0) return "";
+	if (fun == null) return s.copy(alloc);
 
-  String t = fun(s, alloc);
-  if (t == "")
-  {
-    return trans::NAME_IGNORED~;
-  }
+	String t = fun(s, alloc);
+	if (t == "")
+	{
+		return trans::NAME_IGNORED~;
+	}
 
-  return t;
+	return t;
 }
 
 
 <*
- Applies 'fun' to 's', returns the new 
- translated one and caches it into types table 
- with 'key' as key type. String itself is always 
- allocated on the heap and should NOT be freed 
- as it would cause dangerous dead nodes in table.
- @param s : "String to translate"
+	Applies 'fun' to 's', returns the new 
+	translated one and caches it into types table 
+	with 'key' as key type. String itself is always 
+	allocated on the heap and should NOT be freed 
+	as it would cause dangerous dead nodes in table.
+	@param s : "String to translate"
 *>
 fn String? capply(
-  String s, 
-  CXType key,
-  BGTransFn fun, 
-  TypesTable* table) 
+	String s, 
+	CXType key,
+	BGTransFn fun, 
+	TypesTable* table) 
 {
-  String translated;
+	String translated;
 
-  if (try sc = (*table)[key]) {
-    translated = sc;
-  } else {
-    translated = trans::apply(s, fun)!;
-    if (table != null) (*table)[key] = translated; // 'translated' is not copied here
-  }
+	if (try sc = (*table)[key]) {
+		translated = sc;
+	} else {
+		translated = trans::apply(s, fun)!;
+		if (table != null) (*table)[key] = translated; // 'translated' is not copied here
+	}
 
-  return translated;
+	return translated;
 }
 
 
 <*
- Translates type to a string, caching it also.
- It has a special behaviour when translating a function parameter for ABI compatibility:
- - int[] -> CInt*
- - int[]* -> CInt* 
- - int[10] -> CInt[10]* (as function parameter)
- - int[10] -> CInt[10] (as structure field or typedef).
+	Translates type to a string, caching it also.
+	It has a special behaviour when translating a function parameter for ABI compatibility:
+	- int[] -> CInt*
+	- int[]* -> CInt* 
+	- int[10] -> CInt[10]* (as function parameter)
+	- int[10] -> CInt[10] (as structure field or typedef).
 
- @param is_func_param : "Whether this is a type of function parameter (made for arrays)"
+	@param is_func_param : "Whether this is a type of function parameter (made for arrays)"
 *>
 fn String? ctype(
-  CXType type, 
-  GlobalVisitData* vd, 
-  bool is_func_param = false) 
-  => @pool() 
+	CXType type, 
+	GlobalVisitData* vd, 
+	bool is_func_param = false) => @pool() 
 {
-  CTypeTokens tokens = tparse::getTypeTokens(tmem, type);
+	CTypeTokens tokens = tparse::getTypeTokens(tmem, type);
 
-  CXType base_type = misc::getBaseType(type);
+	CXType base_type = misc::getBaseType(type);
 
-  // Here we get canonical type for correct comparisons 
-  // for unnamed enums or records. The main problem
-  // is that clang::getCanonicalType() practically
-  // erases the difference between alias and type itself,
-  // so we apply it under the following conditions
-  if (clang::cursor_isAnonymous(clang::getTypeDeclaration(base_type))) {
-    base_type = clang::getCanonicalType(base_type);
-  }
+	// Here we get canonical type for correct comparisons 
+	// for unnamed enums or records. The main problem
+	// is that clang::getCanonicalType() practically
+	// erases the difference between alias and type itself,
+	// so we apply it under the following conditions
+	if (clang::cursor_isAnonymous(clang::getTypeDeclaration(base_type))) {
+		base_type = clang::getCanonicalType(base_type);
+	}
 
-  DString res_dstr;
-  res_dstr.tinit();
+	DString res_dstr;
+	res_dstr.tinit();
 
-  // We will never check NAME for previous kind
-  CTypeTokenKind prev_kind = NAME;
-  tokens.@foreach(;CTypeTokenKind kind, usz str_index) {
-    String str = tparse::convertCTypeTokenToC3(kind, tokens.strs.array_view(), str_index);
+	// We will never check NAME for previous kind
+	CTypeTokenKind prev_kind = NAME;
+	tokens.@foreach(;CTypeTokenKind kind, usz str_index) {
+		String str = tparse::convertCTypeTokenToC3(kind, tokens.strs.array_view(), str_index);
 
-    switch (kind) {
-      case NAME:
-        String trans_str = trans::basicType(str) ?? trans::capply(str, base_type, vd.trans_fns.type, &vd.types_table)!;
-        res_dstr.append(trans_str);
+		switch (kind) {
+		case NAME:
+			String trans_str = trans::basicType(str) ?? trans::capply(str, base_type, vd.trans_fns.type, &vd.types_table)!;
+			res_dstr.append(trans_str);
 
-      case POINTER:
-        if (prev_kind != SIZED_ARRAY || !is_func_param) res_dstr.append("*");
+		case POINTER:
+			if (prev_kind != SIZED_ARRAY || !is_func_param) res_dstr.append("*");
 
-      case SIZED_ARRAY:
-        res_dstr.append(str);
-        if (is_func_param) res_dstr.append("*");
+		case SIZED_ARRAY:
+			res_dstr.append(str);
+			if (is_func_param) res_dstr.append("*");
 
-      case UNSIZED_ARRAY:
-        if (prev_kind != POINTER) res_dstr.append("*");
-    }
+		case UNSIZED_ARRAY:
+			if (prev_kind != POINTER) res_dstr.append("*");
+		}
 
-    prev_kind = kind;
-  };
+		prev_kind = kind;
+	};
 
-  return res_dstr.copy_str(mem); // TODO: get rid of leak
+	// TODO:
+	// Do we want it to map?
+	// seems convenient?
+	if (res_dstr.str_view() == "CChar*") {
+		return "ZString";
+	}
+	if (res_dstr.str_view() == "CChar**") {
+		return "ZString*";
+	}
+
+	return res_dstr.copy_str(mem); // TODO: get rid of leak
 }
 
 
 <*
- The same as trans::ctype but should be applied on types 
- which can possibly be pointers to functions. It is a superset
- of trans::ctype
+	The same as trans::ctype but should be applied on types 
+	which can possibly be pointers to functions. It is a superset
+	of trans::ctype
 *>
 fn String? ctypeWithPFN(
-  CXCursor cursor, 
-  GlobalVisitData* vd, 
-  bool is_func_param = false) 
-  => @pool() 
+	CXCursor cursor, 
+	GlobalVisitData* vd, 
+	bool is_func_param = false) => @pool() 
 {
-  CXType type = clang::getCursorType(cursor);
+	CXType type = clang::getCursorType(cursor);
 
-  String res;
-  if (misc::isTypePFN(type)) {
-    if (try trans_type_str = vd.types_table[type]) return trans_type_str;
+	String res;
+	if (misc::isTypePFN(type)) {
+		if (try trans_type_str = vd.types_table[type]) return trans_type_str;
 
-    ++vd.anon_fns_counter;
-    res = string::format(mem, "UnnamedPFN%d", vd.anon_fns_counter);
-    vd.types_table[type] = res;
-    
-    ttor::pfnType(vd, res, type, cursor, { .private = true });
-  } else {
-    res = trans::ctype(type, vd, is_func_param)!;
-  }
+		++vd.anon_fns_counter;
+		res = string::format(mem, "UnnamedPFN%d", vd.anon_fns_counter);
+		vd.types_table[type] = res;
+		
+		ttor::pfnType(vd, res, type, cursor, { .private = true });
+	} else {
+		res = trans::ctype(type, vd, is_func_param)!;
+	}
 
-  return res;
+	return res;
 }
 
 
 <*
- Translates tokens under cursor.
- @return "String, allocated via alloc"
+	Translates tokens under cursor.
+	@return "String, allocated via alloc"
 *>
 fn String? tokensUnderCursor(
-  Allocator alloc, 
-  CXCursor cursor, 
-  BGTransCallbacks* tfns)
-  => @pool() 
+	Allocator alloc, 
+	CXCursor cursor, 
+	BGTransCallbacks* tfns) => @pool() 
 {
-  CXString cursor_spell = clang::getCursorSpelling(cursor);
-  defer clang::disposeString(cursor_spell);
-  String cursor_str = misc::convStr(cursor_spell);
+	CXString cursor_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(cursor_spell);
+	String cursor_str = misc::convStr(cursor_spell);
 
-  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
-  CXSourceRange sr = misc::getTrueCursorExtent(cursor);
+	CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
+	CXSourceRange sr = misc::getTrueCursorExtent(cursor);
 
-  CXToken* tokens_ptr; uint tokens_len;
-  clang::tokenize(tu, sr, &tokens_ptr, &tokens_len);
-  defer clang::disposeTokens(tu, tokens_ptr, tokens_len);
-    
-  CXCursorKind kind = clang::getCursorKind(cursor);
-  
-  // Token number to start iterating from. 
-  // It's needed as sometimes cursor name can be also tokenized, 
-  // e.g. when tokenizing a macro, first token is it's name.
-  usz start_from = kind == CURSOR_MACRO_DEFINITION ? 1 : 0;
-  if (tokens_len <= start_from) return trans::EMPTY_MACRO_VAL~;
+	CXToken* tokens_ptr; uint tokens_len;
+	clang::tokenize(tu, sr, &tokens_ptr, &tokens_len);
+	defer clang::disposeTokens(tu, tokens_ptr, tokens_len);
+		
+	CXCursorKind kind = clang::getCursorKind(cursor);
+	
+	// Token number to start iterating from. 
+	// It's needed as sometimes cursor name can be also tokenized, 
+	// e.g. when tokenizing a macro, first token is it's name.
+	usz start_from = kind == CURSOR_MACRO_DEFINITION ? 1 : 0;
+	if (tokens_len <= start_from) return trans::EMPTY_MACRO_VAL~;
 
-  DString res;
-  res.init(mem); // res.append() falls into infinite loop if use temp allocator
-  defer res.free();
-  
-  bool is_in_func_macro;
-  foreach (&token : tokens_ptr[start_from..tokens_len-1])
-  {
-    CXTokenKind token_kind = clang::getTokenKind(*token);
-    CXString token_spell = clang::getTokenSpelling(tu, *token);
-    defer clang::disposeString(token_spell);
-    String token_str = misc::convStr(token_spell);
+	DString res;
+	res.init(mem); // res.append() falls into infinite loop if use temp allocator
+	defer res.free();
+	
+	bool is_in_func_macro;
+	foreach (&token : tokens_ptr[start_from..tokens_len-1])
+	{
+		CXTokenKind token_kind = clang::getTokenKind(*token);
+		CXString token_spell = clang::getTokenSpelling(tu, *token);
+		defer clang::disposeString(token_spell);
+		String token_str = misc::convStr(token_spell);
 
-    if (token_str == ")") is_in_func_macro = false;
+		if (token_str == ")") is_in_func_macro = false;
 
-    bool is_func_macro;
-    switch (token_kind) {
-      // Assume that identifier is one of:
-      // 1. Constant (macro)
-      // 2. Functional macro
-      case TOKEN_IDENTIFIER:
-        usz i = token - tokens_ptr;
-        if (i < tokens_len - 1) {
-          CXString token_spell_2 = clang::getTokenSpelling(tu, tokens_ptr[i + 1]);
-          defer clang::disposeString(token_spell_2);
-          String token_str_2 = misc::convStr(token_spell_2);
-          if (token_str_2 == "(") {
-            is_func_macro = true;
-            is_in_func_macro = true;
-          }
-        }
+		bool is_func_macro;
+		switch (token_kind) {
+		// Assume that identifier is one of:
+		// 1. Constant (macro)
+		// 2. Functional macro
+		case TOKEN_IDENTIFIER:
+			usz i = token - tokens_ptr;
+			if (i < tokens_len - 1) {
+			CXString token_spell_2 = clang::getTokenSpelling(tu, tokens_ptr[i + 1]);
+			defer clang::disposeString(token_spell_2);
+			String token_str_2 = misc::convStr(token_spell_2);
+			if (token_str_2 == "(") {
+				is_func_macro = true;
+				is_in_func_macro = true;
+			}
+			}
 
-        if (is_func_macro) {
-          res.append("@");
-          res.append(trans::apply(token_str, tfns.func_macro)!);
-        } else {
-          res.append(trans::apply(token_str, tfns.constant, tmem))!;
-        }
+			if (is_func_macro) {
+			res.append("@");
+			res.append(trans::apply(token_str, tfns.func_macro)!);
+			} else {
+			res.append(trans::apply(token_str, tfns.constant, tmem))!;
+			}
 
-      case TOKEN_LITERAL:
-        res.append(trans::literal(tmem, token_str));
+		case TOKEN_LITERAL:
+			res.append(trans::literal(tmem, token_str));
 
-      case TOKEN_KEYWORD:
-      case TOKEN_PUNCTUATION:
-      case TOKEN_COMMENT:
-        res.append(token_str);
-    }
-  };
+		case TOKEN_KEYWORD:
+		case TOKEN_PUNCTUATION:
+		case TOKEN_COMMENT:
+			res.append(token_str);
+		}
+  	};
 
-  // If we finished tokenizing but we haven't encountered
-  // ')' at the end, append it to result. Probably a bug of
-  // a libclang that it skips ')' if macro is expanded at the
-  // end of a line.
-  if (is_in_func_macro) {
-    res.append(")");
-  }
+	// If we finished tokenizing but we haven't encountered
+	// ')' at the end, append it to result. Probably a bug of
+	// a libclang that it skips ')' if macro is expanded at the
+	// end of a line.
+	if (is_in_func_macro) {
+		res.append(")");
+	}
 
-  return res.copy_str(alloc);
+	return res.copy_str(alloc);
 }
 
 
@@ -241,8 +247,7 @@ fn String? tokensUnderCursor(
 *>
 fn String literal(
   Allocator alloc,
-  String str)
-  => @pool()
+  String str) => @pool()
 {
   // If it's a string or empty literal
   if (str.len == 0 || str[0] == '"') return str;

--- a/bindgen.c3l/src/trans.c3
+++ b/bindgen.c3l/src/trans.c3
@@ -82,7 +82,7 @@ fn String? ctype(
   // is that clang::getCanonicalType() practically
   // erases the difference between alias and type itself,
   // so we apply it under the following conditions
-  if (clang::isAnonymous_Cursor(clang::getTypeDeclaration(base_type))) {
+  if (clang::cursor_isAnonymous(clang::getTypeDeclaration(base_type))) {
     base_type = clang::getCanonicalType(base_type);
   }
 
@@ -161,7 +161,7 @@ fn String? tokensUnderCursor(
   defer clang::disposeString(cursor_spell);
   String cursor_str = misc::convStr(cursor_spell);
 
-  CXTranslationUnit tu = clang::getTranslationUnit_Cursor(cursor);
+  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
   CXSourceRange sr = misc::getTrueCursorExtent(cursor);
 
   CXToken* tokens_ptr; uint tokens_len;
@@ -173,7 +173,7 @@ fn String? tokensUnderCursor(
   // Token number to start iterating from. 
   // It's needed as sometimes cursor name can be also tokenized, 
   // e.g. when tokenizing a macro, first token is it's name.
-  usz start_from = kind == clang::CURSOR_MACRO_DEFINITION ? 1 : 0;
+  usz start_from = kind == CURSOR_MACRO_DEFINITION ? 1 : 0;
   if (tokens_len <= start_from) return trans::EMPTY_MACRO_VAL~;
 
   DString res;
@@ -195,7 +195,7 @@ fn String? tokensUnderCursor(
       // Assume that identifier is one of:
       // 1. Constant (macro)
       // 2. Functional macro
-      case clang::TOKEN_IDENTIFIER:
+      case TOKEN_IDENTIFIER:
         usz i = token - tokens_ptr;
         if (i < tokens_len - 1) {
           CXString token_spell_2 = clang::getTokenSpelling(tu, tokens_ptr[i + 1]);
@@ -214,12 +214,12 @@ fn String? tokensUnderCursor(
           res.append(trans::apply(token_str, tfns.constant, tmem))!;
         }
 
-      case clang::TOKEN_LITERAL:
+      case TOKEN_LITERAL:
         res.append(trans::literal(tmem, token_str));
 
-      case clang::TOKEN_KEYWORD:
-      case clang::TOKEN_PUNCTUATION:
-      case clang::TOKEN_COMMENT:
+      case TOKEN_KEYWORD:
+      case TOKEN_PUNCTUATION:
+      case TOKEN_COMMENT:
         res.append(token_str);
     }
   };

--- a/bindgen.c3l/src/translators.c3
+++ b/bindgen.c3l/src/translators.c3
@@ -14,310 +14,322 @@
 *>
 module bgimpl::ttor;
 import bgimpl,
-       std::io, 
-       clang, 
-       std::collections::list;
+		std::io, 
+		clang, 
+		std::collections::list;
 
 
 <*
- Global variable or const declaration
- @require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
+	Global variable or const declaration
+	@require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
 *>
 fn usz? varDecl(
-  GlobalVisitData* vd,
-  CXCursor cursor)
-  @maydiscard 
-  => @pool() 
+	GlobalVisitData* vd,
+	CXCursor cursor)
+	@maydiscard 
+	=> @pool() 
 {
-  CXType type = clang::getCursorType(cursor);
+	CXType type = clang::getCursorType(cursor);
+	String docs;
+	if (vd.use_docs) {
+		docs = misc::getCursorDoc(cursor, tmem);
+	}
 
-  if (clang::isConstQualifiedType(type)) {
-    return ttor::constDecl(vd, cursor);
-  } else {
-    CXString cursor_spell = clang::getCursorSpelling(cursor);
-    defer clang::disposeString(cursor_spell);
-    String cursor_str = misc::convStr(cursor_spell);
+	if (clang::isConstQualifiedType(type)) {
+		return ttor::constDecl(vd, cursor);
+	} else {
+		CXString cursor_spell = clang::getCursorSpelling(cursor);
+		defer clang::disposeString(cursor_spell);
+		String cursor_str = misc::convStr(cursor_spell);
 
-    String rhs_val = "";
-    if (misc::getTopChildrenNumber(cursor) > 0) {
-      rhs_val = valgen::apply(tmem, cursor_str, vd.gen_fns.variable);
-      if (rhs_val == "") {
-        err::warn(vd.no_verbose, "Global variable '%s' contains default value and value generator function return empty string, so complete it manually", cursor_str);
-      }
-    }
-    
-    String? name = trans::apply(cursor_str, vd.trans_fns.variable);
-    if (catch name) {
-      err::warn(vd.no_verbose, "Global variable '%s' is ignored", cursor_str);
-      return 0;
-    }
+		String rhs_val = "";
+		if (misc::getTopChildrenNumber(cursor) > 0) {
+		rhs_val = valgen::apply(tmem, cursor_str, vd.gen_fns.variable);
+		if (rhs_val == "") {
+			err::warn(vd.no_verbose, "Global variable '%s' contains default value and value generator function return empty string, so complete it manually", cursor_str);
+		}
+		}
+		
+		String? name = trans::apply(cursor_str, vd.trans_fns.variable);
+		if (catch name) {
+		err::warn(vd.no_verbose, "Global variable '%s' is ignored", cursor_str);
+		return 0;
+		}
 
-    String? trans_type_str = trans::ctypeWithPFN(cursor, vd);
-    if (catch trans_type_str) {
-      CXString type_spell = clang::getTypeSpelling(type);
-      defer clang::disposeString(type_spell);
-      String type_str = misc::convStr(type_spell);
+		String? trans_type_str = trans::ctypeWithPFN(cursor, vd);
+		if (catch trans_type_str) {
+		CXString type_spell = clang::getTypeSpelling(type);
+		defer clang::disposeString(type_spell);
+		String type_str = misc::convStr(type_spell);
 
-      err::warn(vd.no_verbose, "Can't translate global variable '%s' as it's type name '%s' is ignored", cursor_str, type_str);
-      return 0;
-    }
+		err::warn(vd.no_verbose, "Can't translate global variable '%s' as it's type name '%s' is ignored", cursor_str, type_str);
+		return 0;
+		}
 
-    valgen::moduleWrap(vd, cursor_str);
+		valgen::moduleWrap(vd, cursor_str);
 
-    WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.gen_fns);
-    return wter::varDecl(vd.out, &vd.write_state, trans_type_str, name, rhs_val, attrs);
-  }
+		WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.gen_fns);
+		return wter::varDecl(vd.out, &vd.write_state, trans_type_str, name, rhs_val, docs, attrs);
+	}
 }
 
 
 <*
- Global constant declaration
- @require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
+	Global constant declaration
+	@require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
 *>
 fn usz? constDecl(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard => @pool()
+	GlobalVisitData* vd, 
+	CXCursor cursor) 
+	@maydiscard => @pool()
 {
-  CXString cursor_spell = clang::getCursorSpelling(cursor);
-  defer clang::disposeString(cursor_spell);
-  String cursor_str = misc::convStr(cursor_spell);
+	CXString cursor_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(cursor_spell);
+	String cursor_str = misc::convStr(cursor_spell);
 
-  if (misc::isCursorForwardDeclared(cursor)) {
-    err::warn(vd.no_verbose, "Const '%s' is forward declared, skipping this declaration...", cursor_str);
-    return 0;
-  }
+	if (misc::isCursorForwardDeclared(cursor)) {
+		err::warn(vd.no_verbose, "Const '%s' is forward declared, skipping this declaration...", cursor_str);
+		return 0;
+	}
 
-  ConstVisitData vd_const = { 
-    .g = vd,
-    .allocator = tmem,
-    .val = valgen::apply(tmem, cursor_str, vd.gen_fns.constant),
-  };
+	ConstVisitData vd_const = { 
+		.g = vd,
+		.allocator = tmem,
+		.val = valgen::apply(tmem, cursor_str, vd.gen_fns.constant),
+	};
 
-  // If value is not generated manually, visit tokens.
-  if (vd_const.val == "") {
-    // Visit rhs of var declaration and translate 
-    // there everything, that is identifier
-    clang::visitChildren(cursor, &vtor::constDecl, (CXClientData) &vd_const);
-  }
+	// If value is not generated manually, visit tokens.
+	if (vd_const.val == "") {
+		// Visit rhs of var declaration and translate 
+		// there everything, that is identifier
+		clang::visitChildren(cursor, &vtor::constDecl, (CXClientData) &vd_const);
+	}
 
-  String? name = trans::apply(cursor_str, vd.trans_fns.constant);
-  if (catch name) {
-    err::warn(vd.no_verbose, "Constant '%s' is ignored", cursor_str);
-    return 0;
-  }
+	String? name = trans::apply(cursor_str, vd.trans_fns.constant);
+	if (catch name) {
+		err::warn(vd.no_verbose, "Constant '%s' is ignored", cursor_str);
+		return 0;
+	}
 
-  String? trans_type_str = trans::ctypeWithPFN(cursor, vd);
-  if (catch trans_type_str) {
-    CXString type_spell = clang::getTypeSpelling(clang::getCursorType(cursor));
-    defer clang::disposeString(type_spell);
-    String type_str = misc::convStr(type_spell);
+	String? trans_type_str = trans::ctypeWithPFN(cursor, vd);
+	if (catch trans_type_str) {
+		CXString type_spell = clang::getTypeSpelling(clang::getCursorType(cursor));
+		defer clang::disposeString(type_spell);
+		String type_str = misc::convStr(type_spell);
 
-    err::warn(vd.no_verbose, "Can't translate constant '%s' as it's type name '%s' is ignored", cursor_str, type_str);
-    return 0;
-  }
+		err::warn(vd.no_verbose, "Can't translate constant '%s' as it's type name '%s' is ignored", cursor_str, type_str);
+		return 0;
+	}
 
-  WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.gen_fns);
-  return wter::constDecl(vd.out, &vd.write_state, trans_type_str, name, vd_const.val, attrs);
+	WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.gen_fns);
+	return wter::constDecl(vd.out, &vd.write_state, trans_type_str, name, vd_const.val, attrs);
 }
 
 
 <*
- Enum declaration and all underlying constants
- @require clang::getCursorKind(cursor) == CURSOR_ENUM_DECL
+	Enum declaration and all underlying constants
+	@require clang::getCursorKind(cursor) == CURSOR_ENUM_DECL
 *>
 fn usz? enumDecl(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard => @pool() 
+	GlobalVisitData* vd, 
+	CXCursor cursor) 
+	@maydiscard => @pool() 
 {
-  CXType enum_type = clang::getCursorType(cursor);
-  CXString enum_spell = clang::getTypeSpelling(enum_type);
-  defer clang::disposeString(enum_spell);
-  String orig_enum_name = misc::convStr(enum_spell);
+	CXType enum_type = clang::getCursorType(cursor);
+	CXString enum_spell = clang::getTypeSpelling(enum_type);
+	defer clang::disposeString(enum_spell);
+	String orig_enum_name = misc::convStr(enum_spell);
+	String docs;
+	if (vd.use_docs) {
+		docs = misc::getCursorDoc(cursor, tmem);
+	}
 
-  if (misc::isCursorForwardDeclared(cursor)) {
-    err::warn(vd.no_verbose, "Enum '%s' has forward declaration, skipping this declaration...", orig_enum_name);
-    return 0;
-  }
-  
-  CXType under_type = clang::getEnumDeclIntegerType(cursor);
-  String? under_type_str = trans::ctype(under_type, vd);
-  if (catch under_type_str) {
-    CXString orig_under_type_spell = clang::getTypeSpelling(under_type);
-    defer clang::disposeString(enum_spell);
-    String orig_under_type_str = misc::convStr(orig_under_type_spell);
+	if (misc::isCursorForwardDeclared(cursor)) {
+		err::warn(vd.no_verbose, "Enum '%s' has forward declaration, skipping this declaration...", orig_enum_name);
+		return 0;
+	}
+	
+	CXType under_type = clang::getEnumDeclIntegerType(cursor);
+	String? under_type_str = trans::ctype(under_type, vd);
+	if (catch under_type_str) {
+		CXString orig_under_type_spell = clang::getTypeSpelling(under_type);
+		defer clang::disposeString(enum_spell);
+		String orig_under_type_str = misc::convStr(orig_under_type_spell);
 
-    err::warn(vd.no_verbose, "Can't translate enum '%s' as it's underlying type '%s' is ignored", orig_enum_name, orig_under_type_str);
-    return 0;
-  }
+		err::warn(vd.no_verbose, "Can't translate enum '%s' as it's underlying type '%s' is ignored", orig_enum_name, orig_under_type_str);
+		return 0;
+	}
 
-  EnumVisitData vd_enum = {
-    .g = vd,
-	.allocator = mem,
-  };
+	EnumVisitData vd_enum = {
+		.g = vd,
+		.allocator = mem,
+	};
 
-  switch (under_type.kind) {
-    case TYPE_UCHAR:
-    case TYPE_USHORT: 
-    case TYPE_UINT:      
-    case TYPE_ULONG:
-    case TYPE_ULONGLONG: 
-      vd_enum.is_unsigned = true;
-    default:
-      vd_enum.is_unsigned = false;
-  }
+	switch (under_type.kind) {
+		case TYPE_UCHAR:
+		case TYPE_USHORT: 
+		case TYPE_UINT:      
+		case TYPE_ULONG:
+		case TYPE_ULONGLONG: 
+		vd_enum.is_unsigned = true;
+		default:
+		vd_enum.is_unsigned = false;
+	}
 
-  WriteAttrs attrs;
-  usz? acc;
-  if (clang::cursor_isAnonymous(cursor)) {
-    CXType base = misc::getBaseType(enum_type);
-    vd.types_table[base] = under_type_str;
+	WriteAttrs attrs;
+	usz? acc;
+	if (clang::cursor_isAnonymous(cursor)) {
+		CXType base = misc::getBaseType(enum_type);
+		vd.types_table[base] = under_type_str;
 
-    vd_enum.enum_name = under_type_str;
-  } else {
-    String? tmp = trans::ctype(enum_type, vd);
-    if (catch tmp) {
-      err::warn(vd.no_verbose, "Enum '%s' is ignored", orig_enum_name);
-      return 0;
-    }
+		vd_enum.enum_name = under_type_str;
+	} else {
+		String? tmp = trans::ctype(enum_type, vd);
+		if (catch tmp) {
+		err::warn(vd.no_verbose, "Enum '%s' is ignored", orig_enum_name);
+		return 0;
+		}
 
-  	if (clang::visitChildren(cursor, &vtor::enumField, (CXClientData)&vd_enum) != 0) return 0;
+		if (clang::visitChildren(cursor, &vtor::enumField, (CXClientData)&vd_enum) != 0) return 0;
 
-    valgen::moduleWrap(vd, orig_enum_name);
-    attrs = valgen::getWriteAttrs(tmem, orig_enum_name, vd.gen_fns);
-    acc = wter::enumDecl(vd.out, &vd.write_state, vd_enum.fields.array_view(), tmp, under_type_str);
-    
-    vd_enum.enum_name = tmp;
-  }
+		valgen::moduleWrap(vd, orig_enum_name);
+		attrs = valgen::getWriteAttrs(tmem, orig_enum_name, vd.gen_fns);
+		acc = wter::enumDecl(vd.out, &vd.write_state, vd_enum.fields.array_view(), tmp, under_type_str, docs);
+		
+		vd_enum.enum_name = tmp;
+	}
 
-  return acc;
+	return acc;
 }
 
 
 <*
- Function delcaration
- @require clang::getCursorKind(cursor) == CURSOR_FUNCTION_DECL
+	Function delcaration
+	@require clang::getCursorKind(cursor) == CURSOR_FUNCTION_DECL
 *>
 fn usz? func(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard 
-  => @pool()
+	GlobalVisitData* vd, 
+	CXCursor cursor) 
+	@maydiscard => @pool()
 {
-  FuncVisitData vd_func = {
-    .g = vd,
-    .allocator = tmem,
-  };
+	FuncVisitData vd_func = {
+		.g = vd,
+		.allocator = tmem,
+	};
 
-  vd_func.params.tinit(4);
+	vd_func.params.tinit(4);
 
-  // Translate function parameters and store them into vd_func.params
-  if (clang::visitChildren(cursor, &vtor::func, (CXClientData) &vd_func) != 0) return 0;
-  
-  CXString func_spell = clang::getCursorSpelling(cursor);
-  defer clang::disposeString(func_spell);
-  String func_str = misc::convStr(func_spell);
+	String docs;
+	if (vd.use_docs) {
+		docs = misc::getCursorDoc(cursor, mem);
+	}
 
-  String? trans_func_str = trans::apply(func_str, vd.trans_fns.func);
-  if (catch trans_func_str) {
-    err::warn(vd.no_verbose, "Function '%s' is ignored", func_str);
-    return 0;
-  }
+	// Translate function parameters and store them into vd_func.params
+	if (clang::visitChildren(cursor, &vtor::func, (CXClientData) &vd_func) != 0) return 0;
+	
+	CXString func_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(func_spell);
+	String func_str = misc::convStr(func_spell);
 
-  CXType ret_type = clang::getCursorResultType(cursor); 
-  if (misc::isTypePFN(ret_type)) {
-    err::warn(vd.no_verbose, "Function '%s' returns a pointer to function, which I can't translate, skipping...", func_str);
-    return 0;
-  }
+	String? trans_func_str = trans::apply(func_str, vd.trans_fns.func);
+	if (catch trans_func_str) {
+		err::warn(vd.no_verbose, "Function '%s' is ignored", func_str);
+		return 0;
+	}
 
-  String? trans_ret_type_str = trans::ctype(ret_type, vd);
-  if (catch trans_ret_type_str) {
-    CXString type_spell = clang::getTypeSpelling(ret_type);
-    defer clang::disposeString(type_spell);
-    String type_str = misc::convStr(type_spell);
+	CXType ret_type = clang::getCursorResultType(cursor); 
+	if (misc::isTypePFN(ret_type)) {
+		err::warn(vd.no_verbose, "Function '%s' returns a pointer to function, which I can't translate, skipping...", func_str);
+		return 0;
+	}
 
-    err::warn(vd.no_verbose, "Can't translate function '%s' as it's return type '%s' is ignored", func_str, type_str);
-    return 0;
-  }
+	String? trans_ret_type_str = trans::ctype(ret_type, vd);
+	if (catch trans_ret_type_str) {
+		CXString type_spell = clang::getTypeSpelling(ret_type);
+		defer clang::disposeString(type_spell);
+		String type_str = misc::convStr(type_spell);
 
-  valgen::moduleWrap(vd, func_str);
+		err::warn(vd.no_verbose, "Can't translate function '%s' as it's return type '%s' is ignored", func_str, type_str);
+		return 0;
+	}
 
-  WriteAttrs attrs = valgen::getWriteAttrs(tmem, func_str, vd.gen_fns);
-  return wter::func(vd.out, &vd.write_state, vd_func.params.array_view(), trans_ret_type_str, func_str, trans_func_str, attrs);
+	valgen::moduleWrap(vd, func_str);
+
+	WriteAttrs attrs = valgen::getWriteAttrs(tmem, func_str, vd.gen_fns);
+	return wter::func(vd.out, &vd.write_state, vd_func.params.array_view(), trans_ret_type_str, func_str, trans_func_str, docs, attrs);
 }
 
 
 <*
- Macro definition
- @require clang::getCursorKind(cursor) == CURSOR_MACRO_DEFINITION
+	Macro definition
+	@require clang::getCursorKind(cursor) == CURSOR_MACRO_DEFINITION
 *>
 fn usz? macroDef(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard
+	GlobalVisitData* vd, 
+	CXCursor cursor) 
+	@maydiscard
 {
-  return clang::cursor_isMacroFunctionLike(cursor) ? 
-    ttor::funcMacroDef(vd, cursor) :
-    ttor::constMacroDef(vd, cursor) @inline;
+	return clang::cursor_isMacroFunctionLike(cursor) ? 
+		ttor::funcMacroDef(vd, cursor) :
+		ttor::constMacroDef(vd, cursor) @inline;
 }
 
 
 <*
- Functional macro definition
+	Functional macro definition
 *>
 fn usz? funcMacroDef(
-  GlobalVisitData* vd,
-  CXCursor cursor)
-  @maydiscard => @pool()
+	GlobalVisitData* vd,
+	CXCursor cursor)
+	@maydiscard => @pool()
 {
-  CXString macro_spell = clang::getCursorSpelling(cursor);
-  defer clang::disposeString(macro_spell);
-  String macro_str = misc::convStr(macro_spell);
+	CXString macro_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(macro_spell);
+	String macro_str = misc::convStr(macro_spell);
 
-  String? trans_macro_str = trans::apply(macro_str, vd.trans_fns.func_macro, tmem);
-  if (catch trans_macro_str) {
-    err::warn(vd.no_verbose, "Functional macro '%s' is ignored", macro_str);
-    return 0;
-  }
+	String? trans_macro_str = trans::apply(macro_str, vd.trans_fns.func_macro, tmem);
+	if (catch trans_macro_str) {
+		err::warn(vd.no_verbose, "Functional macro '%s' is ignored", macro_str);
+		return 0;
+	}
 
-  String macro_body = valgen::apply(tmem, macro_str, vd.gen_fns.func_macro);
-  if (macro_body == "") {
-    err::warn(vd.no_verbose, "Macro '%s' (@%s) is function-like and generator function returned empty string so you should complete it's body manually", macro_str, trans_macro_str);
-  }
+	String macro_body = valgen::apply(tmem, macro_str, vd.gen_fns.func_macro);
+	if (macro_body == "") {
+		err::warn(vd.no_verbose, "Macro '%s' (@%s) is function-like and generator function returned empty string so you should complete it's body manually", macro_str, trans_macro_str);
+	}
 
-  List{String} params;
-  params.tinit();
+	List{String} params;
+	params.tinit();
 
-  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
-  CXSourceRange sr = misc::getTrueCursorExtent(cursor); // We don't need to do getTrueCursorExtent as bug is not occured under macro declaration
-  
-  CXToken* tokens_ptr; uint tokens_len;
-  clang::tokenize(tu, sr, &tokens_ptr, &tokens_len);
-  defer clang::disposeTokens(tu, tokens_ptr, tokens_len);
+	CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
+	CXSourceRange sr = misc::getTrueCursorExtent(cursor); // We don't need to do getTrueCursorExtent as bug is not occured under macro declaration
+	
+	CXToken* tokens_ptr; uint tokens_len;
+	clang::tokenize(tu, sr, &tokens_ptr, &tokens_len);
+	defer clang::disposeTokens(tu, tokens_ptr, tokens_len);
 
-  foreach (&token : tokens_ptr[2..tokens_len-1]) {
-    CXString token_spell = clang::getTokenSpelling(tu, *token);
-    defer clang::disposeString(token_spell);
-    String token_str = misc::convStr(token_spell);
+	foreach (&token : tokens_ptr[2..tokens_len-1]) {
+		CXString token_spell = clang::getTokenSpelling(tu, *token);
+		defer clang::disposeString(token_spell);
+		String token_str = misc::convStr(token_spell);
 
-    // First token is the name of a macro and second token is left brace so start from the third one
-    if (token_str == ")") break;
-    if (token_str != ",") {
-      String? trans_token_str = trans::apply(token_str, vd.trans_fns.variable, tmem);
-      if (catch trans_token_str) {
-        err::warn(vd.no_verbose, "Can't translate functional macro '%s' as it's parameter '%s' is ignored", macro_str, token_str);
-        return 0;
-      }
+		// First token is the name of a macro and second token is left brace so start from the third one
+		if (token_str == ")") break;
+		if (token_str != ",") {
+		String? trans_token_str = trans::apply(token_str, vd.trans_fns.variable, tmem);
+		if (catch trans_token_str) {
+			err::warn(vd.no_verbose, "Can't translate functional macro '%s' as it's parameter '%s' is ignored", macro_str, token_str);
+			return 0;
+		}
 
-      params.push(trans_token_str);
-    }
-  }
+		params.push(trans_token_str);
+		}
+	}
 
-  valgen::moduleWrap(vd, macro_str);
+	valgen::moduleWrap(vd, macro_str);
 
-  WriteAttrs attrs = valgen::getWriteAttrs(tmem, macro_str, vd.gen_fns);
-  return wter::funcMacro(vd.out, &vd.write_state, params.array_view(), trans_macro_str, macro_body, attrs);
+	WriteAttrs attrs = valgen::getWriteAttrs(tmem, macro_str, vd.gen_fns);
+	return wter::funcMacro(vd.out, &vd.write_state, params.array_view(), trans_macro_str, macro_body, attrs);
 }
 
 
@@ -325,258 +337,261 @@ fn usz? funcMacroDef(
  Constant macro definition
 *>
 fn usz? constMacroDef(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard => @pool()
+	GlobalVisitData* vd, 
+	CXCursor cursor) @maydiscard => @pool()
 {
-  CXString cursor_spell = clang::getCursorSpelling(cursor);
-  defer clang::disposeString(cursor_spell);
-  String cursor_str = misc::convStr(cursor_spell);
+	CXString cursor_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(cursor_spell);
+	String cursor_str = misc::convStr(cursor_spell);
 
-  String? trans_cursor_str = trans::apply(cursor_str, vd.trans_fns.constant, tmem); 
-  if (catch trans_cursor_str) {
-    err::warn(vd.no_verbose, "Constant '%s' is ignored", cursor_str);
-    return 0;
-  }
+	String? trans_cursor_str = trans::apply(cursor_str, vd.trans_fns.constant, tmem); 
+	if (catch trans_cursor_str) {
+		err::warn(vd.no_verbose, "Constant '%s' is ignored", cursor_str);
+		return 0;
+	}
 
-  String val = valgen::apply(tmem, cursor_str, vd.gen_fns.constant); 
-  if (val == "") {
-    String? t = trans::tokensUnderCursor(tmem, cursor, &vd.trans_fns);
-    if (catch exc = t) {
-      switch (exc) {
-        case trans::NAME_IGNORED:
-          err::warn(vd.no_verbose, "Can't translate constant '%s' as it's rhs comprises ignored name", cursor_str);
-        case trans::EMPTY_MACRO_VAL:
-          err::warn(vd.no_verbose, "Macro '%s' doesn't have value, skipping...", cursor_str);
-      }
-      return 0;
-    }
+	String val = valgen::apply(tmem, cursor_str, vd.gen_fns.constant); 
+	if (val == "") {
+		String? t = trans::tokensUnderCursor(tmem, cursor, &vd.trans_fns);
+		if (catch exc = t) {
+		switch (exc) {
+			case trans::NAME_IGNORED:
+			err::warn(vd.no_verbose, "Can't translate constant '%s' as it's rhs comprises ignored name", cursor_str);
+			case trans::EMPTY_MACRO_VAL:
+			err::warn(vd.no_verbose, "Macro '%s' doesn't have value, skipping...", cursor_str);
+		}
+		return 0;
+		}
 
-    val = t;
-  }
- 
-  valgen::moduleWrap(vd, cursor_str);
+		val = t;
+	}
+	
+	valgen::moduleWrap(vd, cursor_str);
 
-  WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.gen_fns);
-  return wter::constDecl(vd.out, &vd.write_state, "", trans_cursor_str, val, attrs);
+	WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.gen_fns);
+	return wter::constDecl(vd.out, &vd.write_state, "", trans_cursor_str, val, attrs);
 }
 
 
 <*
- Typedef declaration
- @require clang::getCursorKind(cursor) == CURSOR_TYPEDEF_DECL
+	Typedef declaration
+	@require clang::getCursorKind(cursor) == CURSOR_TYPEDEF_DECL
 *>
 fn usz? typedefDecl(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard => @pool()
+	GlobalVisitData* vd, 
+	CXCursor cursor) 
+	@maydiscard => @pool()
 {
-  CXType type = clang::getCursorType(cursor);
-  CXString type_spell = clang::getTypeSpelling(type);
-  defer clang::disposeString(type_spell);
-  String type_str = misc::convStr(type_spell);
+	CXType type = clang::getCursorType(cursor);
+	CXString type_spell = clang::getTypeSpelling(type);
+	defer clang::disposeString(type_spell);
+	String type_str = misc::convStr(type_spell);
 
-  String? trans_type_str = trans::ctype(type, vd);
-  if (catch trans_type_str) {
-    err::warn(vd.no_verbose, "Alias '%s' is ignored", type_str);
-    return 0;
-  }
+	String? trans_type_str = trans::ctype(type, vd);
+	if (catch trans_type_str) {
+		err::warn(vd.no_verbose, "Alias '%s' is ignored", type_str);
+		return 0;
+	}
 
-  CXType under_type = clang::getTypedefDeclUnderlyingType(cursor);
+	CXType under_type = clang::getTypedefDeclUnderlyingType(cursor);
 
-  valgen::moduleWrap(vd, type_str);
-  WriteAttrs attrs = valgen::getWriteAttrs(tmem, type_str, vd.gen_fns);
+	valgen::moduleWrap(vd, type_str);
+	WriteAttrs attrs = valgen::getWriteAttrs(tmem, type_str, vd.gen_fns);
 
-  if (misc::isTypePFN(under_type)) {
-    return ttor::pfnType(vd, trans_type_str, under_type, cursor, attrs);
-  } else {
-    TypedefVisitData vd_inner = {
-      .g = vd,
-      .under_type = under_type,
-    };
+	if (misc::isTypePFN(under_type)) {
+		return ttor::pfnType(vd, trans_type_str, under_type, cursor, attrs);
+	} else {
+		TypedefVisitData vd_inner = {
+		.g = vd,
+		.under_type = under_type,
+		};
 
-    clang::visitChildren(cursor, &vtor::typedefDecl, (CXClientData) &vd_inner);
+		clang::visitChildren(cursor, &vtor::typedefDecl, (CXClientData) &vd_inner);
 
-    // Translate alias
-    String? under_type_name = trans::ctype(under_type, vd);
-    if (catch under_type_name) {
-      err::warn(vd.no_verbose, "Can't translate alias as it's underlying type '%s' is ignored", type_str);
-      return 0;
-    }
+		// Translate alias
+		String? under_type_name = trans::ctype(under_type, vd);
+		if (catch under_type_name) {
+		err::warn(vd.no_verbose, "Can't translate alias as it's underlying type '%s' is ignored", type_str);
+		return 0;
+		}
 
-    if (!vd_inner.is_incomplete && trans_type_str == under_type_name) {
-      return 0;
-    } else {
-      return wter::typedefAlias(vd.out, &vd.write_state, trans_type_str, under_type_name, attrs);
-    }
-  }
+		if (!vd_inner.is_incomplete && trans_type_str == under_type_name) {
+		return 0;
+		} else {
+		return wter::typedefAlias(vd.out, &vd.write_state, trans_type_str, under_type_name, attrs);
+		}
+	}
 }
 
 
 <*
- Structure declaration
- @require clang::getCursorKind(cursor) == CURSOR_STRUCT_DECL
+	Structure declaration
+	@require clang::getCursorKind(cursor) == CURSOR_STRUCT_DECL
 *>
 fn usz? structDecl(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard
+	GlobalVisitData* vd, 
+	CXCursor cursor) 
+	@maydiscard
 {
-  return ttor::recordDecl(vd, cursor, $is_union: false);
+  	return ttor::recordDecl(vd, cursor, $is_union: false);
 }
 
 
 <*
- Union declaration
- @require  clang::getCursorKind(cursor) == CURSOR_UNION_DECL 
+	Union declaration
+	@require  clang::getCursorKind(cursor) == CURSOR_UNION_DECL 
 *>
 fn usz? unionDecl(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard
+	GlobalVisitData* vd, 
+	CXCursor cursor) 
+	@maydiscard
 {
-  return ttor::recordDecl(vd, cursor, $is_union: true);
+  	return ttor::recordDecl(vd, cursor, $is_union: true);
 }
 
 
 <*
- Both struct and union declaration helper macro
+	Both struct and union declaration helper macro
 *>
 macro usz? recordDecl(
-  GlobalVisitData* vd,
-  CXCursor cursor, 
-  bool $is_union)
-  @maydiscard => @pool()
+	GlobalVisitData* vd,
+	CXCursor cursor, 
+	bool $is_union)
+	@maydiscard => @pool()
 {
-  CXType rec_type = clang::getCursorType(cursor);
-  CXString rec_spell = clang::getTypeSpelling(rec_type);
-  defer clang::disposeString(rec_spell);
-  String orig_rec_name = misc::convStr(rec_spell);
+	CXType rec_type = clang::getCursorType(cursor);
+	CXString rec_spell = clang::getTypeSpelling(rec_type);
+	defer clang::disposeString(rec_spell);
+	String orig_rec_name = misc::convStr(rec_spell);
+	String docs;
+	if (vd.use_docs) {
+		docs = misc::getCursorDoc(cursor, tmem);
+	}
 
-  if (misc::isCursorForwardDeclared(cursor)) {
-    $if $is_union:
-      err::warn(vd.no_verbose, "Union '%s' has forward declaration, skipping this declaration...", orig_rec_name);
-    $else
-      err::warn(vd.no_verbose, "Struct '%s' has forward declaration, skipping this declaration...", orig_rec_name);
-    $endif
-    return 0;
-  }
+	if (misc::isCursorForwardDeclared(cursor)) {
+		$if $is_union:
+		err::warn(vd.no_verbose, "Union '%s' has forward declaration, skipping this declaration...", orig_rec_name);
+		$else
+		err::warn(vd.no_verbose, "Struct '%s' has forward declaration, skipping this declaration...", orig_rec_name);
+		$endif
+		return 0;
+	}
 
-  String? rec_name = trans::ctype(rec_type, vd);
+	String? rec_name = trans::ctype(rec_type, vd);
 
-  if (catch rec_name) {
-    $if $is_union:
-      err::warn(vd.no_verbose, "Union '%s' is ignored", orig_rec_name);
-    $else
-      err::warn(vd.no_verbose, "Struct '%s' is ignored", orig_rec_name);
-    $endif
-    return 0;
-  }
- 
-  if (clang::cursor_isAnonymous(cursor)) {
-    CXSourceLocation cursor_loc = clang::getCursorLocation(cursor);
-    CUInt line, col;
-    CXFile file;
-    clang::getFileLocation(cursor_loc, &file, &line, &col, null);
-    CXString file_spell = clang::getFileName(file);
-    defer clang::disposeString(file_spell);
-    String file_name = misc::convStr(file_spell);
+	if (catch rec_name) {
+		$if $is_union:
+		err::warn(vd.no_verbose, "Union '%s' is ignored", orig_rec_name);
+		$else
+		err::warn(vd.no_verbose, "Struct '%s' is ignored", orig_rec_name);
+		$endif
+		return 0;
+	}
+	
+	if (clang::cursor_isAnonymous(cursor)) {
+		CXSourceLocation cursor_loc = clang::getCursorLocation(cursor);
+		CUInt line, col;
+		CXFile file;
+		clang::getFileLocation(cursor_loc, &file, &line, &col, null);
+		CXString file_spell = clang::getFileName(file);
+		defer clang::disposeString(file_spell);
+		String file_name = misc::convStr(file_spell);
 
-    $if $is_union:
-      err::warn(vd.no_verbose, "Can't translate union at %s:%d:%d as it's anonymous", file_name, line, col);
-    $else
-      err::warn(vd.no_verbose, "Can't translate struct at %s:%d:%d as it's anonymous", file_name, line, col);
-    $endif
-    return 0;
-  }
+		$if $is_union:
+			err::warn(vd.no_verbose, "Can't translate union at %s:%d:%d as it's anonymous", file_name, line, col);
+		$else
+			err::warn(vd.no_verbose, "Can't translate struct at %s:%d:%d as it's anonymous", file_name, line, col);
+		$endif
+		return 0;
+	}
 
-  WriteAttrs attrs = valgen::getWriteAttrs(tmem, orig_rec_name, vd.gen_fns);
+	WriteAttrs attrs = valgen::getWriteAttrs(tmem, orig_rec_name, vd.gen_fns);
 
-  // If no fields are defined, rec_type is incomplete.
-  // Then we write it as typedef to void and wrap into
-  // module if needed
-  usz fields_len = misc::getTopChildrenNumber(cursor);
-  if (fields_len == 0)  {
-    valgen::moduleWrap(vd, orig_rec_name);
-    return wter::typedefDistinct(vd.out, &vd.write_state, rec_name, "void", attrs);
-  }
+	// If no fields are defined, rec_type is incomplete.
+	// Then we write it as typedef to void and wrap into
+	// module if needed
+	usz fields_len = misc::getTopChildrenNumber(cursor);
+	if (fields_len == 0)  {
+		valgen::moduleWrap(vd, orig_rec_name);
+		return wter::typedefDistinct(vd.out, &vd.write_state, rec_name, "void", attrs);
+	}
 
-  FieldsVisitData vd_rec = {
-    .g = vd,
-    .allocator = tmem,
-    .prev_inline = clang::getNullCursor(),
-  };
+	FieldsVisitData vd_rec = {
+		.g = vd,
+		.allocator = tmem,
+		.prev_inline = clang::getNullCursor(),
+	};
 
-  vd_rec.fields.init(vd_rec.allocator);
+	vd_rec.fields.init(vd_rec.allocator);
 
-  // Translate record fields and store them into vd_rec.fields
-  if (clang::visitChildren(cursor, &vtor::fields, (CXClientData) &vd_rec) != 0) return 0;
+	// Translate record fields and store them into vd_rec.fields
+	if (clang::visitChildren(cursor, &vtor::fields, (CXClientData) &vd_rec) != 0) return 0;
 
-  C3Fields? c3_fields = tparse::getC3Fields(tmem, vd_rec.fields);
-  if (catch c3_fields) {
-    $if $is_union:
-      err::warn(vd.no_verbose, "Can't translate bit fields within union '%s', skipping...", orig_rec_name);
-    $else
-      err::warn(vd.no_verbose, "Can't translate bit fields within struct '%s', skipping...", orig_rec_name);
-    $endif
-    return 0;
-  }
+	C3Fields? c3_fields = tparse::getC3Fields(tmem, vd_rec.fields);
+	if (catch c3_fields) {
+		$if $is_union:
+		err::warn(vd.no_verbose, "Can't translate bit fields within union '%s', skipping...", orig_rec_name);
+		$else
+		err::warn(vd.no_verbose, "Can't translate bit fields within struct '%s', skipping...", orig_rec_name);
+		$endif
+		return 0;
+	}
 
-  if (c3_fields.bit.len() > 0) {
-    $if $is_union:
-      err::warn(vd.no_verbose, "Bit fields encountered within union '%s'!", orig_rec_name);
-    $else
-      err::warn(vd.no_verbose, "Bit fields encountered within struct '%s'!", orig_rec_name);
-    $endif
-  }
+	if (c3_fields.bit.len() > 0) {
+		$if $is_union:
+		err::warn(vd.no_verbose, "Bit fields encountered within union '%s'!", orig_rec_name);
+		$else
+		err::warn(vd.no_verbose, "Bit fields encountered within struct '%s'!", orig_rec_name);
+		$endif
+	}
 
-  valgen::moduleWrap(vd, orig_rec_name);
-  $if $is_union:
-    return wter::unionDecl(vd.out, &vd.write_state, rec_name, &c3_fields, 0, attrs);
-  $else
-    return wter::structDecl(vd.out, &vd.write_state, rec_name, &c3_fields, 0, attrs);
-  $endif
+	valgen::moduleWrap(vd, orig_rec_name);
+	$if $is_union:
+		return wter::unionDecl(vd.out, &vd.write_state, rec_name, &c3_fields, 0, attrs);
+	$else
+		return wter::structDecl(vd.out, &vd.write_state, rec_name, &c3_fields, 0, docs, attrs);
+	$endif
 }
 
 
 <*
- Pointer to function type (not top-level declaration)
+ 	Pointer to function type (not top-level declaration)
 *>
 fn usz? pfnType(
-  GlobalVisitData* vd, 
-  String name,
-  CXType type, 
-  CXCursor cursor,
-  WriteAttrs attribs = {}) 
-  @maydiscard 
-  => @pool()
+	GlobalVisitData* vd, 
+	String name,
+	CXType type, 
+	CXCursor cursor,
+	WriteAttrs attribs = {}) 
+	@maydiscard 
+	=> @pool()
 {
-  FuncVisitData vd_func = {
-    .g = vd,
-    .allocator = tmem,
-  };
+	FuncVisitData vd_func = {
+		.g = vd,
+		.allocator = tmem,
+	};
 
-  vd_func.params.tinit(4);
-  
-  CXType ret_type = clang::getResultType(clang::getPointeeType(type));
-  String? trans_ret_type_str = trans::ctype(ret_type, vd);
+	vd_func.params.tinit(4);
+	
+	CXType ret_type = clang::getResultType(clang::getPointeeType(type));
+	String? trans_ret_type_str = trans::ctype(ret_type, vd);
 
-  if (catch trans_ret_type_str) {
-    CXString ret_type_spell = clang::getTypeSpelling(ret_type);
-    defer clang::disposeString(ret_type_spell);
-    String ret_type_str = misc::convStr(ret_type_spell);
+	if (catch trans_ret_type_str) {
+		CXString ret_type_spell = clang::getTypeSpelling(ret_type);
+		defer clang::disposeString(ret_type_spell);
+		String ret_type_str = misc::convStr(ret_type_spell);
 
-    CXString cursor_spell = clang::getCursorSpelling(cursor);
-    defer clang::disposeString(cursor_spell);
-    String cursor_str = misc::convStr(cursor_spell);
+		CXString cursor_spell = clang::getCursorSpelling(cursor);
+		defer clang::disposeString(cursor_spell);
+		String cursor_str = misc::convStr(cursor_spell);
 
-    err::warn(vd.no_verbose, "Can't translate function pointer alias '%s' as it's return type '%s' is ignored", cursor_str, ret_type_str);
-    return 0;
-  }
+		err::warn(vd.no_verbose, "Can't translate function pointer alias '%s' as it's return type '%s' is ignored", cursor_str, ret_type_str);
+		return 0;
+	}
 
-  // Translate function parameters and store them into vd_struct.fields
-  if (clang::visitChildren(cursor, &vtor::func, (CXClientData) &vd_func) != 0) return 0;
+	// Translate function parameters and store them into vd_struct.fields
+	if (clang::visitChildren(cursor, &vtor::func, (CXClientData) &vd_func) != 0) return 0;
 
-  return wter::typedefFunc(vd.out, &vd.write_state, name, trans_ret_type_str, vd_func.params.array_view(), attribs: attribs);
+	return wter::typedefFunc(vd.out, &vd.write_state, name, trans_ret_type_str, vd_func.params.array_view(), attribs: attribs);
 }
 

--- a/bindgen.c3l/src/translators.c3
+++ b/bindgen.c3l/src/translators.c3
@@ -23,7 +23,7 @@ import bgimpl,
 	Global variable or const declaration
 	@require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
 *>
-fn usz? varDecl(
+fn sz? varDecl(
 	GlobalVisitData* vd,
 	CXCursor cursor)
 	@maydiscard 
@@ -78,7 +78,7 @@ fn usz? varDecl(
 	Global constant declaration
 	@require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
 *>
-fn usz? constDecl(
+fn sz? constDecl(
 	GlobalVisitData* vd, 
 	CXCursor cursor) 
 	@maydiscard => @pool()
@@ -130,7 +130,7 @@ fn usz? constDecl(
 	Enum declaration and all underlying constants
 	@require clang::getCursorKind(cursor) == CURSOR_ENUM_DECL
 *>
-fn usz? enumDecl(
+fn sz? enumDecl(
 	GlobalVisitData* vd, 
 	CXCursor cursor) 
 	@maydiscard => @pool() 
@@ -177,7 +177,7 @@ fn usz? enumDecl(
 	}
 
 	WriteAttrs attrs;
-	usz? acc;
+	sz? acc;
 	if (clang::cursor_isAnonymous(cursor)) {
 		CXType base = misc::getBaseType(enum_type);
 		vd.types_table[base] = under_type_str;
@@ -207,7 +207,7 @@ fn usz? enumDecl(
 	Function delcaration
 	@require clang::getCursorKind(cursor) == CURSOR_FUNCTION_DECL
 *>
-fn usz? func(
+fn sz? func(
 	GlobalVisitData* vd, 
 	CXCursor cursor) 
 	@maydiscard => @pool()
@@ -264,7 +264,7 @@ fn usz? func(
 	Macro definition
 	@require clang::getCursorKind(cursor) == CURSOR_MACRO_DEFINITION
 *>
-fn usz? macroDef(
+fn sz? macroDef(
 	GlobalVisitData* vd, 
 	CXCursor cursor) 
 	@maydiscard
@@ -278,7 +278,7 @@ fn usz? macroDef(
 <*
 	Functional macro definition
 *>
-fn usz? funcMacroDef(
+fn sz? funcMacroDef(
 	GlobalVisitData* vd,
 	CXCursor cursor)
 	@maydiscard => @pool()
@@ -336,7 +336,7 @@ fn usz? funcMacroDef(
 <*
  Constant macro definition
 *>
-fn usz? constMacroDef(
+fn sz? constMacroDef(
 	GlobalVisitData* vd, 
 	CXCursor cursor) @maydiscard => @pool()
 {
@@ -377,7 +377,7 @@ fn usz? constMacroDef(
 	Typedef declaration
 	@require clang::getCursorKind(cursor) == CURSOR_TYPEDEF_DECL
 *>
-fn usz? typedefDecl(
+fn sz? typedefDecl(
 	GlobalVisitData* vd, 
 	CXCursor cursor) 
 	@maydiscard => @pool()
@@ -428,7 +428,7 @@ fn usz? typedefDecl(
 	Structure declaration
 	@require clang::getCursorKind(cursor) == CURSOR_STRUCT_DECL
 *>
-fn usz? structDecl(
+fn sz? structDecl(
 	GlobalVisitData* vd, 
 	CXCursor cursor) 
 	@maydiscard
@@ -441,7 +441,7 @@ fn usz? structDecl(
 	Union declaration
 	@require  clang::getCursorKind(cursor) == CURSOR_UNION_DECL 
 *>
-fn usz? unionDecl(
+fn sz? unionDecl(
 	GlobalVisitData* vd, 
 	CXCursor cursor) 
 	@maydiscard
@@ -453,7 +453,7 @@ fn usz? unionDecl(
 <*
 	Both struct and union declaration helper macro
 *>
-macro usz? recordDecl(
+macro sz? recordDecl(
 	GlobalVisitData* vd,
 	CXCursor cursor, 
 	bool $is_union)
@@ -510,7 +510,7 @@ macro usz? recordDecl(
 	// If no fields are defined, rec_type is incomplete.
 	// Then we write it as typedef to void and wrap into
 	// module if needed
-	usz fields_len = misc::getTopChildrenNumber(cursor);
+	sz fields_len = misc::getTopChildrenNumber(cursor);
 	if (fields_len == 0)  {
 		valgen::moduleWrap(vd, orig_rec_name);
 		return wter::typedefDistinct(vd.out, &vd.write_state, rec_name, "void", attrs);
@@ -557,7 +557,7 @@ macro usz? recordDecl(
 <*
  	Pointer to function type (not top-level declaration)
 *>
-fn usz? pfnType(
+fn sz? pfnType(
 	GlobalVisitData* vd, 
 	String name,
 	CXType type, 

--- a/bindgen.c3l/src/translators.c3
+++ b/bindgen.c3l/src/translators.c3
@@ -21,7 +21,7 @@ import bgimpl,
 
 <*
  Global variable or const declaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_VAR_DECL
+ @require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
 *>
 fn usz? varDecl(
   GlobalVisitData* vd,
@@ -72,7 +72,7 @@ fn usz? varDecl(
 
 <*
  Global constant declaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_VAR_DECL
+ @require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
 *>
 fn usz? constDecl(
   GlobalVisitData* vd, 
@@ -124,7 +124,7 @@ fn usz? constDecl(
 
 <*
  Enum declaration and all underlying constants
- @require clang::getCursorKind(cursor) == clang::CURSOR_ENUM_DECL
+ @require clang::getCursorKind(cursor) == CURSOR_ENUM_DECL
 *>
 fn usz? enumDecl(
   GlobalVisitData* vd, 
@@ -153,15 +153,16 @@ fn usz? enumDecl(
   }
 
   EnumVisitData vd_enum = {
-    .g = vd
+    .g = vd,
+	.allocator = mem,
   };
 
   switch (under_type.kind) {
-    case clang::TYPE_UCHAR:
-    case clang::TYPE_USHORT: 
-    case clang::TYPE_UINT:      
-    case clang::TYPE_ULONG:
-    case clang::TYPE_ULONGLONG: 
+    case TYPE_UCHAR:
+    case TYPE_USHORT: 
+    case TYPE_UINT:      
+    case TYPE_ULONG:
+    case TYPE_ULONGLONG: 
       vd_enum.is_unsigned = true;
     default:
       vd_enum.is_unsigned = false;
@@ -169,7 +170,7 @@ fn usz? enumDecl(
 
   WriteAttrs attrs;
   usz? acc;
-  if (clang::isAnonymous_Cursor(cursor)) {
+  if (clang::cursor_isAnonymous(cursor)) {
     CXType base = misc::getBaseType(enum_type);
     vd.types_table[base] = under_type_str;
 
@@ -181,21 +182,22 @@ fn usz? enumDecl(
       return 0;
     }
 
+  	if (clang::visitChildren(cursor, &vtor::enumField, (CXClientData)&vd_enum) != 0) return 0;
+
     valgen::moduleWrap(vd, orig_enum_name);
     attrs = valgen::getWriteAttrs(tmem, orig_enum_name, vd.gen_fns);
-    acc = wter::enumDecl(vd.out, &vd.write_state, tmp, under_type_str);
+    acc = wter::enumDecl(vd.out, &vd.write_state, vd_enum.fields.array_view(), tmp, under_type_str);
     
     vd_enum.enum_name = tmp;
   }
 
-  clang::visitChildren(cursor, &vtor::enumDecl, (CXClientData) &vd_enum);
   return acc;
 }
 
 
 <*
  Function delcaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_FUNCTION_DECL
+ @require clang::getCursorKind(cursor) == CURSOR_FUNCTION_DECL
 *>
 fn usz? func(
   GlobalVisitData* vd, 
@@ -248,14 +250,14 @@ fn usz? func(
 
 <*
  Macro definition
- @require clang::getCursorKind(cursor) == clang::CURSOR_MACRO_DEFINITION
+ @require clang::getCursorKind(cursor) == CURSOR_MACRO_DEFINITION
 *>
 fn usz? macroDef(
   GlobalVisitData* vd, 
   CXCursor cursor) 
   @maydiscard
 {
-  return clang::isMacroFunctionLike_Cursor(cursor) ? 
+  return clang::cursor_isMacroFunctionLike(cursor) ? 
     ttor::funcMacroDef(vd, cursor) :
     ttor::constMacroDef(vd, cursor) @inline;
 }
@@ -287,7 +289,7 @@ fn usz? funcMacroDef(
   List{String} params;
   params.tinit();
 
-  CXTranslationUnit tu = clang::getTranslationUnit_Cursor(cursor);
+  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
   CXSourceRange sr = misc::getTrueCursorExtent(cursor); // We don't need to do getTrueCursorExtent as bug is not occured under macro declaration
   
   CXToken* tokens_ptr; uint tokens_len;
@@ -362,7 +364,7 @@ fn usz? constMacroDef(
 
 <*
  Typedef declaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_TYPEDEF_DECL
+ @require clang::getCursorKind(cursor) == CURSOR_TYPEDEF_DECL
 *>
 fn usz? typedefDecl(
   GlobalVisitData* vd, 
@@ -413,7 +415,7 @@ fn usz? typedefDecl(
 
 <*
  Structure declaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_STRUCT_DECL
+ @require clang::getCursorKind(cursor) == CURSOR_STRUCT_DECL
 *>
 fn usz? structDecl(
   GlobalVisitData* vd, 
@@ -426,7 +428,7 @@ fn usz? structDecl(
 
 <*
  Union declaration
- @require  clang::getCursorKind(cursor) == clang::CURSOR_UNION_DECL 
+ @require  clang::getCursorKind(cursor) == CURSOR_UNION_DECL 
 *>
 fn usz? unionDecl(
   GlobalVisitData* vd, 
@@ -471,7 +473,7 @@ macro usz? recordDecl(
     return 0;
   }
  
-  if (clang::isAnonymous_Cursor(cursor)) {
+  if (clang::cursor_isAnonymous(cursor)) {
     CXSourceLocation cursor_loc = clang::getCursorLocation(cursor);
     CUInt line, col;
     CXFile file;

--- a/bindgen.c3l/src/user.c3
+++ b/bindgen.c3l/src/user.c3
@@ -1,80 +1,91 @@
-
 module bgimpl::user;
+
 import bgimpl,
-       std::os::process, 
-       std::io,
-       std::collections::list;
+	std::os::process, 
+	std::io,
+	std::collections::list;
 
 
 <*
- Retrieves essential command args for clang and append extra_args to it.
- @return "ZString[], which and each element of which should be then freed via alloc"
+	Retrieves essential command args for clang and append extra_args to it.
+	@return "ZString[], which and each element of which should be then freed via alloc"
 *>
 fn ZString[]? getParseCommandArgs(
-  Allocator alloc, 
-  String[] extra_args = {},
-  bool no_libc = false) 
-  => @pool() 
+	Allocator alloc, 
+	String[] extra_args = {},
+	bool no_libc = false) 
+	=> @pool() 
 {
-  const ADD_ARGS = 4;
+	const ADD_ARGS = 4;
 
-  List{ZString} args;
-  args.tinit(extra_args.len + ADD_ARGS);
-  defer args.free();
+	List{ZString} args;
+	args.tinit(extra_args.len + ADD_ARGS);
+	defer args.free();
 
-  // Just make sure that we treat a file as a C one
-  args.push("-xc");
+	// Just make sure that we treat a file as a C one
+	args.push("-xc");
 
-  if (!no_libc) {
-    user::includeLibcToArgs(alloc, &args)!;
-  }
+	if (!no_libc) {
+		user::includeLibcToArgs(alloc, &args)!;
+	}
 
-  foreach (extra_opt : extra_args) {
-    args.push((ZString)extra_opt);
-  }
+	foreach (extra_opt : extra_args) {
+		args.push((ZString)extra_opt);
+	}
 
-  return args.to_array(alloc);
+	return args.to_array(alloc);
 }
 
 
 <*
- Appends flags to res to locate libc headers for clang
- @param [&out] res              : "List, which will be pushed with flags"
- @require res.is_initialized()  : "List must be initialized"
+	Appends flags to res to locate libc headers for clang
+	@param [&out] res              : "List, which will be pushed with flags"
+	@require res.is_initialized()  : "List must be initialized"
 *>
 fn void? includeLibcToArgs(
-  Allocator alloc,
-  List{ZString}* res) 
-  => @pool()
+	Allocator alloc,
+	List{ZString}* res) 
+	=> @pool()
 {
-  SubProcess proc = process::create({ "clang", "-E", "-Wp,-v", "-xc", "-" })!;
-  proc.join()!; // join the process to close stdin of clang
-  defer proc.destroy();
-  File in = proc.stderr();
+	Process proc = process::spawn({ "clang", "-E", "-Wp,-v", "-xc", "-" })!;
+	defer proc.destroy();
+	File in = proc.stderr();
 
-  bool found;
-  while (!found) {
-    if (in.read_byte()! == '\n') {
-      char[14] buffer;
-      in.read(buffer[..])!;
-      if (buffer[..] == "#include <...>") {
-        while(in.read_byte()! != '\n') {}; // read till '\n'
-        found = true;
-      }
-    }
-  }
+	bool inside_include_section = false;
+	DString current_line;
+	current_line.tinit();
 
-  while (try first_c = in.read_byte() && first_c == ' ') {
-    DString path_dstr;
-    path_dstr.tinit();
+	while (try c = in.read_byte()) {
+		if (c != '\n') {
+			current_line.append(c);
+			continue;
+		}
 
-    path_dstr.append("-I");
-    while (try c = in.read_byte() && c != '\n') {
-      path_dstr.append(c);
-    }
+		if (!inside_include_section) {
+			if (current_line.str_view().contains("#include <...>")) {
+			inside_include_section = true;
+		}
 
-    // Append all possible headers
-    res.push(path_dstr.copy_zstr(alloc));
-  }
+	} else {
+		// If we are inside the section, lines starting with ' ' are paths
+		if (current_line.str_view().starts_with(" ")) {
+		DString path_flag;
+		path_flag.tinit();
+		path_flag.append("-I");
+		// Append the path, stripping the leading space
+		path_flag.append(current_line.str_view()[1..]); 
+		
+		res.push(path_flag.copy_zstr(alloc));
+		} 
+		else 
+		{
+		break;
+		}
+	}
+
+	current_line.clear();
+	}
+
+	proc.join()!;
 }
 

--- a/bindgen.c3l/src/valgen.c3
+++ b/bindgen.c3l/src/valgen.c3
@@ -5,21 +5,21 @@ import bindgen::bg,
 
 
 <*
- Applies fun to a name for value generation.
- If function is null, returns the default value
- of return type.
- @require $typeof(fun) == BGGenFn ||| $typeof(fun) == BGModuleWrapFn
+	Applies fun to a name for value generation.
+	If function is null, returns the default value
+	of return type.
+	@require $Typeof(fun) == BGGenFn ||| $Typeof(fun) == BGModuleWrapFn
 *>
 macro apply(
-  Allocator alloc, 
-  String name,  
-  fun)
+	Allocator alloc, 
+	String name,  
+	fun)
 {
-  var $RetType = $typefrom($typeof(fun).returns);
-  if (fun == null) return ($RetType){};
+	var $RetType = $Typefrom($Typeof(fun)::returns);
+	if (fun == null) return ($RetType){};
 
-  $RetType res = fun(name, alloc);
-  return res;
+	$RetType res = fun(name, alloc);
+	return res;
 }
 
 
@@ -29,13 +29,13 @@ macro apply(
  See WriteAttrs docs for more info.
 *>
 fn WriteAttrs getWriteAttrs(
-  Allocator alloc,
-  String name, 
-  BGGenCallbacks gen_fns)
+	Allocator alloc,
+	String name, 
+	BGGenCallbacks gen_fns)
 {
-  return {
-    .if_condition = valgen::apply(alloc, name, gen_fns.if_condition),
-  };
+	return {
+		.if_condition = valgen::apply(alloc, name, gen_fns.if_condition),
+	};
 }
 
 

--- a/bindgen.c3l/src/visitors.c3
+++ b/bindgen.c3l/src/visitors.c3
@@ -296,7 +296,7 @@ fn CXChildVisitResult fields(
 			vd.fields.kinds.push(NORMAL);
 		case BIT:
 			CInt width = clang::getFieldDeclBitWidth(cursor);
-			vd.fields.bit.push({trans_type_str, trans_field_name, (usz)width});
+			vd.fields.bit.push({trans_type_str, trans_field_name, (sz)width});
 			vd.fields.kinds.push(BIT);
 		default: 
 			unreachable();

--- a/bindgen.c3l/src/visitors.c3
+++ b/bindgen.c3l/src/visitors.c3
@@ -33,28 +33,28 @@ fn CXChildVisitResult global(
   clang::getExpansionLocation(clang::getCursorLocation(cursor), &cursor_file, null, null, null);
 
   // Ignore null file as it might be a macro included by a compiler
-  if (cursor_file == null) return clang::CHILD_VISIT_CONTINUE;
+  if (cursor_file == null) return CHILD_VISIT_CONTINUE;
 
   // If file is not equal to ours and it's not permitted, skip it
-  if (!clang::isEqual_File(cursor_file, vd.cxfile)) {
+  if (!clang::file_isEqual(cursor_file, vd.cxfile)) {
     CXString file_spell = clang::getFileName(cursor_file);
     defer clang::disposeString(file_spell);
     String file_str = misc::convStr(file_spell);
 
-    if (!check::apply(file_str, vd.include_file)) return clang::CHILD_VISIT_CONTINUE; 
+    if (!check::apply(file_str, vd.include_file)) return CHILD_VISIT_CONTINUE; 
   }
 
   switch (cursor_kind) {
-    case clang::CURSOR_FUNCTION_DECL: ttor::func(vd, cursor);
-    case clang::CURSOR_STRUCT_DECL: ttor::structDecl(vd, cursor);
-    case clang::CURSOR_TYPEDEF_DECL: ttor::typedefDecl(vd, cursor);
-    case clang::CURSOR_VAR_DECL: ttor::varDecl(vd, cursor);
-    case clang::CURSOR_ENUM_DECL: ttor::enumDecl(vd, cursor);
-    case clang::CURSOR_MACRO_DEFINITION: ttor::macroDef(vd, cursor);
-    case clang::CURSOR_UNION_DECL: ttor::unionDecl(vd, cursor);
+    case CURSOR_FUNCTION_DECL: ttor::func(vd, cursor);
+    case CURSOR_STRUCT_DECL: ttor::structDecl(vd, cursor);
+    case CURSOR_TYPEDEF_DECL: ttor::typedefDecl(vd, cursor);
+    case CURSOR_VAR_DECL: ttor::varDecl(vd, cursor);
+    case CURSOR_ENUM_DECL: ttor::enumDecl(vd, cursor);
+    case CURSOR_MACRO_DEFINITION: ttor::macroDef(vd, cursor);
+    case CURSOR_UNION_DECL: ttor::unionDecl(vd, cursor);
   }
 
-  return clang::CHILD_VISIT_CONTINUE;
+  return CHILD_VISIT_CONTINUE;
 }
 
 
@@ -71,15 +71,49 @@ fn CXChildVisitResult constDecl(
 
   // When cursor type is a typedef of some other type, one more 
   // child is added to it so skip it
-  if (clang::getCursorKind(cursor) == clang::CURSOR_TYPE_REF) {
-    return clang::CHILD_VISIT_CONTINUE;
+  if (clang::getCursorKind(cursor) == CURSOR_TYPE_REF) {
+    return CHILD_VISIT_CONTINUE;
   }
 
   vd.val = trans::tokensUnderCursor(vd.allocator, cursor, &vd.g.trans_fns) ?? EMPTY_TOKENS;
 
-  return clang::CHILD_VISIT_CONTINUE;
+  if (clang::getCursorKind(cursor) != CURSOR_FIELD_DECL) {
+
+
+
+    return CHILD_VISIT_CONTINUE;
+  }
+
+  return CHILD_VISIT_CONTINUE;
 }
 
+<*
+	visit an enums fields/members
+*>
+fn CXChildVisitResult enumField(
+  CXCursor cursor, 
+  CXCursor parent, 
+  CXClientData client_data)
+{
+	if (clang::getCursorKind(cursor) != CURSOR_ENUM_CONSTANT_DECL) {
+		return CHILD_VISIT_CONTINUE;
+	}
+
+	EnumVisitData* vd = (EnumVisitData*)client_data;
+	
+	CXString name_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(name_spell);
+	String name_str = misc::convStr(name_spell); 
+
+  	String trans_name_str = trans::apply(name_str, vd.g.trans_fns.enum_field, vd.allocator) ?? "";
+
+	CLongLong enum_value = clang::getEnumConstantDeclValue(cursor);
+	String value_str = string::format(vd.allocator, "%d", enum_value);
+
+	vd.fields.push({ trans_name_str, value_str });
+
+	return CHILD_VISIT_CONTINUE;
+}
 
 <*
  Enum constants
@@ -91,40 +125,29 @@ fn CXChildVisitResult enumDecl(
   CXCursor parent, 
   CXClientData client_data)
 {
-  EnumVisitData* vd = (EnumVisitData*) client_data;
+	log::info("enumDecl - %s", clang::getCursorKind(cursor));
+	if (clang::getCursorKind(cursor) != CURSOR_ENUM_DECL) {
+    	return CHILD_VISIT_CONTINUE;
+  	}
 
-  CXString cursor_spell = clang::getCursorSpelling(cursor);
-  defer clang::disposeString(cursor_spell);
-  String cursor_str = misc::convStr(cursor_spell);
-  
-  String? trans_cursor_str = trans::apply(cursor_str, vd.g.trans_fns.constant, tmem);
-  if (catch trans_cursor_str) {
-    err::warn(vd.g.no_verbose, "Enum constant '%s' is ignored", cursor_str);
-    return clang::CHILD_VISIT_CONTINUE;
-  }
-  
-  ConstVisitData vd_const = {
-    .g = vd.g,
-    .allocator = tmem,
-  };
+	EnumVisitData* vd = (EnumVisitData*)client_data;
 
-  clang::visitChildren(cursor, &vtor::constDecl, (CXClientData) &vd_const);
+	CXString cursor_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(cursor_spell);
+	String cursor_str = misc::convStr(cursor_spell);
+	
+	String? trans_cursor_str = trans::apply(cursor_str, vd.g.trans_fns.constant, tmem);
+	if (catch trans_cursor_str) {
+		err::warn(vd.g.no_verbose, "Enum constant '%s' is ignored", cursor_str);
+		return CHILD_VISIT_CONTINUE;
+	}
+	
+	vd.fields.tinit();
 
-  // If we get empty rhs, evaluate value
-  if (vd_const.val == EMPTY_TOKENS) {
-    if (vd.is_unsigned) {
-      CULongLong ival = clang::getEnumConstantDeclUnsignedValue(cursor);
-      vd_const.val = string::tformat("%s", ival);
-    } else {
-      CLongLong ival = clang::getEnumConstantDeclValue(cursor);
-      vd_const.val = string::tformat("%s", ival);
-    }
-  }
+	clang::visitChildren(cursor, &enumField, (CXClientData)&vd);
 
-  WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.g.gen_fns);
-  wter::constDecl(vd.g.out, &vd.g.write_state, vd.enum_name, trans_cursor_str, vd_const.val, attrs);
-
-  return clang::CHILD_VISIT_CONTINUE;
+	WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.g.gen_fns);
+	return CHILD_VISIT_CONTINUE;
 }
 
 
@@ -137,21 +160,26 @@ fn CXChildVisitResult typedefDecl(
   CXCursor parent, 
   CXClientData client_data)
 {
-  // The visitor can also encounter non-types in a function.
-  // For example, it may be attributes, declared structures, etc.
-  if (clang::getCursorKind(cursor) != clang::CURSOR_TYPE_REF) {
-    return clang::CHILD_VISIT_CONTINUE;
-  }
+	// The visitor can also encounter non-types in a function.
+	// For example, it may be attributes, declared structures, etc.
+	if (clang::getCursorKind(cursor) != CURSOR_TYPE_REF) {
+	return CHILD_VISIT_CONTINUE;
+	}
 
-  TypedefVisitData* vd = (TypedefVisitData*) client_data;
-  vd.is_incomplete = !clang::isCursorDefinition(cursor) && misc::isTypeIncomplete(vd.under_type);
+	TypedefVisitData* vd = (TypedefVisitData*) client_data;
 
-  if (vd.is_incomplete) {
-    CXType key = misc::getBaseType(vd.under_type);
-    vd.g.types_table[key] = "void";
-  }
+	CXCursor ref_cursor = clang::getCursorReferenced(cursor);
+	bool has_definition = clang::isCursorDefinition(ref_cursor) != 0;
+	bool is_layout_incomplete = clang::type_getSizeOf(vd.under_type) == -2;
 
-  return clang::CHILD_VISIT_BREAK;
+	vd.is_incomplete = !has_definition || is_layout_incomplete;
+
+	if (vd.is_incomplete) {
+		CXType key = misc::getBaseType(vd.under_type);
+		vd.g.types_table[key] = "void";
+	}
+
+	return CHILD_VISIT_BREAK;
 }
 
 
@@ -166,8 +194,8 @@ fn CXChildVisitResult func(
 {
   // The visitor can also encounter non-paremeters in a function.
   // For example, it may be attributes, etc.
-  if (clang::getCursorKind(cursor) != clang::CURSOR_PARM_DECL) {
-    return clang::CHILD_VISIT_CONTINUE;
+  if (clang::getCursorKind(cursor) != CURSOR_PARM_DECL) {
+    return CHILD_VISIT_CONTINUE;
   }
 
   FuncVisitData* vd = (FuncVisitData*) client_data;
@@ -192,12 +220,12 @@ fn CXChildVisitResult func(
     String parent_str = misc::convStr(parent_spell);
 
     err::warn(vd.g.no_verbose, "Can't translate function '%s' as it's parameter type '%s' is ignored", parent_str, type_str);
-    return clang::CHILD_VISIT_BREAK;
+    return CHILD_VISIT_BREAK;
   }
 
   vd.params.push({trans_type_str, trans_name_str});
 
-  return clang::CHILD_VISIT_CONTINUE;
+  return CHILD_VISIT_CONTINUE;
 }
 
 
@@ -222,13 +250,13 @@ fn CXChildVisitResult fields(
   String? trans_field_name = trans::apply(field_name, vd.g.trans_fns.variable, vd.allocator);
   if (catch trans_field_name) {
     err::warn(vd.g.no_verbose, "Field (variable) '%s' is ignored", field_name);
-    return clang::CHILD_VISIT_BREAK;
+    return CHILD_VISIT_BREAK;
   }
 
   CXType type = clang::getCanonicalType(clang::getCursorType(cursor));
   CXType prev_type = clang::getCursorType(vd.prev_inline);
 
-  if (!clang::isNull_Cursor(vd.prev_inline) && clang::equalTypes(type, prev_type)) {
+  if (!clang::cursor_isNull(vd.prev_inline) && clang::equalTypes(type, prev_type)) {
     switch (tparse::getCFieldKind(vd.prev_inline)) {
       case STRUCT:
         vd.fields.structs[^1].name = trans_field_name;
@@ -239,7 +267,7 @@ fn CXChildVisitResult fields(
     }
 
     vd.prev_inline = clang::getNullCursor();
-    return clang::CHILD_VISIT_CONTINUE;
+    return CHILD_VISIT_CONTINUE;
   }
 
   CFieldKind kind = tparse::getCFieldKind(cursor);
@@ -256,7 +284,7 @@ fn CXChildVisitResult fields(
       String parent_str = misc::convStr(parent_spell);
 
       err::warn(vd.g.no_verbose, "Can't translate struct/union '%s' as it's field type '%s' is ignored", parent_str, type_str);
-      return clang::CHILD_VISIT_BREAK;
+      return CHILD_VISIT_BREAK;
     }
 
     switch (kind) {
@@ -277,7 +305,7 @@ fn CXChildVisitResult fields(
     // is anonymous or not. In first case, we create anonymous record 
     // as well; in second one, we regularly translate a record and 
     // write it globally
-    if (clang::isAnonymous_Cursor(cursor)) {
+    if (clang::cursor_isAnonymous(cursor)) {
       vd.prev_inline = cursor;
       FieldsVisitData vd_inner = {
         .g = vd.g,
@@ -286,7 +314,7 @@ fn CXChildVisitResult fields(
       };
 
       vd_inner.fields.init(vd_inner.allocator);
-      if (clang::visitChildren(cursor, &vtor::fields, (CXClientData) &vd_inner) != 0) return clang::CHILD_VISIT_BREAK;
+      if (clang::visitChildren(cursor, &vtor::fields, (CXClientData) &vd_inner) != 0) return CHILD_VISIT_BREAK;
 
       switch (kind) {
         case STRUCT:
@@ -310,7 +338,7 @@ fn CXChildVisitResult fields(
     }
   }
 
-  return clang::CHILD_VISIT_CONTINUE;
+  return CHILD_VISIT_CONTINUE;
 }
 
 

--- a/bindgen.c3l/src/visitors.c3
+++ b/bindgen.c3l/src/visitors.c3
@@ -110,7 +110,12 @@ fn CXChildVisitResult enumField(
 	CLongLong enum_value = clang::getEnumConstantDeclValue(cursor);
 	String value_str = string::format(vd.allocator, "%d", enum_value);
 
-	vd.fields.push({ trans_name_str, value_str });
+	String docs;
+	if (vd.g.use_docs) {
+		docs = misc::getCursorDoc(cursor, mem, 1);
+	}
+
+	vd.fields.push({ trans_name_str, value_str, docs });
 
 	return CHILD_VISIT_CONTINUE;
 }
@@ -125,7 +130,6 @@ fn CXChildVisitResult enumDecl(
   CXCursor parent, 
   CXClientData client_data)
 {
-	log::info("enumDecl - %s", clang::getCursorKind(cursor));
 	if (clang::getCursorKind(cursor) != CURSOR_ENUM_DECL) {
     	return CHILD_VISIT_CONTINUE;
   	}
@@ -184,161 +188,160 @@ fn CXChildVisitResult typedefDecl(
 
 
 <*
- Function parameters
- Translate them and push to visit data
+	Function parameters
+	Translate them and push to visit data
 *>
 fn CXChildVisitResult func(
-  CXCursor cursor, 
-  CXCursor parent, 
-  CXClientData client_data)
+	CXCursor cursor, 
+	CXCursor parent, 
+	CXClientData client_data)
 {
-  // The visitor can also encounter non-paremeters in a function.
-  // For example, it may be attributes, etc.
-  if (clang::getCursorKind(cursor) != CURSOR_PARM_DECL) {
-    return CHILD_VISIT_CONTINUE;
-  }
+	// The visitor can also encounter non-paremeters in a function.
+	// For example, it may be attributes, etc.
+	if (clang::getCursorKind(cursor) != CURSOR_PARM_DECL) {
+		return CHILD_VISIT_CONTINUE;
+	}
 
-  FuncVisitData* vd = (FuncVisitData*) client_data;
+	FuncVisitData* vd = (FuncVisitData*) client_data;
 
-  CXString name_spell = clang::getCursorSpelling(cursor);
-  defer clang::disposeString(name_spell);
-  String name_str = misc::convStr(name_spell); 
+	CXString name_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(name_spell);
+	String name_str = misc::convStr(name_spell); 
 
-  CXType type = clang::getCursorType(cursor);
-  CXString type_spell = clang::getTypeSpelling(type);
-  defer clang::disposeString(type_spell);
-  String type_str = misc::convStr(type_spell);
+	CXType type = clang::getCursorType(cursor);
+	CXString type_spell = clang::getTypeSpelling(type);
+	defer clang::disposeString(type_spell);
+	String type_str = misc::convStr(type_spell);
 
-  // Make parameter empty if it's ignored
-  String trans_name_str = trans::apply(name_str, vd.g.trans_fns.variable, vd.allocator) ?? "";
- 
-  String? trans_type_str = trans::ctypeWithPFN(cursor, vd.g, is_func_param: true);
-  if (catch trans_type_str)
-  {
-    CXString parent_spell = clang::getCursorSpelling(parent);
-    defer clang::disposeString(parent_spell);
-    String parent_str = misc::convStr(parent_spell);
+	// Make parameter empty if it's ignored
+	String trans_name_str = trans::apply(name_str, vd.g.trans_fns.variable, vd.allocator) ?? "";
+	
+	String? trans_type_str = trans::ctypeWithPFN(cursor, vd.g, is_func_param: true);
+	if (catch trans_type_str)
+	{
+		CXString parent_spell = clang::getCursorSpelling(parent);
+		defer clang::disposeString(parent_spell);
+		String parent_str = misc::convStr(parent_spell);
 
-    err::warn(vd.g.no_verbose, "Can't translate function '%s' as it's parameter type '%s' is ignored", parent_str, type_str);
-    return CHILD_VISIT_BREAK;
-  }
+		err::warn(vd.g.no_verbose, "Can't translate function '%s' as it's parameter type '%s' is ignored", parent_str, type_str);
+		return CHILD_VISIT_BREAK;
+	}
 
-  vd.params.push({trans_type_str, trans_name_str});
+	vd.params.push({trans_type_str, trans_name_str});
 
-  return CHILD_VISIT_CONTINUE;
+	return CHILD_VISIT_CONTINUE;
 }
 
 
 <*
- Fields of either struct or union.
- If a field declares a type, translates
- it and write to global output.
+	Fields of either struct or union.
+	If a field declares a type, translates
+	it and write to global output.
 *>
 fn CXChildVisitResult fields(
-  CXCursor cursor, 
-  CXCursor parent, 
-  CXClientData client_data)
-  => @pool()
+	CXCursor cursor, 
+	CXCursor parent, 
+	CXClientData client_data) => @pool()
 {
-  // TODO: cope with incomplete types!!!
-  FieldsVisitData* vd = (FieldsVisitData*) client_data;
+	// TODO: cope with incomplete types!!!
+	FieldsVisitData* vd = (FieldsVisitData*) client_data;
 
-  CXString field_spell = clang::getCursorSpelling(cursor);
-  defer clang::disposeString(field_spell);
-  String field_name = misc::convStr(field_spell);
+	CXString field_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(field_spell);
+	String field_name = misc::convStr(field_spell);
 
-  String? trans_field_name = trans::apply(field_name, vd.g.trans_fns.variable, vd.allocator);
-  if (catch trans_field_name) {
-    err::warn(vd.g.no_verbose, "Field (variable) '%s' is ignored", field_name);
-    return CHILD_VISIT_BREAK;
-  }
+	String? trans_field_name = trans::apply(field_name, vd.g.trans_fns.variable, vd.allocator);
+	if (catch trans_field_name) {
+		err::warn(vd.g.no_verbose, "Field (variable) '%s' is ignored", field_name);
+		return CHILD_VISIT_BREAK;
+	}
 
-  CXType type = clang::getCanonicalType(clang::getCursorType(cursor));
-  CXType prev_type = clang::getCursorType(vd.prev_inline);
+	CXType type = clang::getCanonicalType(clang::getCursorType(cursor));
+	CXType prev_type = clang::getCursorType(vd.prev_inline);
 
-  if (!clang::cursor_isNull(vd.prev_inline) && clang::equalTypes(type, prev_type)) {
-    switch (tparse::getCFieldKind(vd.prev_inline)) {
-      case STRUCT:
-        vd.fields.structs[^1].name = trans_field_name;
-      case UNION:
-        vd.fields.unions[^1].name = trans_field_name;
-      default:
-        unreachable();
-    }
+	if (!clang::cursor_isNull(vd.prev_inline) && clang::equalTypes(type, prev_type)) {
+		switch (tparse::getCFieldKind(vd.prev_inline)) {
+		case STRUCT:
+			vd.fields.structs[^1].name = trans_field_name;
+		case UNION:
+			vd.fields.unions[^1].name = trans_field_name;
+		default:
+			unreachable();
+		}
 
-    vd.prev_inline = clang::getNullCursor();
-    return CHILD_VISIT_CONTINUE;
-  }
+		vd.prev_inline = clang::getNullCursor();
+		return CHILD_VISIT_CONTINUE;
+	}
 
-  CFieldKind kind = tparse::getCFieldKind(cursor);
+	CFieldKind kind = tparse::getCFieldKind(cursor);
 
-  if (kind == NORMAL || kind == BIT) {
-    String? trans_type_str = trans::ctypeWithPFN(cursor, vd.g);
-    if (catch trans_type_str) {
-      CXString type_spell = clang::getTypeSpelling(type);
-      defer clang::disposeString(type_spell);
-      String type_str = misc::convStr(type_spell);
+	if (kind == NORMAL || kind == BIT) {
+		String? trans_type_str = trans::ctypeWithPFN(cursor, vd.g);
+		if (catch trans_type_str) {
+		CXString type_spell = clang::getTypeSpelling(type);
+		defer clang::disposeString(type_spell);
+		String type_str = misc::convStr(type_spell);
 
-      CXString parent_spell = clang::getCursorSpelling(parent);
-      defer clang::disposeString(parent_spell);
-      String parent_str = misc::convStr(parent_spell);
+		CXString parent_spell = clang::getCursorSpelling(parent);
+		defer clang::disposeString(parent_spell);
+		String parent_str = misc::convStr(parent_spell);
 
-      err::warn(vd.g.no_verbose, "Can't translate struct/union '%s' as it's field type '%s' is ignored", parent_str, type_str);
-      return CHILD_VISIT_BREAK;
-    }
+		err::warn(vd.g.no_verbose, "Can't translate struct/union '%s' as it's field type '%s' is ignored", parent_str, type_str);
+		return CHILD_VISIT_BREAK;
+		}
 
-    switch (kind) {
-      case NORMAL:
-        vd.fields.norm.push({trans_type_str, trans_field_name});
-        vd.fields.kinds.push(NORMAL);
-      case BIT:
-        CInt width = clang::getFieldDeclBitWidth(cursor);
-        vd.fields.bit.push({trans_type_str, trans_field_name, (usz)width});
-        vd.fields.kinds.push(BIT);
-      default: 
-        unreachable();
-    }
-  } else if (kind == ENUM) {
-    ttor::enumDecl(vd.g, cursor);
-  } else {
-    // We have two different behaviours depending on whether a record
-    // is anonymous or not. In first case, we create anonymous record 
-    // as well; in second one, we regularly translate a record and 
-    // write it globally
-    if (clang::cursor_isAnonymous(cursor)) {
-      vd.prev_inline = cursor;
-      FieldsVisitData vd_inner = {
-        .g = vd.g,
-        .allocator = vd.allocator,
-        .prev_inline = clang::getNullCursor(),
-      };
+		switch (kind) {
+		case NORMAL:
+			vd.fields.norm.push({trans_type_str, trans_field_name});
+			vd.fields.kinds.push(NORMAL);
+		case BIT:
+			CInt width = clang::getFieldDeclBitWidth(cursor);
+			vd.fields.bit.push({trans_type_str, trans_field_name, (usz)width});
+			vd.fields.kinds.push(BIT);
+		default: 
+			unreachable();
+		}
+	} else if (kind == ENUM) {
+		ttor::enumDecl(vd.g, cursor);
+	} else {
+		// We have two different behaviours depending on whether a record
+		// is anonymous or not. In first case, we create anonymous record 
+		// as well; in second one, we regularly translate a record and 
+		// write it globally
+		if (clang::cursor_isAnonymous(cursor)) {
+		vd.prev_inline = cursor;
+		FieldsVisitData vd_inner = {
+			.g = vd.g,
+			.allocator = vd.allocator,
+			.prev_inline = clang::getNullCursor(),
+		};
 
-      vd_inner.fields.init(vd_inner.allocator);
-      if (clang::visitChildren(cursor, &vtor::fields, (CXClientData) &vd_inner) != 0) return CHILD_VISIT_BREAK;
+		vd_inner.fields.init(vd_inner.allocator);
+		if (clang::visitChildren(cursor, &vtor::fields, (CXClientData) &vd_inner) != 0) return CHILD_VISIT_BREAK;
 
-      switch (kind) {
-        case STRUCT:
-          vd.fields.structs.push({"", vd_inner.fields});
-          vd.fields.kinds.push(STRUCT);
-        case UNION:
-          vd.fields.unions.push({"", vd_inner.fields});
-          vd.fields.kinds.push(UNION);
-        default: 
-          unreachable();
-      }
-    } else {
-      switch (kind) {
-        case STRUCT:
-          ttor::structDecl(vd.g, cursor);
-        case UNION:
-          ttor::unionDecl(vd.g, cursor);
-        default:
-          unreachable();
-      }
-    }
-  }
+		switch (kind) {
+			case STRUCT:
+			vd.fields.structs.push({"", vd_inner.fields});
+			vd.fields.kinds.push(STRUCT);
+			case UNION:
+			vd.fields.unions.push({"", vd_inner.fields});
+			vd.fields.kinds.push(UNION);
+			default: 
+			unreachable();
+		}
+		} else {
+		switch (kind) {
+			case STRUCT:
+			ttor::structDecl(vd.g, cursor);
+			case UNION:
+			ttor::unionDecl(vd.g, cursor);
+			default:
+			unreachable();
+		}
+		}
+	}
 
-  return CHILD_VISIT_CONTINUE;
+	return CHILD_VISIT_CONTINUE;
 }
 
 

--- a/bindgen.c3l/src/writers.c3
+++ b/bindgen.c3l/src/writers.c3
@@ -177,14 +177,27 @@ fn usz? varDecl(
 fn usz? enumDecl(
   OutStream out,
   WriteState* state,
+  EnumField[] fields,
   String name,
   String type,
   WriteAttrs attribs = {})
   @maydiscard
 {
-  state.kind = ENUM;
+	state.kind = ENUM;
 
-  return io::fprintfn(out, "\ntypedef %s%s = inline %s;", name, attribs, type);
+	usz? acc;
+
+	acc += io::fprintfn(out, "\nconstdef %s%s : %s {", name, attribs, type);
+
+	foreach (i, p : fields)  {
+		acc += io::fprintf(out, INDENT+++"%s =", p.name);
+		acc += io::fprintf(out, " %s", p.init);
+		if (i < fields.len - 1) acc += io::fprintn(out, ",");
+  	}
+
+	acc += io::fprintfn(out, "\n}");
+
+	return acc;
 }
 
 
@@ -211,7 +224,7 @@ fn usz? func(
 
   usz? acc;
 
-  acc += io::fprintf(out, "\nfn %s %s(", return_type, name);
+  acc += io::fprintf(out, "\nextern fn %s %s(", return_type, name);
   if (params.len > 0) acc += io::fprintf(out, "\n");
 
   foreach (i, p : params)  {
@@ -221,7 +234,7 @@ fn usz? func(
     }
     if (i < params.len - 1) acc += io::fprintn(out, ",");
   }
-  acc += io::fprintfn(out, ")\n@extern(\"%s\")%s;", original_name, attribs);
+  acc += io::fprintfn(out, ")\n@cname(\"%s\")%s;", original_name, attribs);
 
   return acc;
 }

--- a/bindgen.c3l/src/writers.c3
+++ b/bindgen.c3l/src/writers.c3
@@ -23,7 +23,7 @@ const INDENT = "\t";
 	@require name            != ""
 	@require underlying_name != ""
 *>
-fn usz? typedefAlias(
+fn sz? typedefAlias(
 	OutStream out,
 	WriteState* state,
 	String name,
@@ -33,7 +33,7 @@ fn usz? typedefAlias(
 {
 	state.kind = ALIAS;
 
-	usz? acc;
+	sz? acc;
 	acc += io::fprintfn(out, "\nalias %s%s = %s;", name, attribs, underlying_name);
 	return acc;
 }
@@ -46,7 +46,7 @@ fn usz? typedefAlias(
 	@require name            != ""
 	@require underlying_name != ""
 *>
-fn usz? typedefDistinct(
+fn sz? typedefDistinct(
 	OutStream out,
 	WriteState* state,
 	String name,
@@ -56,7 +56,7 @@ fn usz? typedefDistinct(
 {
 	state.kind = TYPEDEF;
 
-	usz? acc;
+	sz? acc;
 	acc += io::fprintfn(out, "\ntypedef %s%s = %s;", name, attribs, underlying_name);
 	return acc;
 }
@@ -70,7 +70,7 @@ fn usz? typedefDistinct(
 	@require name        != ""
 	@require return_type != ""
 *>
-fn usz? typedefFunc(
+fn sz? typedefFunc(
 	OutStream out,
 	WriteState* state,
 	String name,
@@ -81,7 +81,7 @@ fn usz? typedefFunc(
 {
 	state.kind = ALIAS;
 
-	usz? acc;
+	sz? acc;
 	
 	acc += io::fprintf(out, "\nalias %s%s = fn %s(", name, attribs, return_type);
 	
@@ -111,7 +111,7 @@ fn usz? typedefFunc(
 	@require name  != ""
 	@require value != ""
 *>
-fn usz? constDecl(
+fn sz? constDecl(
 	OutStream out,
 	WriteState* state,
 	String type,
@@ -123,7 +123,7 @@ fn usz? constDecl(
 	WriteKind prev_kind = state.kind;
 	state.kind = CONST;
 
-	usz? acc;
+	sz? acc;
 
 	if (prev_kind != CONST && prev_kind != ENUM) acc += io::fprintf(out, "\n");
 
@@ -145,7 +145,7 @@ fn usz? constDecl(
 	@require type != ""
 	@require name != ""
 *>
-fn usz? varDecl(
+fn sz? varDecl(
 	OutStream out,
 	WriteState* state,
 	String type,
@@ -157,9 +157,12 @@ fn usz? varDecl(
 {
 	state.kind = VAR;
 
-	usz? acc;
+	sz? acc;
 
-	acc += io::fprintf(out, "\n%s", docs);
+	if (docs)
+	{
+		acc += io::fprintf(out, "\n%s", docs);
+	}
 
 	if (value == "") {
 		acc += io::fprintfn(out, "\n%s %s%s;", type, name, attribs);
@@ -178,7 +181,7 @@ fn usz? varDecl(
  @require name != ""
  @require type != ""
 *>
-fn usz? enumDecl(
+fn sz? enumDecl(
 	OutStream out,
 	WriteState* state,
 	EnumField[] fields,
@@ -190,8 +193,11 @@ fn usz? enumDecl(
 {
 	state.kind = ENUM;
 
-	usz? acc;
-	acc += io::fprintf(out, "\n%s", docs);
+	sz? acc;
+	if (docs)
+	{
+		acc += io::fprintf(out, "\n%s", docs);
+	}
 	acc += io::fprintfn(out, "\nconstdef %s%s : %s {", name, attribs, type);
 
 	foreach (i, p : fields)  {
@@ -219,7 +225,7 @@ fn usz? enumDecl(
 	@require original_name != ""
 	@require name          != ""
 *>
-fn usz? func(
+fn sz? func(
 	OutStream out,
 	WriteState* state,
 	VarDecl[] params,
@@ -232,9 +238,12 @@ fn usz? func(
 {
 	state.kind = FUNC;
 
-	usz? acc;
+	sz? acc;
 
-	acc += io::fprintf(out, "\n%s", docs);
+	if (docs.len > 0)
+	{
+		acc += io::fprintf(out, "\n%s", docs);
+	}
 
 	acc += io::fprintf(out, "\nextern fn %s %s(", return_type, name);
 	if (params.len > 0) acc += io::fprintf(out, "\n");
@@ -260,7 +269,7 @@ fn usz? func(
 	@require !array::has(params, fn bool(String val) => val == "") : "params can't contain empty entries"
 	@require name != ""
 *>
-fn usz? funcMacro(
+fn sz? funcMacro(
 	OutStream out,
 	WriteState* state,
 	String[] params,
@@ -271,7 +280,7 @@ fn usz? funcMacro(
 {
 	state.kind = MACRO;
 
-	usz? acc;
+	sz? acc;
 
 	acc += io::fprintf(out, "\nmacro @%s(", name);
 	foreach (i, p : params) {
@@ -296,7 +305,7 @@ fn usz? funcMacro(
 	@param [&out]   state : "Sets state.kind to WriteKind.MODULE"
 	@require module_name != ""
 *>
-fn usz? moduleHead(
+fn sz? moduleHead(
 	OutStream out,
 	WriteState* state,
 	String module_name,
@@ -315,7 +324,7 @@ fn usz? moduleHead(
 	@param [&out]   state : "Sets state.kind to WriteKind.IMPORT"
 	@require import_module != ""
 *>
-fn usz? importModule(
+fn sz? importModule(
 	OutStream out,
 	WriteState* state,
 	String import_module)
@@ -333,19 +342,19 @@ fn usz? importModule(
 	@param [&in]    fields
 	@param [&out]   state  : "Sets state.kind to WriteKind.IMPORT"
 *>
-fn usz? structDecl(
+fn sz? structDecl(
 	OutStream out,
 	WriteState* state,
 	String name,
 	C3Fields* fields,
-	usz indent_level = 0,
+	sz indent_level = 0,
 	String docs = "",
 	WriteAttrs attribs = {}) 
 	@maydiscard
 {
 	state.kind = STRUCT;
 
-	usz? acc;
+	sz? acc;
 
 	acc += printIndent(out, indent_level);
 	
@@ -370,18 +379,18 @@ fn usz? structDecl(
 <*
 	Union declaration
 *>
-fn usz? unionDecl(
+fn sz? unionDecl(
 	OutStream out,
 	WriteState* state,
 	String name,
 	C3Fields* fields,
-	usz indent_level = 0,
+	sz indent_level = 0,
 	WriteAttrs attribs = {}) 
 	@maydiscard
 {
 	state.kind = UNION;
 
-	usz? acc;
+	sz? acc;
 
 	acc += printIndent(out, indent_level);
 
@@ -406,15 +415,15 @@ fn usz? unionDecl(
  Helper function for wter::structDecl and wter::unionDecl,
  which writes record fields
 *>
-fn usz? fields(
+fn sz? fields(
 	OutStream out,
 	WriteState* state,
 	C3Fields* fields,
-	usz indent_level)
+	sz indent_level)
 	{
-	usz? acc;
+	sz? acc;
 
-	fields.@foreach(; C3FieldKind* kind, usz index)
+	fields.@foreach(; C3FieldKind* kind, sz index)
 	{
 		switch (*kind)
 		{
@@ -454,12 +463,12 @@ fn usz? fields(
 <*
  	Helper printer
 *>
-fn usz? printIndent( 
+fn sz? printIndent( 
 	OutStream out, 
-	usz indent_level = 1)
+	sz indent_level = 1)
 {
-	usz? acc;
-	for (usz i; i < indent_level; ++i) acc += io::fprintf(out, INDENT);
+	sz? acc;
+	for (sz i; i < indent_level; ++i) acc += io::fprintf(out, INDENT);
 	return acc;
 }
 

--- a/bindgen.c3l/src/writers.c3
+++ b/bindgen.c3l/src/writers.c3
@@ -11,159 +11,163 @@ import bindgen::bg,
        std::io, 
        clang;
 
-
-const INDENT = "  ";
-
+// \t is much more optimal
+// instead of editors showing exact spaces
+// users can decide how their editor represents it (as how many spaces)
+const INDENT = "\t";
 
 <*
- Aliasing typedef
- @param [&inout] out
- @param [&out]   state  : "Sets state.kind to WriteKind.ALIAS"
- @require name            != ""
- @require underlying_name != ""
+	Aliasing typedef
+	@param [&inout] out
+	@param [&out]   state  : "Sets state.kind to WriteKind.ALIAS"
+	@require name            != ""
+	@require underlying_name != ""
 *>
 fn usz? typedefAlias(
-  OutStream out,
-  WriteState* state,
-  String name,
-  String underlying_name,
-  WriteAttrs attribs = {})
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String name,
+	String underlying_name,
+	WriteAttrs attribs = {})
+	@maydiscard
 {
-  state.kind = ALIAS;
+	state.kind = ALIAS;
 
-  usz? acc;
-  acc += io::fprintfn(out, "\nalias %s%s = %s;", name, attribs, underlying_name);
-  return acc;
+	usz? acc;
+	acc += io::fprintfn(out, "\nalias %s%s = %s;", name, attribs, underlying_name);
+	return acc;
 }
 
 
 <*
- Distinct typedef
- @param [&inout] out
- @param [&out]   state  : "Sets state.kind to WriteKind.TYPEDEF"
- @require name            != ""
- @require underlying_name != ""
+	Distinct typedef
+	@param [&inout] out
+	@param [&out]   state  : "Sets state.kind to WriteKind.TYPEDEF"
+	@require name            != ""
+	@require underlying_name != ""
 *>
 fn usz? typedefDistinct(
-  OutStream out,
-  WriteState* state,
-  String name,
-  String underlying_name,
-  WriteAttrs attribs = {}) 
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String name,
+	String underlying_name,
+	WriteAttrs attribs = {}) 
+	@maydiscard
 {
-  state.kind = TYPEDEF;
+	state.kind = TYPEDEF;
 
-  usz? acc;
-  acc += io::fprintfn(out, "\ntypedef %s%s = %s;", name, attribs, underlying_name);
-  return acc;
+	usz? acc;
+	acc += io::fprintfn(out, "\ntypedef %s%s = %s;", name, attribs, underlying_name);
+	return acc;
 }
 
 
 <*
- Function pointer typedef
- @param [&inout] out
- @param [&out]   state                                                            : "Sets state.kind to WriteKind.ALIAS"
- @require !array::has(params, fn bool(VarDecl e) => e.type == "" && e.name != "") : "Each parameter must have type if it has name"
- @require name        != ""
- @require return_type != ""
+	Function pointer typedef
+	@param [&inout] out
+	@param [&out]   state                                                            : "Sets state.kind to WriteKind.ALIAS"
+	@require !array::has(params, fn bool(VarDecl e) => e.type == "" && e.name != "") : "Each parameter must have type if it has name"
+	@require name        != ""
+	@require return_type != ""
 *>
 fn usz? typedefFunc(
-  OutStream out,
-  WriteState* state,
-  String name,
-  String return_type,
-  VarDecl[] params,
-  WriteAttrs attribs = {})
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String name,
+	String return_type,
+	VarDecl[] params,
+	WriteAttrs attribs = {})
+	@maydiscard
 {
-  state.kind = ALIAS;
+	state.kind = ALIAS;
 
-  usz? acc;
-  
-  acc += io::fprintf(out, "\nalias %s%s = fn %s(", name, attribs, return_type);
-  
-  if (params.len > 0) acc += io::fprintf(out, "\n");
+	usz? acc;
+	
+	acc += io::fprintf(out, "\nalias %s%s = fn %s(", name, attribs, return_type);
+	
+	if (params.len > 0) acc += io::fprintf(out, "\n");
 
-  foreach (i, p : params) {
-    acc += io::fprintf(out, INDENT+++"%s", p.type);
-    if (p.name) {
-      acc += io::fprintf(out, " %s", p.name);
-    }
-    if (i < params.len - 1) acc += io::fprintn(out, ",");
-  }
+	foreach (i, p : params) {
+		acc += io::fprintf(out, INDENT+++"%s", p.type);
+		if (p.name) {
+		acc += io::fprintf(out, " %s", p.name);
+		}
+		if (i < params.len - 1) acc += io::fprintn(out, ",");
+	}
 
-  acc += io::fprintn(out, ");");
-  
-  return acc;
+	acc += io::fprintn(out, ");");
+	
+	return acc;
 }
 
 
 <*
- Constant declaration.
- If state.kind is CONST or ENUM, does not write extra 
- new line at the beginning.
- @param [&inout] out
- @param [&inout] state : "Sets state.kind to CONST"
- @param          type  : "Can be empty, for example, for macro"
- @require name  != ""
- @require value != ""
+	Constant declaration.
+	If state.kind is CONST or ENUM, does not write extra 
+	new line at the beginning.
+	@param [&inout] out
+	@param [&inout] state : "Sets state.kind to CONST"
+	@param          type  : "Can be empty, for example, for macro"
+	@require name  != ""
+	@require value != ""
 *>
 fn usz? constDecl(
-  OutStream out,
-  WriteState* state,
-  String type,
-  String name,
-  String value,
-  WriteAttrs attribs = {})
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String type,
+	String name,
+	String value,
+	WriteAttrs attribs = {})
+	@maydiscard
 {
-  WriteKind prev_kind = state.kind;
-  state.kind = CONST;
+	WriteKind prev_kind = state.kind;
+	state.kind = CONST;
 
-  usz? acc;
+	usz? acc;
 
-  if (prev_kind != CONST && prev_kind != ENUM) acc += io::fprintf(out, "\n");
+	if (prev_kind != CONST && prev_kind != ENUM) acc += io::fprintf(out, "\n");
 
-  if (type == "") {
-    acc += io::fprintfn(out, "const %s%s = %s;", name, attribs, value);
-  } else {
-    acc += io::fprintfn(out, "const %s %s%s = %s;", type, name, attribs, value);
-  }
+	if (type == "") {
+		acc += io::fprintfn(out, "const %s%s = %s;", name, attribs, value);
+	} else {
+		acc += io::fprintfn(out, "const %s %s%s = %s;", type, name, attribs, value);
+	}
 
-  return acc;
+	return acc;
 }
 
 
 <*
- Global variable declaration
- @param [&inout] out
- @param [&inout] state : "Sets state.kind to CONST"
- @param          value : "Can be empty"
- @require type != ""
- @require name != ""
+	Global variable declaration
+	@param [&inout] out
+	@param [&inout] state : "Sets state.kind to CONST"
+	@param          value : "Can be empty"
+	@require type != ""
+	@require name != ""
 *>
 fn usz? varDecl(
-  OutStream out,
-  WriteState* state,
-  String type,
-  String name,
-  String value,
-  WriteAttrs attribs = {})
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String type,
+	String name,
+	String value,
+	String docs = "",
+	WriteAttrs attribs = {})
+	@maydiscard
 {
-  state.kind = VAR;
+	state.kind = VAR;
 
-  usz? acc;
+	usz? acc;
 
-  if (value == "") {
-    acc += io::fprintfn(out, "\n%s %s%s;", type, name, attribs);
-  } else {
-    acc += io::fprintfn(out, "\n%s %s%s = %s;", type, name, attribs, value);
-  }
+	acc += io::fprintf(out, "\n%s", docs);
 
-  return acc;
+	if (value == "") {
+		acc += io::fprintfn(out, "\n%s %s%s;", type, name, attribs);
+	} else {
+		acc += io::fprintfn(out, "\n%s %s%s = %s;", type, name, attribs, value);
+	}
+
+	return acc;
 }
 
 
@@ -175,21 +179,26 @@ fn usz? varDecl(
  @require type != ""
 *>
 fn usz? enumDecl(
-  OutStream out,
-  WriteState* state,
-  EnumField[] fields,
-  String name,
-  String type,
-  WriteAttrs attribs = {})
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	EnumField[] fields,
+	String name,
+	String type,
+	String docs = "",
+	WriteAttrs attribs = {})
+	@maydiscard
 {
 	state.kind = ENUM;
 
 	usz? acc;
-
+	acc += io::fprintf(out, "\n%s", docs);
 	acc += io::fprintfn(out, "\nconstdef %s%s : %s {", name, attribs, type);
 
 	foreach (i, p : fields)  {
+		if (p.docs != "")
+		{
+			acc += io::fprintfn(out, "\n%s", p.docs);
+		}
 		acc += io::fprintf(out, INDENT+++"%s =", p.name);
 		acc += io::fprintf(out, " %s", p.init);
 		if (i < fields.len - 1) acc += io::fprintn(out, ",");
@@ -202,189 +211,194 @@ fn usz? enumDecl(
 
 
 <*
- Function declaration
- @param [&inout] out
- @param [&inout] state                                                            : "Sets state.kind to FUNC"
- @require !array::has(params, fn bool(VarDecl e) => e.type == "" && e.name != "") : "Each parameter must have type if it has name"
- @require return_type   != ""
- @require original_name != ""
- @require name          != ""
+	Function declaration
+	@param [&inout] out
+	@param [&inout] state                                                            : "Sets state.kind to FUNC"
+	@require !array::has(params, fn bool(VarDecl e) => e.type == "" && e.name != "") : "Each parameter must have type if it has name"
+	@require return_type   != ""
+	@require original_name != ""
+	@require name          != ""
 *>
 fn usz? func(
-  OutStream out,
-  WriteState* state,
-  VarDecl[] params,
-  String return_type,
-  String original_name,
-  String name,
-  WriteAttrs attribs = {}) 
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	VarDecl[] params,
+	String return_type,
+	String original_name,
+	String name,
+	String docs = "",
+	WriteAttrs attribs = {}) 
+	@maydiscard
 {
-  state.kind = FUNC;
+	state.kind = FUNC;
 
-  usz? acc;
+	usz? acc;
 
-  acc += io::fprintf(out, "\nextern fn %s %s(", return_type, name);
-  if (params.len > 0) acc += io::fprintf(out, "\n");
+	acc += io::fprintf(out, "\n%s", docs);
 
-  foreach (i, p : params)  {
-    acc += io::fprintf(out, INDENT+++"%s", p.type);
-    if (p.name) {
-      acc += io::fprintf(out, " %s", p.name);
-    }
-    if (i < params.len - 1) acc += io::fprintn(out, ",");
-  }
-  acc += io::fprintfn(out, ")\n@cname(\"%s\")%s;", original_name, attribs);
+	acc += io::fprintf(out, "\nextern fn %s %s(", return_type, name);
+	if (params.len > 0) acc += io::fprintf(out, "\n");
 
-  return acc;
+	foreach (i, p : params)  {
+		acc += io::fprintf(out, INDENT+++"%s", p.type);
+		if (p.name) {
+		acc += io::fprintf(out, " %s", p.name);
+		}
+		if (i < params.len - 1) acc += io::fprintn(out, ",");
+	}
+	acc += io::fprintfn(out, ")\n@cname(\"%s\")%s;", original_name, attribs);
+
+	return acc;
 }
 
 
 <*
- Functional macro
- @param [&inout] out
- @param [&inout] state                                          : "Sets state.kind to MACRO"
- @param          body                                           : "Can be empty"
- @require !array::has(params, fn bool(String val) => val == "") : "params can't contain empty entries"
- @require name != ""
+	Functional macro
+	@param [&inout] out
+	@param [&inout] state                                          : "Sets state.kind to MACRO"
+	@param          body                                           : "Can be empty"
+	@require !array::has(params, fn bool(String val) => val == "") : "params can't contain empty entries"
+	@require name != ""
 *>
 fn usz? funcMacro(
-  OutStream out,
-  WriteState* state,
-  String[] params,
-  String name,
-  String body,
-  WriteAttrs attribs = {})
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String[] params,
+	String name,
+	String body,
+	WriteAttrs attribs = {})
+	@maydiscard
 {
-  state.kind = MACRO;
+	state.kind = MACRO;
 
-  usz? acc;
+	usz? acc;
 
-  acc += io::fprintf(out, "\nmacro @%s(", name);
-  foreach (i, p : params) {
-    acc += io::fprintf(out, "#%s", p);
-    if (i < params.len - 1) acc += io::fprint(out, ", ");
-  }
-  acc += io::fprintf(out, ")%s {", attribs);
-  
-  if (body != "") {
-    acc += io::fprintfn(out, "\n"+++INDENT+++"%s", body);
-  }
+	acc += io::fprintf(out, "\nmacro @%s(", name);
+	foreach (i, p : params) {
+		acc += io::fprintf(out, "#%s", p);
+		if (i < params.len - 1) acc += io::fprint(out, ", ");
+	}
+	acc += io::fprintf(out, ")%s {", attribs);
+	
+	if (body != "") {
+		acc += io::fprintfn(out, "\n"+++INDENT+++"%s", body);
+	}
 
-  acc += io::fprintfn(out, "}");
+	acc += io::fprintfn(out, "}");
 
-  return acc;
+	return acc;
 }
 
 
 <*
- Module section statement
- @param [&inout] out
- @param [&out]   state : "Sets state.kind to WriteKind.MODULE"
- @require module_name != ""
+	Module section statement
+	@param [&inout] out
+	@param [&out]   state : "Sets state.kind to WriteKind.MODULE"
+	@require module_name != ""
 *>
 fn usz? moduleHead(
-  OutStream out,
-  WriteState* state,
-  String module_name,
-  WriteAttrs attribs = {})
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String module_name,
+	WriteAttrs attribs = {})
+	@maydiscard
 {
-  state.kind = MODULE;
+	state.kind = MODULE;
 
-  return io::fprintfn(out, "\nmodule %s%s;", module_name, attribs);
+	return io::fprintfn(out, "\nmodule %s%s;", module_name, attribs);
 }
 
 
 <*
- Import statemenet 
- @param [&inout] out
- @param [&out]   state : "Sets state.kind to WriteKind.IMPORT"
- @require import_module != ""
+	Import statemenet 
+	@param [&inout] out
+	@param [&out]   state : "Sets state.kind to WriteKind.IMPORT"
+	@require import_module != ""
 *>
 fn usz? importModule(
-  OutStream out,
-  WriteState* state,
-  String import_module)
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String import_module)
+	@maydiscard
 {
-  state.kind = IMPORT;
+	state.kind = IMPORT;
 
-  return io::fprintfn(out, "import %s;", import_module);
+	return io::fprintfn(out, "import %s;", import_module);
 }
 
 
 <*
- Struct declaration
- @param [&inout] out
- @param [&in]    fields
- @param [&out]   state  : "Sets state.kind to WriteKind.IMPORT"
+	Struct declaration
+	@param [&inout] out
+	@param [&in]    fields
+	@param [&out]   state  : "Sets state.kind to WriteKind.IMPORT"
 *>
 fn usz? structDecl(
-  OutStream out,
-  WriteState* state,
-  String name,
-  C3Fields* fields,
-  usz indent_level = 0,
-  WriteAttrs attribs = {}) 
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String name,
+	C3Fields* fields,
+	usz indent_level = 0,
+	String docs = "",
+	WriteAttrs attribs = {}) 
+	@maydiscard
 {
-  state.kind = STRUCT;
+	state.kind = STRUCT;
 
-  usz? acc;
+	usz? acc;
 
-  acc += printIndent(out, indent_level);
-  
-  if (indent_level == 0) acc += io::fprintf(out, "\n");
+	acc += printIndent(out, indent_level);
+	
+	if (indent_level == 0) acc += io::fprintf(out, "\n");
+	acc += io::fprintfn(out, docs);
 
-  if (name == "") {
-    acc += io::fprintfn(out, "struct {");
-  } else {
-    acc += io::fprintfn(out, "struct %s%s {", name, attribs);
-  }
+	if (name == "") {
+		acc += io::fprintfn(out, "struct {");
+	} else {
+		acc += io::fprintfn(out, "struct %s%s {", name, attribs);
+	}
 
-  acc += wter::fields(out, state, fields, indent_level + 1);
+	acc += wter::fields(out, state, fields, indent_level + 1);
 
-  acc += printIndent(out, indent_level);
-  acc += io::fprintfn(out, "}");
-  
-  return acc;
+	acc += printIndent(out, indent_level);
+	acc += io::fprintfn(out, "}");
+	
+	return acc;
 }
 
 
 <*
- Union declaration
+	Union declaration
 *>
 fn usz? unionDecl(
-  OutStream out,
-  WriteState* state,
-  String name,
-  C3Fields* fields,
-  usz indent_level = 0,
-  WriteAttrs attribs = {}) 
-  @maydiscard
+	OutStream out,
+	WriteState* state,
+	String name,
+	C3Fields* fields,
+	usz indent_level = 0,
+	WriteAttrs attribs = {}) 
+	@maydiscard
 {
-  state.kind = UNION;
+	state.kind = UNION;
 
-  usz? acc;
+	usz? acc;
 
-  acc += printIndent(out, indent_level);
+	acc += printIndent(out, indent_level);
 
-  if (indent_level == 0) acc += io::fprintf(out, "\n");
+	if (indent_level == 0) acc += io::fprintf(out, "\n");
 
-  if (name == "") {
-    acc += io::fprintfn(out, "union {");
-  } else {
-    acc += io::fprintfn(out, "union %s%s {", name, attribs);
-  }
+	if (name == "") {
+		acc += io::fprintfn(out, "union {");
+	} else {
+		acc += io::fprintfn(out, "union %s%s {", name, attribs);
+	}
 
-  acc += wter::fields(out, state, fields, indent_level + 1);
+	acc += wter::fields(out, state, fields, indent_level + 1);
 
-  acc += printIndent(out, indent_level);
-  acc += io::fprintfn(out, "}");
-  
-  return acc;
+	acc += printIndent(out, indent_level);
+	acc += io::fprintfn(out, "}");
+	
+	return acc;
 }
 
 
@@ -393,59 +407,59 @@ fn usz? unionDecl(
  which writes record fields
 *>
 fn usz? fields(
-  OutStream out,
-  WriteState* state,
-  C3Fields* fields,
-  usz indent_level)
-{
-  usz? acc;
+	OutStream out,
+	WriteState* state,
+	C3Fields* fields,
+	usz indent_level)
+	{
+	usz? acc;
 
-  fields.@foreach(; C3FieldKind* kind, usz index)
-  {
-    switch (*kind)
-    {
-      case NORMAL:
-        acc += printIndent(out, indent_level);
-        acc += io::fprintfn(out, "%s %s;", fields.norm[index].type, fields.norm[index].name);
+	fields.@foreach(; C3FieldKind* kind, usz index)
+	{
+		switch (*kind)
+		{
+		case NORMAL:
+			acc += printIndent(out, indent_level);
+			acc += io::fprintfn(out, "%s %s;", fields.norm[index].type, fields.norm[index].name);
 
-      case BITSTRUCT:
-        state.kind = BITSTRUCT;
+		case BITSTRUCT:
+			state.kind = BITSTRUCT;
 
-        acc += printIndent(out, indent_level);
-        acc += io::fprintfn(out, "bitstruct : %s {", fields.bit[index].under_type)!;
+			acc += printIndent(out, indent_level);
+			acc += io::fprintfn(out, "bitstruct : %s {", fields.bit[index].under_type)!;
 
-        foreach (C3BitstructField bitf : fields.bit[index].fields)
-        {
-          acc += printIndent(out, indent_level + 1);
-          acc += io::fprintfn(out, "%s %s : %s..%s;", bitf.type, bitf.name, bitf.from, bitf.to)!;
-        }
+			foreach (C3BitstructField bitf : fields.bit[index].fields)
+			{
+			acc += printIndent(out, indent_level + 1);
+			acc += io::fprintfn(out, "%s %s : %s..%s;", bitf.type, bitf.name, bitf.from, bitf.to)!;
+			}
 
-        acc += printIndent(out, indent_level);
-        acc += io::fprintfn(out, "}")!;
+			acc += printIndent(out, indent_level);
+			acc += io::fprintfn(out, "}")!;
 
-      case STRUCT:
-        acc += wter::structDecl(out, state, fields.structs[index].name, &fields.structs[index].fields, indent_level);
+		case STRUCT:
+			acc += wter::structDecl(out, state, fields.structs[index].name, &fields.structs[index].fields, indent_level);
 
-      case UNION:
-        acc += wter::unionDecl(out, state, fields.unions[index].name, &fields.unions[index].fields, indent_level);
-        
-      default: unreachable();
-    }
-  };
+		case UNION:
+			acc += wter::unionDecl(out, state, fields.unions[index].name, &fields.unions[index].fields, indent_level);
+			
+		default: unreachable();
+		}
+	};
 
-  return acc;
+	return acc;
 }
 
 
 <*
- Helper printer
+ 	Helper printer
 *>
 fn usz? printIndent( 
-  OutStream out, 
-  usz indent_level = 1)
+	OutStream out, 
+	usz indent_level = 1)
 {
-  usz? acc;
-  for (usz i; i < indent_level; ++i) acc += io::fprintf(out, INDENT);
-  return acc;
+	usz? acc;
+	for (usz i; i < indent_level; ++i) acc += io::fprintf(out, INDENT);
+	return acc;
 }
 

--- a/examples/clang-c/BuildSystem.h
+++ b/examples/clang-c/BuildSystem.h
@@ -1,0 +1,153 @@
+/*==-- clang-c/BuildSystem.h - Utilities for use by build systems -*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides various utilities for use by build systems.           *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_BUILDSYSTEM_H
+#define LLVM_CLANG_C_BUILDSYSTEM_H
+
+#include "clang-c/CXErrorCode.h"
+#include "clang-c/CXString.h"
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/**
+ * \defgroup BUILD_SYSTEM Build system utilities
+ * @{
+ */
+
+/**
+ * Return the timestamp for use with Clang's
+ * \c -fbuild-session-timestamp= option.
+ */
+CINDEX_LINKAGE unsigned long long clang_getBuildSessionTimestamp(void);
+
+/**
+ * Object encapsulating information about overlaying virtual
+ * file/directories over the real file system.
+ */
+typedef struct CXVirtualFileOverlayImpl *CXVirtualFileOverlay;
+
+/**
+ * Create a \c CXVirtualFileOverlay object.
+ * Must be disposed with \c clang_VirtualFileOverlay_dispose().
+ *
+ * \param options is reserved, always pass 0.
+ */
+CINDEX_LINKAGE CXVirtualFileOverlay
+clang_VirtualFileOverlay_create(unsigned options);
+
+/**
+ * Map an absolute virtual file path to an absolute real one.
+ * The virtual path must be canonicalized (not contain "."/"..").
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_VirtualFileOverlay_addFileMapping(CXVirtualFileOverlay,
+                                        const char *virtualPath,
+                                        const char *realPath);
+
+/**
+ * Set the case sensitivity for the \c CXVirtualFileOverlay object.
+ * The \c CXVirtualFileOverlay object is case-sensitive by default, this
+ * option can be used to override the default.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_VirtualFileOverlay_setCaseSensitivity(CXVirtualFileOverlay,
+                                            int caseSensitive);
+
+/**
+ * Write out the \c CXVirtualFileOverlay object to a char buffer.
+ *
+ * \param options is reserved, always pass 0.
+ * \param out_buffer_ptr pointer to receive the buffer pointer, which should be
+ * disposed using \c clang_free().
+ * \param out_buffer_size pointer to receive the buffer size.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_VirtualFileOverlay_writeToBuffer(CXVirtualFileOverlay, unsigned options,
+                                       char **out_buffer_ptr,
+                                       unsigned *out_buffer_size);
+
+/**
+ * free memory allocated by libclang, such as the buffer returned by
+ * \c CXVirtualFileOverlay() or \c clang_ModuleMapDescriptor_writeToBuffer().
+ *
+ * \param buffer memory pointer to free.
+ */
+CINDEX_LINKAGE void clang_free(void *buffer);
+
+/**
+ * Dispose a \c CXVirtualFileOverlay object.
+ */
+CINDEX_LINKAGE void clang_VirtualFileOverlay_dispose(CXVirtualFileOverlay);
+
+/**
+ * Object encapsulating information about a module.modulemap file.
+ */
+typedef struct CXModuleMapDescriptorImpl *CXModuleMapDescriptor;
+
+/**
+ * Create a \c CXModuleMapDescriptor object.
+ * Must be disposed with \c clang_ModuleMapDescriptor_dispose().
+ *
+ * \param options is reserved, always pass 0.
+ */
+CINDEX_LINKAGE CXModuleMapDescriptor
+clang_ModuleMapDescriptor_create(unsigned options);
+
+/**
+ * Sets the framework module name that the module.modulemap describes.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_ModuleMapDescriptor_setFrameworkModuleName(CXModuleMapDescriptor,
+                                                 const char *name);
+
+/**
+ * Sets the umbrella header name that the module.modulemap describes.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_ModuleMapDescriptor_setUmbrellaHeader(CXModuleMapDescriptor,
+                                            const char *name);
+
+/**
+ * Write out the \c CXModuleMapDescriptor object to a char buffer.
+ *
+ * \param options is reserved, always pass 0.
+ * \param out_buffer_ptr pointer to receive the buffer pointer, which should be
+ * disposed using \c clang_free().
+ * \param out_buffer_size pointer to receive the buffer size.
+ * \returns 0 for success, non-zero to indicate an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_ModuleMapDescriptor_writeToBuffer(CXModuleMapDescriptor, unsigned options,
+                                       char **out_buffer_ptr,
+                                       unsigned *out_buffer_size);
+
+/**
+ * Dispose a \c CXModuleMapDescriptor object.
+ */
+CINDEX_LINKAGE void clang_ModuleMapDescriptor_dispose(CXModuleMapDescriptor);
+
+/**
+ * @}
+ */
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif /* CLANG_C_BUILD_SYSTEM_H */
+

--- a/examples/clang-c/CXCompilationDatabase.h
+++ b/examples/clang-c/CXCompilationDatabase.h
@@ -1,0 +1,174 @@
+/*===-- clang-c/CXCompilationDatabase.h - Compilation database  ---*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides a public interface to use CompilationDatabase without *|
+|* the full Clang C++ API.                                                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_CXCOMPILATIONDATABASE_H
+#define LLVM_CLANG_C_CXCOMPILATIONDATABASE_H
+
+#include "clang-c/CXString.h"
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/** \defgroup COMPILATIONDB CompilationDatabase functions
+ * \ingroup CINDEX
+ *
+ * @{
+ */
+
+/**
+ * A compilation database holds all information used to compile files in a
+ * project. For each file in the database, it can be queried for the working
+ * directory or the command line used for the compiler invocation.
+ *
+ * Must be freed by \c clang_CompilationDatabase_dispose
+ */
+typedef void * CXCompilationDatabase;
+
+/**
+ * Contains the results of a search in the compilation database
+ *
+ * When searching for the compile command for a file, the compilation db can
+ * return several commands, as the file may have been compiled with
+ * different options in different places of the project. This choice of compile
+ * commands is wrapped in this opaque data structure. It must be freed by
+ * \c clang_CompileCommands_dispose.
+ */
+typedef void * CXCompileCommands;
+
+/**
+ * Represents the command line invocation to compile a specific file.
+ */
+typedef void * CXCompileCommand;
+
+/**
+ * Error codes for Compilation Database
+ */
+typedef enum  {
+  /*
+   * No error occurred
+   */
+  CXCompilationDatabase_NoError = 0,
+
+  /*
+   * Database can not be loaded
+   */
+  CXCompilationDatabase_CanNotLoadDatabase = 1
+
+} CXCompilationDatabase_Error;
+
+/**
+ * Creates a compilation database from the database found in directory
+ * buildDir. For example, CMake can output a compile_commands.json which can
+ * be used to build the database.
+ *
+ * It must be freed by \c clang_CompilationDatabase_dispose.
+ */
+CINDEX_LINKAGE CXCompilationDatabase
+clang_CompilationDatabase_fromDirectory(const char *BuildDir,
+                                        CXCompilationDatabase_Error *ErrorCode);
+
+/**
+ * Free the given compilation database
+ */
+CINDEX_LINKAGE void
+clang_CompilationDatabase_dispose(CXCompilationDatabase);
+
+/**
+ * Find the compile commands used for a file. The compile commands
+ * must be freed by \c clang_CompileCommands_dispose.
+ */
+CINDEX_LINKAGE CXCompileCommands
+clang_CompilationDatabase_getCompileCommands(CXCompilationDatabase,
+                                             const char *CompleteFileName);
+
+/**
+ * Get all the compile commands in the given compilation database.
+ */
+CINDEX_LINKAGE CXCompileCommands
+clang_CompilationDatabase_getAllCompileCommands(CXCompilationDatabase);
+
+/**
+ * Free the given CompileCommands
+ */
+CINDEX_LINKAGE void clang_CompileCommands_dispose(CXCompileCommands);
+
+/**
+ * Get the number of CompileCommand we have for a file
+ */
+CINDEX_LINKAGE unsigned
+clang_CompileCommands_getSize(CXCompileCommands);
+
+/**
+ * Get the I'th CompileCommand for a file
+ *
+ * Note : 0 <= i < clang_CompileCommands_getSize(CXCompileCommands)
+ */
+CINDEX_LINKAGE CXCompileCommand
+clang_CompileCommands_getCommand(CXCompileCommands, unsigned I);
+
+/**
+ * Get the working directory where the CompileCommand was executed from
+ */
+CINDEX_LINKAGE CXString
+clang_CompileCommand_getDirectory(CXCompileCommand);
+
+/**
+ * Get the filename associated with the CompileCommand.
+ */
+CINDEX_LINKAGE CXString
+clang_CompileCommand_getFilename(CXCompileCommand);
+
+/**
+ * Get the number of arguments in the compiler invocation.
+ *
+ */
+CINDEX_LINKAGE unsigned
+clang_CompileCommand_getNumArgs(CXCompileCommand);
+
+/**
+ * Get the I'th argument value in the compiler invocations
+ *
+ * Invariant :
+ *  - argument 0 is the compiler executable
+ */
+CINDEX_LINKAGE CXString
+clang_CompileCommand_getArg(CXCompileCommand, unsigned I);
+
+/**
+ * Get the number of source mappings for the compiler invocation.
+ */
+CINDEX_LINKAGE unsigned
+clang_CompileCommand_getNumMappedSources(CXCompileCommand);
+
+/**
+ * Get the I'th mapped source path for the compiler invocation.
+ */
+CINDEX_LINKAGE CXString
+clang_CompileCommand_getMappedSourcePath(CXCompileCommand, unsigned I);
+
+/**
+ * Get the I'th mapped source content for the compiler invocation.
+ */
+CINDEX_LINKAGE CXString
+clang_CompileCommand_getMappedSourceContent(CXCompileCommand, unsigned I);
+
+/**
+ * @}
+ */
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif
+

--- a/examples/clang-c/CXDiagnostic.h
+++ b/examples/clang-c/CXDiagnostic.h
@@ -1,0 +1,379 @@
+/*===-- clang-c/CXDiagnostic.h - C Index Diagnostics --------------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides the interface to C Index diagnostics.                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_CXDIAGNOSTIC_H
+#define LLVM_CLANG_C_CXDIAGNOSTIC_H
+
+#include "clang-c/CXSourceLocation.h"
+#include "clang-c/CXString.h"
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/**
+ * \defgroup CINDEX_DIAG Diagnostic reporting
+ *
+ * @{
+ */
+
+/**
+ * Describes the severity of a particular diagnostic.
+ */
+enum CXDiagnosticSeverity {
+  /**
+   * A diagnostic that has been suppressed, e.g., by a command-line
+   * option.
+   */
+  CXDiagnostic_Ignored = 0,
+
+  /**
+   * This diagnostic is a note that should be attached to the
+   * previous (non-note) diagnostic.
+   */
+  CXDiagnostic_Note = 1,
+
+  /**
+   * This diagnostic indicates suspicious code that may not be
+   * wrong.
+   */
+  CXDiagnostic_Warning = 2,
+
+  /**
+   * This diagnostic indicates that the code is ill-formed.
+   */
+  CXDiagnostic_Error = 3,
+
+  /**
+   * This diagnostic indicates that the code is ill-formed such
+   * that future parser recovery is unlikely to produce useful
+   * results.
+   */
+  CXDiagnostic_Fatal = 4
+};
+
+/**
+ * A single diagnostic, containing the diagnostic's severity,
+ * location, text, source ranges, and fix-it hints.
+ */
+typedef void *CXDiagnostic;
+
+/**
+ * A group of CXDiagnostics.
+ */
+typedef void *CXDiagnosticSet;
+
+/**
+ * Determine the number of diagnostics in a CXDiagnosticSet.
+ */
+CINDEX_LINKAGE unsigned clang_getNumDiagnosticsInSet(CXDiagnosticSet Diags);
+
+/**
+ * Retrieve a diagnostic associated with the given CXDiagnosticSet.
+ *
+ * \param Diags the CXDiagnosticSet to query.
+ * \param Index the zero-based diagnostic number to retrieve.
+ *
+ * \returns the requested diagnostic. This diagnostic must be freed
+ * via a call to \c clang_disposeDiagnostic().
+ */
+CINDEX_LINKAGE CXDiagnostic clang_getDiagnosticInSet(CXDiagnosticSet Diags,
+                                                     unsigned Index);
+
+/**
+ * Describes the kind of error that occurred (if any) in a call to
+ * \c clang_loadDiagnostics.
+ */
+enum CXLoadDiag_Error {
+  /**
+   * Indicates that no error occurred.
+   */
+  CXLoadDiag_None = 0,
+
+  /**
+   * Indicates that an unknown error occurred while attempting to
+   * deserialize diagnostics.
+   */
+  CXLoadDiag_Unknown = 1,
+
+  /**
+   * Indicates that the file containing the serialized diagnostics
+   * could not be opened.
+   */
+  CXLoadDiag_CannotLoad = 2,
+
+  /**
+   * Indicates that the serialized diagnostics file is invalid or
+   * corrupt.
+   */
+  CXLoadDiag_InvalidFile = 3
+};
+
+/**
+ * Deserialize a set of diagnostics from a Clang diagnostics bitcode
+ * file.
+ *
+ * \param file The name of the file to deserialize.
+ * \param error A pointer to a enum value recording if there was a problem
+ *        deserializing the diagnostics.
+ * \param errorString A pointer to a CXString for recording the error string
+ *        if the file was not successfully loaded.
+ *
+ * \returns A loaded CXDiagnosticSet if successful, and NULL otherwise.  These
+ * diagnostics should be released using clang_disposeDiagnosticSet().
+ */
+CINDEX_LINKAGE CXDiagnosticSet clang_loadDiagnostics(
+    const char *file, enum CXLoadDiag_Error *error, CXString *errorString);
+
+/**
+ * Release a CXDiagnosticSet and all of its contained diagnostics.
+ */
+CINDEX_LINKAGE void clang_disposeDiagnosticSet(CXDiagnosticSet Diags);
+
+/**
+ * Retrieve the child diagnostics of a CXDiagnostic.
+ *
+ * This CXDiagnosticSet does not need to be released by
+ * clang_disposeDiagnosticSet.
+ */
+CINDEX_LINKAGE CXDiagnosticSet clang_getChildDiagnostics(CXDiagnostic D);
+
+/**
+ * Destroy a diagnostic.
+ */
+CINDEX_LINKAGE void clang_disposeDiagnostic(CXDiagnostic Diagnostic);
+
+/**
+ * Options to control the display of diagnostics.
+ *
+ * The values in this enum are meant to be combined to customize the
+ * behavior of \c clang_formatDiagnostic().
+ */
+enum CXDiagnosticDisplayOptions {
+  /**
+   * Display the source-location information where the
+   * diagnostic was located.
+   *
+   * When set, diagnostics will be prefixed by the file, line, and
+   * (optionally) column to which the diagnostic refers. For example,
+   *
+   * \code
+   * test.c:28: warning: extra tokens at end of #endif directive
+   * \endcode
+   *
+   * This option corresponds to the clang flag \c -fshow-source-location.
+   */
+  CXDiagnostic_DisplaySourceLocation = 0x01,
+
+  /**
+   * If displaying the source-location information of the
+   * diagnostic, also include the column number.
+   *
+   * This option corresponds to the clang flag \c -fshow-column.
+   */
+  CXDiagnostic_DisplayColumn = 0x02,
+
+  /**
+   * If displaying the source-location information of the
+   * diagnostic, also include information about source ranges in a
+   * machine-parsable format.
+   *
+   * This option corresponds to the clang flag
+   * \c -fdiagnostics-print-source-range-info.
+   */
+  CXDiagnostic_DisplaySourceRanges = 0x04,
+
+  /**
+   * Display the option name associated with this diagnostic, if any.
+   *
+   * The option name displayed (e.g., -Wconversion) will be placed in brackets
+   * after the diagnostic text. This option corresponds to the clang flag
+   * \c -fdiagnostics-show-option.
+   */
+  CXDiagnostic_DisplayOption = 0x08,
+
+  /**
+   * Display the category number associated with this diagnostic, if any.
+   *
+   * The category number is displayed within brackets after the diagnostic text.
+   * This option corresponds to the clang flag
+   * \c -fdiagnostics-show-category=id.
+   */
+  CXDiagnostic_DisplayCategoryId = 0x10,
+
+  /**
+   * Display the category name associated with this diagnostic, if any.
+   *
+   * The category name is displayed within brackets after the diagnostic text.
+   * This option corresponds to the clang flag
+   * \c -fdiagnostics-show-category=name.
+   */
+  CXDiagnostic_DisplayCategoryName = 0x20
+};
+
+/**
+ * Format the given diagnostic in a manner that is suitable for display.
+ *
+ * This routine will format the given diagnostic to a string, rendering
+ * the diagnostic according to the various options given. The
+ * \c clang_defaultDiagnosticDisplayOptions() function returns the set of
+ * options that most closely mimics the behavior of the clang compiler.
+ *
+ * \param Diagnostic The diagnostic to print.
+ *
+ * \param Options A set of options that control the diagnostic display,
+ * created by combining \c CXDiagnosticDisplayOptions values.
+ *
+ * \returns A new string containing for formatted diagnostic.
+ */
+CINDEX_LINKAGE CXString clang_formatDiagnostic(CXDiagnostic Diagnostic,
+                                               unsigned Options);
+
+/**
+ * Retrieve the set of display options most similar to the
+ * default behavior of the clang compiler.
+ *
+ * \returns A set of display options suitable for use with \c
+ * clang_formatDiagnostic().
+ */
+CINDEX_LINKAGE unsigned clang_defaultDiagnosticDisplayOptions(void);
+
+/**
+ * Determine the severity of the given diagnostic.
+ */
+CINDEX_LINKAGE enum CXDiagnosticSeverity
+    clang_getDiagnosticSeverity(CXDiagnostic);
+
+/**
+ * Retrieve the source location of the given diagnostic.
+ *
+ * This location is where Clang would print the caret ('^') when
+ * displaying the diagnostic on the command line.
+ */
+CINDEX_LINKAGE CXSourceLocation clang_getDiagnosticLocation(CXDiagnostic);
+
+/**
+ * Retrieve the text of the given diagnostic.
+ */
+CINDEX_LINKAGE CXString clang_getDiagnosticSpelling(CXDiagnostic);
+
+/**
+ * Retrieve the name of the command-line option that enabled this
+ * diagnostic.
+ *
+ * \param Diag The diagnostic to be queried.
+ *
+ * \param Disable If non-NULL, will be set to the option that disables this
+ * diagnostic (if any).
+ *
+ * \returns A string that contains the command-line option used to enable this
+ * warning, such as "-Wconversion" or "-pedantic".
+ */
+CINDEX_LINKAGE CXString clang_getDiagnosticOption(CXDiagnostic Diag,
+                                                  CXString *Disable);
+
+/**
+ * Retrieve the category number for this diagnostic.
+ *
+ * Diagnostics can be categorized into groups along with other, related
+ * diagnostics (e.g., diagnostics under the same warning flag). This routine
+ * retrieves the category number for the given diagnostic.
+ *
+ * \returns The number of the category that contains this diagnostic, or zero
+ * if this diagnostic is uncategorized.
+ */
+CINDEX_LINKAGE unsigned clang_getDiagnosticCategory(CXDiagnostic);
+
+/**
+ * Retrieve the name of a particular diagnostic category.  This
+ *  is now deprecated.  Use clang_getDiagnosticCategoryText()
+ *  instead.
+ *
+ * \param Category A diagnostic category number, as returned by
+ * \c clang_getDiagnosticCategory().
+ *
+ * \returns The name of the given diagnostic category.
+ */
+CINDEX_DEPRECATED CINDEX_LINKAGE CXString
+clang_getDiagnosticCategoryName(unsigned Category);
+
+/**
+ * Retrieve the diagnostic category text for a given diagnostic.
+ *
+ * \returns The text of the given diagnostic category.
+ */
+CINDEX_LINKAGE CXString clang_getDiagnosticCategoryText(CXDiagnostic);
+
+/**
+ * Determine the number of source ranges associated with the given
+ * diagnostic.
+ */
+CINDEX_LINKAGE unsigned clang_getDiagnosticNumRanges(CXDiagnostic);
+
+/**
+ * Retrieve a source range associated with the diagnostic.
+ *
+ * A diagnostic's source ranges highlight important elements in the source
+ * code. On the command line, Clang displays source ranges by
+ * underlining them with '~' characters.
+ *
+ * \param Diagnostic the diagnostic whose range is being extracted.
+ *
+ * \param Range the zero-based index specifying which range to
+ *
+ * \returns the requested source range.
+ */
+CINDEX_LINKAGE CXSourceRange clang_getDiagnosticRange(CXDiagnostic Diagnostic,
+                                                      unsigned Range);
+
+/**
+ * Determine the number of fix-it hints associated with the
+ * given diagnostic.
+ */
+CINDEX_LINKAGE unsigned clang_getDiagnosticNumFixIts(CXDiagnostic Diagnostic);
+
+/**
+ * Retrieve the replacement information for a given fix-it.
+ *
+ * Fix-its are described in terms of a source range whose contents
+ * should be replaced by a string. This approach generalizes over
+ * three kinds of operations: removal of source code (the range covers
+ * the code to be removed and the replacement string is empty),
+ * replacement of source code (the range covers the code to be
+ * replaced and the replacement string provides the new code), and
+ * insertion (both the start and end of the range point at the
+ * insertion location, and the replacement string provides the text to
+ * insert).
+ *
+ * \param Diagnostic The diagnostic whose fix-its are being queried.
+ *
+ * \param FixIt The zero-based index of the fix-it.
+ *
+ * \param ReplacementRange The source range whose contents will be
+ * replaced with the returned replacement string. Note that source
+ * ranges are half-open ranges [a, b), so the source code should be
+ * replaced from a and up to (but not including) b.
+ *
+ * \returns A string containing text that should be replace the source
+ * code indicated by the \c ReplacementRange.
+ */
+CINDEX_LINKAGE CXString clang_getDiagnosticFixIt(
+    CXDiagnostic Diagnostic, unsigned FixIt, CXSourceRange *ReplacementRange);
+
+/**
+ * @}
+ */
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif

--- a/examples/clang-c/CXErrorCode.h
+++ b/examples/clang-c/CXErrorCode.h
@@ -1,0 +1,62 @@
+/*===-- clang-c/CXErrorCode.h - C Index Error Codes  --------------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides the CXErrorCode enumerators.                          *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_CXERRORCODE_H
+#define LLVM_CLANG_C_CXERRORCODE_H
+
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/**
+ * Error codes returned by libclang routines.
+ *
+ * Zero (\c CXError_Success) is the only error code indicating success.  Other
+ * error codes, including not yet assigned non-zero values, indicate errors.
+ */
+enum CXErrorCode {
+  /**
+   * No error.
+   */
+  CXError_Success = 0,
+
+  /**
+   * A generic error code, no further details are available.
+   *
+   * Errors of this kind can get their own specific error codes in future
+   * libclang versions.
+   */
+  CXError_Failure = 1,
+
+  /**
+   * libclang crashed while performing the requested operation.
+   */
+  CXError_Crashed = 2,
+
+  /**
+   * The function detected that the arguments violate the function
+   * contract.
+   */
+  CXError_InvalidArguments = 3,
+
+  /**
+   * An AST deserialization error has occurred.
+   */
+  CXError_ASTReadError = 4
+};
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif
+

--- a/examples/clang-c/CXFile.h
+++ b/examples/clang-c/CXFile.h
@@ -1,0 +1,83 @@
+/*===-- clang-c/CXFile.h - C Index File ---------------------------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides the interface to C Index files.                       *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_CXFILE_H
+#define LLVM_CLANG_C_CXFILE_H
+
+#include <time.h>
+
+#include "clang-c/CXString.h"
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/**
+ * \defgroup CINDEX_FILES File manipulation routines
+ *
+ * @{
+ */
+
+/**
+ * A particular source file that is part of a translation unit.
+ */
+typedef void *CXFile;
+
+/**
+ * Retrieve the complete file and path name of the given file.
+ */
+CINDEX_LINKAGE CXString clang_getFileName(CXFile SFile);
+
+/**
+ * Retrieve the last modification time of the given file.
+ */
+CINDEX_LINKAGE time_t clang_getFileTime(CXFile SFile);
+
+/**
+ * Uniquely identifies a CXFile, that refers to the same underlying file,
+ * across an indexing session.
+ */
+typedef struct {
+  unsigned long long data[3];
+} CXFileUniqueID;
+
+/**
+ * Retrieve the unique ID for the given \c file.
+ *
+ * \param file the file to get the ID for.
+ * \param outID stores the returned CXFileUniqueID.
+ * \returns If there was a failure getting the unique ID, returns non-zero,
+ * otherwise returns 0.
+ */
+CINDEX_LINKAGE int clang_getFileUniqueID(CXFile file, CXFileUniqueID *outID);
+
+/**
+ * Returns non-zero if the \c file1 and \c file2 point to the same file,
+ * or they are both NULL.
+ */
+CINDEX_LINKAGE int clang_File_isEqual(CXFile file1, CXFile file2);
+
+/**
+ * Returns the real path name of \c file.
+ *
+ * An empty string may be returned. Use \c clang_getFileName() in that case.
+ */
+CINDEX_LINKAGE CXString clang_File_tryGetRealPathName(CXFile file);
+
+/**
+ * @}
+ */
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif

--- a/examples/clang-c/CXSourceLocation.h
+++ b/examples/clang-c/CXSourceLocation.h
@@ -1,0 +1,296 @@
+/*===-- clang-c/CXSourceLocation.h - C Index Source Location ------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides the interface to C Index source locations.            *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_CXSOURCE_LOCATION_H
+#define LLVM_CLANG_C_CXSOURCE_LOCATION_H
+
+#include "clang-c/CXFile.h"
+#include "clang-c/CXString.h"
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/**
+ * \defgroup CINDEX_LOCATIONS Physical source locations
+ *
+ * Clang represents physical source locations in its abstract syntax tree in
+ * great detail, with file, line, and column information for the majority of
+ * the tokens parsed in the source code. These data types and functions are
+ * used to represent source location information, either for a particular
+ * point in the program or for a range of points in the program, and extract
+ * specific location information from those data types.
+ *
+ * @{
+ */
+
+/**
+ * Identifies a specific source location within a translation
+ * unit.
+ *
+ * Use clang_getExpansionLocation() or clang_getSpellingLocation()
+ * to map a source location to a particular file, line, and column.
+ */
+typedef struct {
+  const void *ptr_data[2];
+  unsigned int_data;
+} CXSourceLocation;
+
+/**
+ * Identifies a half-open character range in the source code.
+ *
+ * Use clang_getRangeStart() and clang_getRangeEnd() to retrieve the
+ * starting and end locations from a source range, respectively.
+ */
+typedef struct {
+  const void *ptr_data[2];
+  unsigned begin_int_data;
+  unsigned end_int_data;
+} CXSourceRange;
+
+/**
+ * Retrieve a NULL (invalid) source location.
+ */
+CINDEX_LINKAGE CXSourceLocation clang_getNullLocation(void);
+
+/**
+ * Determine whether two source locations, which must refer into
+ * the same translation unit, refer to exactly the same point in the source
+ * code.
+ *
+ * \returns non-zero if the source locations refer to the same location, zero
+ * if they refer to different locations.
+ */
+CINDEX_LINKAGE unsigned clang_equalLocations(CXSourceLocation loc1,
+                                             CXSourceLocation loc2);
+
+/**
+ * Determine for two source locations if the first comes
+ * strictly before the second one in the source code.
+ *
+ * \returns non-zero if the first source location comes
+ * strictly before the second one, zero otherwise.
+ */
+CINDEX_LINKAGE unsigned clang_isBeforeInTranslationUnit(CXSourceLocation loc1,
+                                                        CXSourceLocation loc2);
+
+/**
+ * Returns non-zero if the given source location is in a system header.
+ */
+CINDEX_LINKAGE int clang_Location_isInSystemHeader(CXSourceLocation location);
+
+/**
+ * Returns non-zero if the given source location is in the main file of
+ * the corresponding translation unit.
+ */
+CINDEX_LINKAGE int clang_Location_isFromMainFile(CXSourceLocation location);
+
+/**
+ * Retrieve a NULL (invalid) source range.
+ */
+CINDEX_LINKAGE CXSourceRange clang_getNullRange(void);
+
+/**
+ * Retrieve a source range given the beginning and ending source
+ * locations.
+ */
+CINDEX_LINKAGE CXSourceRange clang_getRange(CXSourceLocation begin,
+                                            CXSourceLocation end);
+
+/**
+ * Determine whether two ranges are equivalent.
+ *
+ * \returns non-zero if the ranges are the same, zero if they differ.
+ */
+CINDEX_LINKAGE unsigned clang_equalRanges(CXSourceRange range1,
+                                          CXSourceRange range2);
+
+/**
+ * Returns non-zero if \p range is null.
+ */
+CINDEX_LINKAGE int clang_Range_isNull(CXSourceRange range);
+
+/**
+ * Retrieve the file, line, column, and offset represented by
+ * the given source location.
+ *
+ * If the location refers into a macro expansion, retrieves the
+ * location of the macro expansion.
+ *
+ * \param location the location within a source file that will be decomposed
+ * into its parts.
+ *
+ * \param file [out] if non-NULL, will be set to the file to which the given
+ * source location points.
+ *
+ * \param line [out] if non-NULL, will be set to the line to which the given
+ * source location points.
+ *
+ * \param column [out] if non-NULL, will be set to the column to which the given
+ * source location points.
+ *
+ * \param offset [out] if non-NULL, will be set to the offset into the
+ * buffer to which the given source location points.
+ */
+CINDEX_LINKAGE void clang_getExpansionLocation(CXSourceLocation location,
+                                               CXFile *file, unsigned *line,
+                                               unsigned *column,
+                                               unsigned *offset);
+
+/**
+ * Retrieve the file, line and column represented by the given source
+ * location, as specified in a # line directive.
+ *
+ * Example: given the following source code in a file somefile.c
+ *
+ * \code
+ * #123 "dummy.c" 1
+ *
+ * static int func(void)
+ * {
+ *     return 0;
+ * }
+ * \endcode
+ *
+ * the location information returned by this function would be
+ *
+ * File: dummy.c Line: 124 Column: 12
+ *
+ * whereas clang_getExpansionLocation would have returned
+ *
+ * File: somefile.c Line: 3 Column: 12
+ *
+ * \param location the location within a source file that will be decomposed
+ * into its parts.
+ *
+ * \param filename [out] if non-NULL, will be set to the filename of the
+ * source location. Note that filenames returned will be for "virtual" files,
+ * which don't necessarily exist on the machine running clang - e.g. when
+ * parsing preprocessed output obtained from a different environment. If
+ * a non-NULL value is passed in, remember to dispose of the returned value
+ * using \c clang_disposeString() once you've finished with it. For an invalid
+ * source location, an empty string is returned.
+ *
+ * \param line [out] if non-NULL, will be set to the line number of the
+ * source location. For an invalid source location, zero is returned.
+ *
+ * \param column [out] if non-NULL, will be set to the column number of the
+ * source location. For an invalid source location, zero is returned.
+ */
+CINDEX_LINKAGE void clang_getPresumedLocation(CXSourceLocation location,
+                                              CXString *filename,
+                                              unsigned *line, unsigned *column);
+
+/**
+ * Legacy API to retrieve the file, line, column, and offset represented
+ * by the given source location.
+ *
+ * This interface has been replaced by the newer interface
+ * #clang_getExpansionLocation(). See that interface's documentation for
+ * details.
+ */
+CINDEX_LINKAGE void clang_getInstantiationLocation(CXSourceLocation location,
+                                                   CXFile *file, unsigned *line,
+                                                   unsigned *column,
+                                                   unsigned *offset);
+
+/**
+ * Retrieve the file, line, column, and offset represented by
+ * the given source location.
+ *
+ * If the location refers into a macro instantiation, return where the
+ * location was originally spelled in the source file.
+ *
+ * \param location the location within a source file that will be decomposed
+ * into its parts.
+ *
+ * \param file [out] if non-NULL, will be set to the file to which the given
+ * source location points.
+ *
+ * \param line [out] if non-NULL, will be set to the line to which the given
+ * source location points.
+ *
+ * \param column [out] if non-NULL, will be set to the column to which the given
+ * source location points.
+ *
+ * \param offset [out] if non-NULL, will be set to the offset into the
+ * buffer to which the given source location points.
+ */
+CINDEX_LINKAGE void clang_getSpellingLocation(CXSourceLocation location,
+                                              CXFile *file, unsigned *line,
+                                              unsigned *column,
+                                              unsigned *offset);
+
+/**
+ * Retrieve the file, line, column, and offset represented by
+ * the given source location.
+ *
+ * If the location refers into a macro expansion, return where the macro was
+ * expanded or where the macro argument was written, if the location points at
+ * a macro argument.
+ *
+ * \param location the location within a source file that will be decomposed
+ * into its parts.
+ *
+ * \param file [out] if non-NULL, will be set to the file to which the given
+ * source location points.
+ *
+ * \param line [out] if non-NULL, will be set to the line to which the given
+ * source location points.
+ *
+ * \param column [out] if non-NULL, will be set to the column to which the given
+ * source location points.
+ *
+ * \param offset [out] if non-NULL, will be set to the offset into the
+ * buffer to which the given source location points.
+ */
+CINDEX_LINKAGE void clang_getFileLocation(CXSourceLocation location,
+                                          CXFile *file, unsigned *line,
+                                          unsigned *column, unsigned *offset);
+
+/**
+ * Retrieve a source location representing the first character within a
+ * source range.
+ */
+CINDEX_LINKAGE CXSourceLocation clang_getRangeStart(CXSourceRange range);
+
+/**
+ * Retrieve a source location representing the last character within a
+ * source range.
+ */
+CINDEX_LINKAGE CXSourceLocation clang_getRangeEnd(CXSourceRange range);
+
+/**
+ * Identifies an array of ranges.
+ */
+typedef struct {
+  /** The number of ranges in the \c ranges array. */
+  unsigned count;
+  /**
+   * An array of \c CXSourceRanges.
+   */
+  CXSourceRange *ranges;
+} CXSourceRangeList;
+
+/**
+ * Destroy the given \c CXSourceRangeList.
+ */
+CINDEX_LINKAGE void clang_disposeSourceRangeList(CXSourceRangeList *ranges);
+
+/**
+ * @}
+ */
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif

--- a/examples/clang-c/CXString.h
+++ b/examples/clang-c/CXString.h
@@ -1,0 +1,73 @@
+/*===-- clang-c/CXString.h - C Index strings  --------------------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides the interface to C Index strings.                     *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_CXSTRING_H
+#define LLVM_CLANG_C_CXSTRING_H
+
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/**
+ * \defgroup CINDEX_STRING String manipulation routines
+ * \ingroup CINDEX
+ *
+ * @{
+ */
+
+/**
+ * A character string.
+ *
+ * The \c CXString type is used to return strings from the interface when
+ * the ownership of that string might differ from one call to the next.
+ * Use \c clang_getCString() to retrieve the string data and, once finished
+ * with the string data, call \c clang_disposeString() to free the string.
+ */
+typedef struct {
+  const void *data;
+  unsigned private_flags;
+} CXString;
+
+typedef struct {
+  CXString *Strings;
+  unsigned Count;
+} CXStringSet;
+
+/**
+ * Retrieve the character data associated with the given string.
+ *
+ * The returned data is a reference and not owned by the user. This data
+ * is only valid while the `CXString` is valid. This function is similar
+ * to `std::string::c_str()`.
+ */
+CINDEX_LINKAGE const char *clang_getCString(CXString string);
+
+/**
+ * Free the given string.
+ */
+CINDEX_LINKAGE void clang_disposeString(CXString string);
+
+/**
+ * Free the given string set.
+ */
+CINDEX_LINKAGE void clang_disposeStringSet(CXStringSet *set);
+
+/**
+ * @}
+ */
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif
+

--- a/examples/clang-c/Documentation.h
+++ b/examples/clang-c/Documentation.h
@@ -1,0 +1,619 @@
+/*==-- clang-c/Documentation.h - Utilities for comment processing -*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides a supplementary interface for inspecting              *|
+|* documentation comments.                                                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_DOCUMENTATION_H
+#define LLVM_CLANG_C_DOCUMENTATION_H
+
+#include "clang-c/CXErrorCode.h"
+#include "clang-c/ExternC.h"
+#include "clang-c/Index.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/**
+ * \defgroup CINDEX_COMMENT Comment introspection
+ *
+ * The routines in this group provide access to information in documentation
+ * comments. These facilities are distinct from the core and may be subject to
+ * their own schedule of stability and deprecation.
+ *
+ * @{
+ */
+
+/**
+ * A parsed comment.
+ */
+typedef struct {
+  const void *ASTNode;
+  CXTranslationUnit TranslationUnit;
+} CXComment;
+
+/**
+ * Given a cursor that represents a documentable entity (e.g.,
+ * declaration), return the associated parsed comment as a
+ * \c CXComment_FullComment AST node.
+ */
+CINDEX_LINKAGE CXComment clang_Cursor_getParsedComment(CXCursor C);
+
+/**
+ * Describes the type of the comment AST node (\c CXComment).  A comment
+ * node can be considered block content (e. g., paragraph), inline content
+ * (plain text) or neither (the root AST node).
+ */
+enum CXCommentKind {
+  /**
+   * Null comment.  No AST node is constructed at the requested location
+   * because there is no text or a syntax error.
+   */
+  CXComment_Null = 0,
+
+  /**
+   * Plain text.  Inline content.
+   */
+  CXComment_Text = 1,
+
+  /**
+   * A command with word-like arguments that is considered inline content.
+   *
+   * For example: \\c command.
+   */
+  CXComment_InlineCommand = 2,
+
+  /**
+   * HTML start tag with attributes (name-value pairs).  Considered
+   * inline content.
+   *
+   * For example:
+   * \verbatim
+   * <br> <br /> <a href="http://example.org/">
+   * \endverbatim
+   */
+  CXComment_HTMLStartTag = 3,
+
+  /**
+   * HTML end tag.  Considered inline content.
+   *
+   * For example:
+   * \verbatim
+   * </a>
+   * \endverbatim
+   */
+  CXComment_HTMLEndTag = 4,
+
+  /**
+   * A paragraph, contains inline comment.  The paragraph itself is
+   * block content.
+   */
+  CXComment_Paragraph = 5,
+
+  /**
+   * A command that has zero or more word-like arguments (number of
+   * word-like arguments depends on command name) and a paragraph as an
+   * argument.  Block command is block content.
+   *
+   * Paragraph argument is also a child of the block command.
+   *
+   * For example: \has 0 word-like arguments and a paragraph argument.
+   *
+   * AST nodes of special kinds that parser knows about (e. g., \\param
+   * command) have their own node kinds.
+   */
+  CXComment_BlockCommand = 6,
+
+  /**
+   * A \\param or \\arg command that describes the function parameter
+   * (name, passing direction, description).
+   *
+   * For example: \\param [in] ParamName description.
+   */
+  CXComment_ParamCommand = 7,
+
+  /**
+   * A \\tparam command that describes a template parameter (name and
+   * description).
+   *
+   * For example: \\tparam T description.
+   */
+  CXComment_TParamCommand = 8,
+
+  /**
+   * A verbatim block command (e. g., preformatted code).  Verbatim
+   * block has an opening and a closing command and contains multiple lines of
+   * text (\c CXComment_VerbatimBlockLine child nodes).
+   *
+   * For example:
+   * \\verbatim
+   * aaa
+   * \\endverbatim
+   */
+  CXComment_VerbatimBlockCommand = 9,
+
+  /**
+   * A line of text that is contained within a
+   * CXComment_VerbatimBlockCommand node.
+   */
+  CXComment_VerbatimBlockLine = 10,
+
+  /**
+   * A verbatim line command.  Verbatim line has an opening command,
+   * a single line of text (up to the newline after the opening command) and
+   * has no closing command.
+   */
+  CXComment_VerbatimLine = 11,
+
+  /**
+   * A full comment attached to a declaration, contains block content.
+   */
+  CXComment_FullComment = 12
+};
+
+/**
+ * The most appropriate rendering mode for an inline command, chosen on
+ * command semantics in Doxygen.
+ */
+enum CXCommentInlineCommandRenderKind {
+  /**
+   * Command argument should be rendered in a normal font.
+   */
+  CXCommentInlineCommandRenderKind_Normal,
+
+  /**
+   * Command argument should be rendered in a bold font.
+   */
+  CXCommentInlineCommandRenderKind_Bold,
+
+  /**
+   * Command argument should be rendered in a monospaced font.
+   */
+  CXCommentInlineCommandRenderKind_Monospaced,
+
+  /**
+   * Command argument should be rendered emphasized (typically italic
+   * font).
+   */
+  CXCommentInlineCommandRenderKind_Emphasized,
+
+  /**
+   * Command argument should not be rendered (since it only defines an anchor).
+   */
+  CXCommentInlineCommandRenderKind_Anchor
+};
+
+/**
+ * Describes parameter passing direction for \\param or \\arg command.
+ */
+enum CXCommentParamPassDirection {
+  /**
+   * The parameter is an input parameter.
+   */
+  CXCommentParamPassDirection_In,
+
+  /**
+   * The parameter is an output parameter.
+   */
+  CXCommentParamPassDirection_Out,
+
+  /**
+   * The parameter is an input and output parameter.
+   */
+  CXCommentParamPassDirection_InOut
+};
+
+/**
+ * \param Comment AST node of any kind.
+ *
+ * \returns the type of the AST node.
+ */
+CINDEX_LINKAGE enum CXCommentKind clang_Comment_getKind(CXComment Comment);
+
+/**
+ * \param Comment AST node of any kind.
+ *
+ * \returns number of children of the AST node.
+ */
+CINDEX_LINKAGE unsigned clang_Comment_getNumChildren(CXComment Comment);
+
+/**
+ * \param Comment AST node of any kind.
+ *
+ * \param ChildIdx child index (zero-based).
+ *
+ * \returns the specified child of the AST node.
+ */
+CINDEX_LINKAGE
+CXComment clang_Comment_getChild(CXComment Comment, unsigned ChildIdx);
+
+/**
+ * A \c CXComment_Paragraph node is considered whitespace if it contains
+ * only \c CXComment_Text nodes that are empty or whitespace.
+ *
+ * Other AST nodes (except \c CXComment_Paragraph and \c CXComment_Text) are
+ * never considered whitespace.
+ *
+ * \returns non-zero if \c Comment is whitespace.
+ */
+CINDEX_LINKAGE unsigned clang_Comment_isWhitespace(CXComment Comment);
+
+/**
+ * \returns non-zero if \c Comment is inline content and has a newline
+ * immediately following it in the comment text.  Newlines between paragraphs
+ * do not count.
+ */
+CINDEX_LINKAGE
+unsigned clang_InlineContentComment_hasTrailingNewline(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_Text AST node.
+ *
+ * \returns text contained in the AST node.
+ */
+CINDEX_LINKAGE CXString clang_TextComment_getText(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_InlineCommand AST node.
+ *
+ * \returns name of the inline command.
+ */
+CINDEX_LINKAGE
+CXString clang_InlineCommandComment_getCommandName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_InlineCommand AST node.
+ *
+ * \returns the most appropriate rendering mode, chosen on command
+ * semantics in Doxygen.
+ */
+CINDEX_LINKAGE enum CXCommentInlineCommandRenderKind
+clang_InlineCommandComment_getRenderKind(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_InlineCommand AST node.
+ *
+ * \returns number of command arguments.
+ */
+CINDEX_LINKAGE
+unsigned clang_InlineCommandComment_getNumArgs(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_InlineCommand AST node.
+ *
+ * \param ArgIdx argument index (zero-based).
+ *
+ * \returns text of the specified argument.
+ */
+CINDEX_LINKAGE
+CXString clang_InlineCommandComment_getArgText(CXComment Comment,
+                                               unsigned ArgIdx);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
+ * node.
+ *
+ * \returns HTML tag name.
+ */
+CINDEX_LINKAGE CXString clang_HTMLTagComment_getTagName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag AST node.
+ *
+ * \returns non-zero if tag is self-closing (for example, &lt;br /&gt;).
+ */
+CINDEX_LINKAGE
+unsigned clang_HTMLStartTagComment_isSelfClosing(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag AST node.
+ *
+ * \returns number of attributes (name-value pairs) attached to the start tag.
+ */
+CINDEX_LINKAGE unsigned clang_HTMLStartTag_getNumAttrs(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag AST node.
+ *
+ * \param AttrIdx attribute index (zero-based).
+ *
+ * \returns name of the specified attribute.
+ */
+CINDEX_LINKAGE
+CXString clang_HTMLStartTag_getAttrName(CXComment Comment, unsigned AttrIdx);
+
+/**
+ * \param Comment a \c CXComment_HTMLStartTag AST node.
+ *
+ * \param AttrIdx attribute index (zero-based).
+ *
+ * \returns value of the specified attribute.
+ */
+CINDEX_LINKAGE
+CXString clang_HTMLStartTag_getAttrValue(CXComment Comment, unsigned AttrIdx);
+
+/**
+ * \param Comment a \c CXComment_BlockCommand AST node.
+ *
+ * \returns name of the block command.
+ */
+CINDEX_LINKAGE
+CXString clang_BlockCommandComment_getCommandName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_BlockCommand AST node.
+ *
+ * \returns number of word-like arguments.
+ */
+CINDEX_LINKAGE
+unsigned clang_BlockCommandComment_getNumArgs(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_BlockCommand AST node.
+ *
+ * \param ArgIdx argument index (zero-based).
+ *
+ * \returns text of the specified word-like argument.
+ */
+CINDEX_LINKAGE
+CXString clang_BlockCommandComment_getArgText(CXComment Comment,
+                                              unsigned ArgIdx);
+
+/**
+ * \param Comment a \c CXComment_BlockCommand or
+ * \c CXComment_VerbatimBlockCommand AST node.
+ *
+ * \returns paragraph argument of the block command.
+ */
+CINDEX_LINKAGE
+CXComment clang_BlockCommandComment_getParagraph(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns parameter name.
+ */
+CINDEX_LINKAGE
+CXString clang_ParamCommandComment_getParamName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns non-zero if the parameter that this AST node represents was found
+ * in the function prototype and \c clang_ParamCommandComment_getParamIndex
+ * function will return a meaningful value.
+ */
+CINDEX_LINKAGE
+unsigned clang_ParamCommandComment_isParamIndexValid(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns zero-based parameter index in function prototype.
+ */
+CINDEX_LINKAGE
+unsigned clang_ParamCommandComment_getParamIndex(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns non-zero if parameter passing direction was specified explicitly in
+ * the comment.
+ */
+CINDEX_LINKAGE
+unsigned clang_ParamCommandComment_isDirectionExplicit(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_ParamCommand AST node.
+ *
+ * \returns parameter passing direction.
+ */
+CINDEX_LINKAGE
+enum CXCommentParamPassDirection clang_ParamCommandComment_getDirection(
+                                                            CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_TParamCommand AST node.
+ *
+ * \returns template parameter name.
+ */
+CINDEX_LINKAGE
+CXString clang_TParamCommandComment_getParamName(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_TParamCommand AST node.
+ *
+ * \returns non-zero if the parameter that this AST node represents was found
+ * in the template parameter list and
+ * \c clang_TParamCommandComment_getDepth and
+ * \c clang_TParamCommandComment_getIndex functions will return a meaningful
+ * value.
+ */
+CINDEX_LINKAGE
+unsigned clang_TParamCommandComment_isParamPositionValid(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_TParamCommand AST node.
+ *
+ * \returns zero-based nesting depth of this parameter in the template parameter list.
+ *
+ * For example,
+ * \verbatim
+ *     template<typename C, template<typename T> class TT>
+ *     void test(TT<int> aaa);
+ * \endverbatim
+ * for C and TT nesting depth is 0,
+ * for T nesting depth is 1.
+ */
+CINDEX_LINKAGE
+unsigned clang_TParamCommandComment_getDepth(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_TParamCommand AST node.
+ *
+ * \returns zero-based parameter index in the template parameter list at a
+ * given nesting depth.
+ *
+ * For example,
+ * \verbatim
+ *     template<typename C, template<typename T> class TT>
+ *     void test(TT<int> aaa);
+ * \endverbatim
+ * for C and TT nesting depth is 0, so we can ask for index at depth 0:
+ * at depth 0 C's index is 0, TT's index is 1.
+ *
+ * For T nesting depth is 1, so we can ask for index at depth 0 and 1:
+ * at depth 0 T's index is 1 (same as TT's),
+ * at depth 1 T's index is 0.
+ */
+CINDEX_LINKAGE
+unsigned clang_TParamCommandComment_getIndex(CXComment Comment, unsigned Depth);
+
+/**
+ * \param Comment a \c CXComment_VerbatimBlockLine AST node.
+ *
+ * \returns text contained in the AST node.
+ */
+CINDEX_LINKAGE
+CXString clang_VerbatimBlockLineComment_getText(CXComment Comment);
+
+/**
+ * \param Comment a \c CXComment_VerbatimLine AST node.
+ *
+ * \returns text contained in the AST node.
+ */
+CINDEX_LINKAGE CXString clang_VerbatimLineComment_getText(CXComment Comment);
+
+/**
+ * Convert an HTML tag AST node to string.
+ *
+ * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
+ * node.
+ *
+ * \returns string containing an HTML tag.
+ */
+CINDEX_LINKAGE CXString clang_HTMLTagComment_getAsString(CXComment Comment);
+
+/**
+ * Convert a given full parsed comment to an HTML fragment.
+ *
+ * Specific details of HTML layout are subject to change.  Don't try to parse
+ * this HTML back into an AST, use other APIs instead.
+ *
+ * Currently the following CSS classes are used:
+ * \li "para-brief" for \paragraph and equivalent commands;
+ * \li "para-returns" for \\returns paragraph and equivalent commands;
+ * \li "word-returns" for the "Returns" word in \\returns paragraph.
+ *
+ * Function argument documentation is rendered as a \<dl\> list with arguments
+ * sorted in function prototype order.  CSS classes used:
+ * \li "param-name-index-NUMBER" for parameter name (\<dt\>);
+ * \li "param-descr-index-NUMBER" for parameter description (\<dd\>);
+ * \li "param-name-index-invalid" and "param-descr-index-invalid" are used if
+ * parameter index is invalid.
+ *
+ * Template parameter documentation is rendered as a \<dl\> list with
+ * parameters sorted in template parameter list order.  CSS classes used:
+ * \li "tparam-name-index-NUMBER" for parameter name (\<dt\>);
+ * \li "tparam-descr-index-NUMBER" for parameter description (\<dd\>);
+ * \li "tparam-name-index-other" and "tparam-descr-index-other" are used for
+ * names inside template template parameters;
+ * \li "tparam-name-index-invalid" and "tparam-descr-index-invalid" are used if
+ * parameter position is invalid.
+ *
+ * \param Comment a \c CXComment_FullComment AST node.
+ *
+ * \returns string containing an HTML fragment.
+ */
+CINDEX_LINKAGE CXString clang_FullComment_getAsHTML(CXComment Comment);
+
+/**
+ * Convert a given full parsed comment to an XML document.
+ *
+ * A Relax NG schema for the XML can be found in comment-xml-schema.rng file
+ * inside clang source tree.
+ *
+ * \param Comment a \c CXComment_FullComment AST node.
+ *
+ * \returns string containing an XML document.
+ */
+CINDEX_LINKAGE CXString clang_FullComment_getAsXML(CXComment Comment);
+
+/**
+ * CXAPISet is an opaque type that represents a data structure containing all
+ * the API information for a given translation unit. This can be used for a
+ * single symbol symbol graph for a given symbol.
+ */
+typedef struct CXAPISetImpl *CXAPISet;
+
+/**
+ * Traverses the translation unit to create a \c CXAPISet.
+ *
+ * \param tu is the \c CXTranslationUnit to build the \c CXAPISet for.
+ *
+ * \param out_api is a pointer to the output of this function. It is needs to be
+ * disposed of by calling clang_disposeAPISet.
+ *
+ * \returns Error code indicating success or failure of the APISet creation.
+ */
+CINDEX_LINKAGE enum CXErrorCode clang_createAPISet(CXTranslationUnit tu,
+                                                   CXAPISet *out_api);
+
+/**
+ * Dispose of an APISet.
+ *
+ * The provided \c CXAPISet can not be used after this function is called.
+ */
+CINDEX_LINKAGE void clang_disposeAPISet(CXAPISet api);
+
+/**
+ * Generate a single symbol symbol graph for the given USR. Returns a null
+ * string if the associated symbol can not be found in the provided \c CXAPISet.
+ *
+ * The output contains the symbol graph as well as some additional information
+ * about related symbols.
+ *
+ * \param usr is a string containing the USR of the symbol to generate the
+ * symbol graph for.
+ *
+ * \param api the \c CXAPISet to look for the symbol in.
+ *
+ * \returns a string containing the serialized symbol graph representation for
+ * the symbol being queried or a null string if it can not be found in the
+ * APISet.
+ */
+CINDEX_LINKAGE CXString clang_getSymbolGraphForUSR(const char *usr,
+                                                   CXAPISet api);
+
+/**
+ * Generate a single symbol symbol graph for the declaration at the given
+ * cursor. Returns a null string if the AST node for the cursor isn't a
+ * declaration.
+ *
+ * The output contains the symbol graph as well as some additional information
+ * about related symbols.
+ *
+ * \param cursor the declaration for which to generate the single symbol symbol
+ * graph.
+ *
+ * \returns a string containing the serialized symbol graph representation for
+ * the symbol being queried or a null string if it can not be found in the
+ * APISet.
+ */
+CINDEX_LINKAGE CXString clang_getSymbolGraphForCursor(CXCursor cursor);
+
+/**
+ * @}
+ */
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif /* CLANG_C_DOCUMENTATION_H */
+

--- a/examples/clang-c/ExternC.h
+++ b/examples/clang-c/ExternC.h
@@ -1,0 +1,39 @@
+/*===- clang-c/ExternC.h - Wrapper for 'extern "C"' ---------------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This file defines an 'extern "C"' wrapper.                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_EXTERN_C_H
+#define LLVM_CLANG_C_EXTERN_C_H
+
+#ifdef __clang__
+#define LLVM_CLANG_C_STRICT_PROTOTYPES_BEGIN                                   \
+  _Pragma("clang diagnostic push")                                             \
+      _Pragma("clang diagnostic error \"-Wstrict-prototypes\"")
+#define LLVM_CLANG_C_STRICT_PROTOTYPES_END _Pragma("clang diagnostic pop")
+#else
+#define LLVM_CLANG_C_STRICT_PROTOTYPES_BEGIN
+#define LLVM_CLANG_C_STRICT_PROTOTYPES_END
+#endif
+
+#ifdef __cplusplus
+#define LLVM_CLANG_C_EXTERN_C_BEGIN                                            \
+  extern "C" {                                                                 \
+  LLVM_CLANG_C_STRICT_PROTOTYPES_BEGIN
+#define LLVM_CLANG_C_EXTERN_C_END                                              \
+  LLVM_CLANG_C_STRICT_PROTOTYPES_END                                           \
+  }
+#else
+#define LLVM_CLANG_C_EXTERN_C_BEGIN LLVM_CLANG_C_STRICT_PROTOTYPES_BEGIN
+#define LLVM_CLANG_C_EXTERN_C_END LLVM_CLANG_C_STRICT_PROTOTYPES_END
+#endif
+
+#endif

--- a/examples/clang-c/FatalErrorHandler.h
+++ b/examples/clang-c/FatalErrorHandler.h
@@ -1,0 +1,33 @@
+/*===-- clang-c/FatalErrorHandler.h - Fatal Error Handling --------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_FATAL_ERROR_HANDLER_H
+#define LLVM_CLANG_C_FATAL_ERROR_HANDLER_H
+
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/**
+ * Installs error handler that prints error message to stderr and calls abort().
+ * Replaces currently installed error handler (if any).
+ */
+CINDEX_LINKAGE void clang_install_aborting_llvm_fatal_error_handler(void);
+
+/**
+ * Removes currently installed error handler (if any).
+ * If no error handler is intalled, the default strategy is to print error
+ * message to stderr and call exit(1).
+ */
+CINDEX_LINKAGE void clang_uninstall_llvm_fatal_error_handler(void);
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif

--- a/examples/clang-c/Index.h
+++ b/examples/clang-c/Index.h
@@ -1,0 +1,6977 @@
+/*===-- clang-c/Index.h - Indexing Public C Interface -------------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides a public interface to a Clang library for extracting  *|
+|* high-level symbol information from source files without exposing the full  *|
+|* Clang C++ API.                                                             *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_INDEX_H
+#define LLVM_CLANG_C_INDEX_H
+
+#include "clang-c/BuildSystem.h"
+#include "clang-c/CXDiagnostic.h"
+#include "clang-c/CXErrorCode.h"
+#include "clang-c/CXFile.h"
+#include "clang-c/CXSourceLocation.h"
+#include "clang-c/CXString.h"
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+
+/**
+ * The version constants for the libclang API.
+ * CINDEX_VERSION_MINOR should increase when there are API additions.
+ * CINDEX_VERSION_MAJOR is intended for "major" source/ABI breaking changes.
+ *
+ * The policy about the libclang API was always to keep it source and ABI
+ * compatible, thus CINDEX_VERSION_MAJOR is expected to remain stable.
+ */
+#define CINDEX_VERSION_MAJOR 0
+#define CINDEX_VERSION_MINOR 64
+
+#define CINDEX_VERSION_ENCODE(major, minor) (((major) * 10000) + ((minor) * 1))
+
+#define CINDEX_VERSION                                                         \
+  CINDEX_VERSION_ENCODE(CINDEX_VERSION_MAJOR, CINDEX_VERSION_MINOR)
+
+#define CINDEX_VERSION_STRINGIZE_(major, minor) #major "." #minor
+#define CINDEX_VERSION_STRINGIZE(major, minor)                                 \
+  CINDEX_VERSION_STRINGIZE_(major, minor)
+
+#define CINDEX_VERSION_STRING                                                  \
+  CINDEX_VERSION_STRINGIZE(CINDEX_VERSION_MAJOR, CINDEX_VERSION_MINOR)
+
+#ifndef __has_feature
+#define __has_feature(feature) 0
+#endif
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/** \defgroup CINDEX libclang: C Interface to Clang
+ *
+ * The C Interface to Clang provides a relatively small API that exposes
+ * facilities for parsing source code into an abstract syntax tree (AST),
+ * loading already-parsed ASTs, traversing the AST, associating
+ * physical source locations with elements within the AST, and other
+ * facilities that support Clang-based development tools.
+ *
+ * This C interface to Clang will never provide all of the information
+ * representation stored in Clang's C++ AST, nor should it: the intent is to
+ * maintain an API that is relatively stable from one release to the next,
+ * providing only the basic functionality needed to support development tools.
+ *
+ * To avoid namespace pollution, data types are prefixed with "CX" and
+ * functions are prefixed with "clang_".
+ *
+ * @{
+ */
+
+/**
+ * An "index" that consists of a set of translation units that would
+ * typically be linked together into an executable or library.
+ */
+typedef void *CXIndex;
+
+/**
+ * An opaque type representing target information for a given translation
+ * unit.
+ */
+typedef struct CXTargetInfoImpl *CXTargetInfo;
+
+/**
+ * A single translation unit, which resides in an index.
+ */
+typedef struct CXTranslationUnitImpl *CXTranslationUnit;
+
+/**
+ * Opaque pointer representing client data that will be passed through
+ * to various callbacks and visitors.
+ */
+typedef void *CXClientData;
+
+/**
+ * Provides the contents of a file that has not yet been saved to disk.
+ *
+ * Each CXUnsavedFile instance provides the name of a file on the
+ * system along with the current contents of that file that have not
+ * yet been saved to disk.
+ */
+struct CXUnsavedFile {
+  /**
+   * The file whose contents have not yet been saved.
+   *
+   * This file must already exist in the file system.
+   */
+  const char *Filename;
+
+  /**
+   * A buffer containing the unsaved contents of this file.
+   */
+  const char *Contents;
+
+  /**
+   * The length of the unsaved contents of this buffer.
+   */
+  unsigned long Length;
+};
+
+/**
+ * Describes the availability of a particular entity, which indicates
+ * whether the use of this entity will result in a warning or error due to
+ * it being deprecated or unavailable.
+ */
+enum CXAvailabilityKind {
+  /**
+   * The entity is available.
+   */
+  CXAvailability_Available,
+  /**
+   * The entity is available, but has been deprecated (and its use is
+   * not recommended).
+   */
+  CXAvailability_Deprecated,
+  /**
+   * The entity is not available; any use of it will be an error.
+   */
+  CXAvailability_NotAvailable,
+  /**
+   * The entity is available, but not accessible; any use of it will be
+   * an error.
+   */
+  CXAvailability_NotAccessible
+};
+
+/**
+ * Describes a version number of the form major.minor.subminor.
+ */
+typedef struct CXVersion {
+  /**
+   * The major version number, e.g., the '10' in '10.7.3'. A negative
+   * value indicates that there is no version number at all.
+   */
+  int Major;
+  /**
+   * The minor version number, e.g., the '7' in '10.7.3'. This value
+   * will be negative if no minor version number was provided, e.g., for
+   * version '10'.
+   */
+  int Minor;
+  /**
+   * The subminor version number, e.g., the '3' in '10.7.3'. This value
+   * will be negative if no minor or subminor version number was provided,
+   * e.g., in version '10' or '10.7'.
+   */
+  int Subminor;
+} CXVersion;
+
+/**
+ * Describes the exception specification of a cursor.
+ *
+ * A negative value indicates that the cursor is not a function declaration.
+ */
+enum CXCursor_ExceptionSpecificationKind {
+  /**
+   * The cursor has no exception specification.
+   */
+  CXCursor_ExceptionSpecificationKind_None,
+
+  /**
+   * The cursor has exception specification throw()
+   */
+  CXCursor_ExceptionSpecificationKind_DynamicNone,
+
+  /**
+   * The cursor has exception specification throw(T1, T2)
+   */
+  CXCursor_ExceptionSpecificationKind_Dynamic,
+
+  /**
+   * The cursor has exception specification throw(...).
+   */
+  CXCursor_ExceptionSpecificationKind_MSAny,
+
+  /**
+   * The cursor has exception specification basic noexcept.
+   */
+  CXCursor_ExceptionSpecificationKind_BasicNoexcept,
+
+  /**
+   * The cursor has exception specification computed noexcept.
+   */
+  CXCursor_ExceptionSpecificationKind_ComputedNoexcept,
+
+  /**
+   * The exception specification has not yet been evaluated.
+   */
+  CXCursor_ExceptionSpecificationKind_Unevaluated,
+
+  /**
+   * The exception specification has not yet been instantiated.
+   */
+  CXCursor_ExceptionSpecificationKind_Uninstantiated,
+
+  /**
+   * The exception specification has not been parsed yet.
+   */
+  CXCursor_ExceptionSpecificationKind_Unparsed,
+
+  /**
+   * The cursor has a __declspec(nothrow) exception specification.
+   */
+  CXCursor_ExceptionSpecificationKind_NoThrow
+};
+
+/**
+ * Provides a shared context for creating translation units.
+ *
+ * It provides two options:
+ *
+ * - excludeDeclarationsFromPCH: When non-zero, allows enumeration of "local"
+ * declarations (when loading any new translation units). A "local" declaration
+ * is one that belongs in the translation unit itself and not in a precompiled
+ * header that was used by the translation unit. If zero, all declarations
+ * will be enumerated.
+ *
+ * Here is an example:
+ *
+ * \code
+ *   // excludeDeclsFromPCH = 1, displayDiagnostics=1
+ *   Idx = clang_createIndex(1, 1);
+ *
+ *   // IndexTest.pch was produced with the following command:
+ *   // "clang -x c IndexTest.h -emit-ast -o IndexTest.pch"
+ *   TU = clang_createTranslationUnit(Idx, "IndexTest.pch");
+ *
+ *   // This will load all the symbols from 'IndexTest.pch'
+ *   clang_visitChildren(clang_getTranslationUnitCursor(TU),
+ *                       TranslationUnitVisitor, 0);
+ *   clang_disposeTranslationUnit(TU);
+ *
+ *   // This will load all the symbols from 'IndexTest.c', excluding symbols
+ *   // from 'IndexTest.pch'.
+ *   char *args[] = { "-Xclang", "-include-pch=IndexTest.pch" };
+ *   TU = clang_createTranslationUnitFromSourceFile(Idx, "IndexTest.c", 2, args,
+ *                                                  0, 0);
+ *   clang_visitChildren(clang_getTranslationUnitCursor(TU),
+ *                       TranslationUnitVisitor, 0);
+ *   clang_disposeTranslationUnit(TU);
+ * \endcode
+ *
+ * This process of creating the 'pch', loading it separately, and using it (via
+ * -include-pch) allows 'excludeDeclsFromPCH' to remove redundant callbacks
+ * (which gives the indexer the same performance benefit as the compiler).
+ */
+CINDEX_LINKAGE CXIndex clang_createIndex(int excludeDeclarationsFromPCH,
+                                         int displayDiagnostics);
+
+/**
+ * Destroy the given index.
+ *
+ * The index must not be destroyed until all of the translation units created
+ * within that index have been destroyed.
+ */
+CINDEX_LINKAGE void clang_disposeIndex(CXIndex index);
+
+typedef enum {
+  /**
+   * Use the default value of an option that may depend on the process
+   * environment.
+   */
+  CXChoice_Default = 0,
+  /**
+   * Enable the option.
+   */
+  CXChoice_Enabled = 1,
+  /**
+   * Disable the option.
+   */
+  CXChoice_Disabled = 2
+} CXChoice;
+
+typedef enum {
+  /**
+   * Used to indicate that no special CXIndex options are needed.
+   */
+  CXGlobalOpt_None = 0x0,
+
+  /**
+   * Used to indicate that threads that libclang creates for indexing
+   * purposes should use background priority.
+   *
+   * Affects #clang_indexSourceFile, #clang_indexTranslationUnit,
+   * #clang_parseTranslationUnit, #clang_saveTranslationUnit.
+   */
+  CXGlobalOpt_ThreadBackgroundPriorityForIndexing = 0x1,
+
+  /**
+   * Used to indicate that threads that libclang creates for editing
+   * purposes should use background priority.
+   *
+   * Affects #clang_reparseTranslationUnit, #clang_codeCompleteAt,
+   * #clang_annotateTokens
+   */
+  CXGlobalOpt_ThreadBackgroundPriorityForEditing = 0x2,
+
+  /**
+   * Used to indicate that all threads that libclang creates should use
+   * background priority.
+   */
+  CXGlobalOpt_ThreadBackgroundPriorityForAll =
+      CXGlobalOpt_ThreadBackgroundPriorityForIndexing |
+      CXGlobalOpt_ThreadBackgroundPriorityForEditing
+
+} CXGlobalOptFlags;
+
+/**
+ * Index initialization options.
+ *
+ * 0 is the default value of each member of this struct except for Size.
+ * Initialize the struct in one of the following three ways to avoid adapting
+ * code each time a new member is added to it:
+ * \code
+ * CXIndexOptions Opts;
+ * memset(&Opts, 0, sizeof(Opts));
+ * Opts.Size = sizeof(CXIndexOptions);
+ * \endcode
+ * or explicitly initialize the first data member and zero-initialize the rest:
+ * \code
+ * CXIndexOptions Opts = { sizeof(CXIndexOptions) };
+ * \endcode
+ * or to prevent the -Wmissing-field-initializers warning for the above version:
+ * \code
+ * CXIndexOptions Opts{};
+ * Opts.Size = sizeof(CXIndexOptions);
+ * \endcode
+ */
+typedef struct CXIndexOptions {
+  /**
+   * The size of struct CXIndexOptions used for option versioning.
+   *
+   * Always initialize this member to sizeof(CXIndexOptions), or assign
+   * sizeof(CXIndexOptions) to it right after creating a CXIndexOptions object.
+   */
+  unsigned Size;
+  /**
+   * A CXChoice enumerator that specifies the indexing priority policy.
+   * \sa CXGlobalOpt_ThreadBackgroundPriorityForIndexing
+   */
+  unsigned char ThreadBackgroundPriorityForIndexing;
+  /**
+   * A CXChoice enumerator that specifies the editing priority policy.
+   * \sa CXGlobalOpt_ThreadBackgroundPriorityForEditing
+   */
+  unsigned char ThreadBackgroundPriorityForEditing;
+  /**
+   * \see clang_createIndex()
+   */
+  unsigned ExcludeDeclarationsFromPCH : 1;
+  /**
+   * \see clang_createIndex()
+   */
+  unsigned DisplayDiagnostics : 1;
+  /**
+   * Store PCH in memory. If zero, PCH are stored in temporary files.
+   */
+  unsigned StorePreamblesInMemory : 1;
+  unsigned /*Reserved*/ : 13;
+
+  /**
+   * The path to a directory, in which to store temporary PCH files. If null or
+   * empty, the default system temporary directory is used. These PCH files are
+   * deleted on clean exit but stay on disk if the program crashes or is killed.
+   *
+   * This option is ignored if \a StorePreamblesInMemory is non-zero.
+   *
+   * Libclang does not create the directory at the specified path in the file
+   * system. Therefore it must exist, or storing PCH files will fail.
+   */
+  const char *PreambleStoragePath;
+  /**
+   * Specifies a path which will contain log files for certain libclang
+   * invocations. A null value implies that libclang invocations are not logged.
+   */
+  const char *InvocationEmissionPath;
+} CXIndexOptions;
+
+/**
+ * Provides a shared context for creating translation units.
+ *
+ * Call this function instead of clang_createIndex() if you need to configure
+ * the additional options in CXIndexOptions.
+ *
+ * \returns The created index or null in case of error, such as an unsupported
+ * value of options->Size.
+ *
+ * For example:
+ * \code
+ * CXIndex createIndex(const char *ApplicationTemporaryPath) {
+ *   const int ExcludeDeclarationsFromPCH = 1;
+ *   const int DisplayDiagnostics = 1;
+ *   CXIndex Idx;
+ * #if CINDEX_VERSION_MINOR >= 64
+ *   CXIndexOptions Opts;
+ *   memset(&Opts, 0, sizeof(Opts));
+ *   Opts.Size = sizeof(CXIndexOptions);
+ *   Opts.ThreadBackgroundPriorityForIndexing = 1;
+ *   Opts.ExcludeDeclarationsFromPCH = ExcludeDeclarationsFromPCH;
+ *   Opts.DisplayDiagnostics = DisplayDiagnostics;
+ *   Opts.PreambleStoragePath = ApplicationTemporaryPath;
+ *   Idx = clang_createIndexWithOptions(&Opts);
+ *   if (Idx)
+ *     return Idx;
+ *   fprintf(stderr,
+ *           "clang_createIndexWithOptions() failed. "
+ *           "CINDEX_VERSION_MINOR = %d, sizeof(CXIndexOptions) = %u\n",
+ *           CINDEX_VERSION_MINOR, Opts.Size);
+ * #else
+ *   (void)ApplicationTemporaryPath;
+ * #endif
+ *   Idx = clang_createIndex(ExcludeDeclarationsFromPCH, DisplayDiagnostics);
+ *   clang_CXIndex_setGlobalOptions(
+ *       Idx, clang_CXIndex_getGlobalOptions(Idx) |
+ *                CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
+ *   return Idx;
+ * }
+ * \endcode
+ *
+ * \sa clang_createIndex()
+ */
+CINDEX_LINKAGE CXIndex
+clang_createIndexWithOptions(const CXIndexOptions *options);
+
+/**
+ * Sets general options associated with a CXIndex.
+ *
+ * This function is DEPRECATED. Set
+ * CXIndexOptions::ThreadBackgroundPriorityForIndexing and/or
+ * CXIndexOptions::ThreadBackgroundPriorityForEditing and call
+ * clang_createIndexWithOptions() instead.
+ *
+ * For example:
+ * \code
+ * CXIndex idx = ...;
+ * clang_CXIndex_setGlobalOptions(idx,
+ *     clang_CXIndex_getGlobalOptions(idx) |
+ *     CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
+ * \endcode
+ *
+ * \param options A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags.
+ */
+CINDEX_LINKAGE void clang_CXIndex_setGlobalOptions(CXIndex, unsigned options);
+
+/**
+ * Gets the general options associated with a CXIndex.
+ *
+ * This function allows to obtain the final option values used by libclang after
+ * specifying the option policies via CXChoice enumerators.
+ *
+ * \returns A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags that
+ * are associated with the given CXIndex object.
+ */
+CINDEX_LINKAGE unsigned clang_CXIndex_getGlobalOptions(CXIndex);
+
+/**
+ * Sets the invocation emission path option in a CXIndex.
+ *
+ * This function is DEPRECATED. Set CXIndexOptions::InvocationEmissionPath and
+ * call clang_createIndexWithOptions() instead.
+ *
+ * The invocation emission path specifies a path which will contain log
+ * files for certain libclang invocations. A null value (default) implies that
+ * libclang invocations are not logged..
+ */
+CINDEX_LINKAGE void
+clang_CXIndex_setInvocationEmissionPathOption(CXIndex, const char *Path);
+
+/**
+ * Determine whether the given header is guarded against
+ * multiple inclusions, either with the conventional
+ * \#ifndef/\#define/\#endif macro guards or with \#pragma once.
+ */
+CINDEX_LINKAGE unsigned clang_isFileMultipleIncludeGuarded(CXTranslationUnit tu,
+                                                           CXFile file);
+
+/**
+ * Retrieve a file handle within the given translation unit.
+ *
+ * \param tu the translation unit
+ *
+ * \param file_name the name of the file.
+ *
+ * \returns the file handle for the named file in the translation unit \p tu,
+ * or a NULL file handle if the file was not a part of this translation unit.
+ */
+CINDEX_LINKAGE CXFile clang_getFile(CXTranslationUnit tu,
+                                    const char *file_name);
+
+/**
+ * Retrieve the buffer associated with the given file.
+ *
+ * \param tu the translation unit
+ *
+ * \param file the file for which to retrieve the buffer.
+ *
+ * \param size [out] if non-NULL, will be set to the size of the buffer.
+ *
+ * \returns a pointer to the buffer in memory that holds the contents of
+ * \p file, or a NULL pointer when the file is not loaded.
+ */
+CINDEX_LINKAGE const char *clang_getFileContents(CXTranslationUnit tu,
+                                                 CXFile file, size_t *size);
+
+/**
+ * Retrieves the source location associated with a given file/line/column
+ * in a particular translation unit.
+ */
+CINDEX_LINKAGE CXSourceLocation clang_getLocation(CXTranslationUnit tu,
+                                                  CXFile file, unsigned line,
+                                                  unsigned column);
+/**
+ * Retrieves the source location associated with a given character offset
+ * in a particular translation unit.
+ */
+CINDEX_LINKAGE CXSourceLocation clang_getLocationForOffset(CXTranslationUnit tu,
+                                                           CXFile file,
+                                                           unsigned offset);
+
+/**
+ * Retrieve all ranges that were skipped by the preprocessor.
+ *
+ * The preprocessor will skip lines when they are surrounded by an
+ * if/ifdef/ifndef directive whose condition does not evaluate to true.
+ */
+CINDEX_LINKAGE CXSourceRangeList *clang_getSkippedRanges(CXTranslationUnit tu,
+                                                         CXFile file);
+
+/**
+ * Retrieve all ranges from all files that were skipped by the
+ * preprocessor.
+ *
+ * The preprocessor will skip lines when they are surrounded by an
+ * if/ifdef/ifndef directive whose condition does not evaluate to true.
+ */
+CINDEX_LINKAGE CXSourceRangeList *
+clang_getAllSkippedRanges(CXTranslationUnit tu);
+
+/**
+ * Determine the number of diagnostics produced for the given
+ * translation unit.
+ */
+CINDEX_LINKAGE unsigned clang_getNumDiagnostics(CXTranslationUnit Unit);
+
+/**
+ * Retrieve a diagnostic associated with the given translation unit.
+ *
+ * \param Unit the translation unit to query.
+ * \param Index the zero-based diagnostic number to retrieve.
+ *
+ * \returns the requested diagnostic. This diagnostic must be freed
+ * via a call to \c clang_disposeDiagnostic().
+ */
+CINDEX_LINKAGE CXDiagnostic clang_getDiagnostic(CXTranslationUnit Unit,
+                                                unsigned Index);
+
+/**
+ * Retrieve the complete set of diagnostics associated with a
+ *        translation unit.
+ *
+ * \param Unit the translation unit to query.
+ */
+CINDEX_LINKAGE CXDiagnosticSet
+clang_getDiagnosticSetFromTU(CXTranslationUnit Unit);
+
+/**
+ * \defgroup CINDEX_TRANSLATION_UNIT Translation unit manipulation
+ *
+ * The routines in this group provide the ability to create and destroy
+ * translation units from files, either by parsing the contents of the files or
+ * by reading in a serialized representation of a translation unit.
+ *
+ * @{
+ */
+
+/**
+ * Get the original translation unit source file name.
+ */
+CINDEX_LINKAGE CXString
+clang_getTranslationUnitSpelling(CXTranslationUnit CTUnit);
+
+/**
+ * Return the CXTranslationUnit for a given source file and the provided
+ * command line arguments one would pass to the compiler.
+ *
+ * Note: The 'source_filename' argument is optional.  If the caller provides a
+ * NULL pointer, the name of the source file is expected to reside in the
+ * specified command line arguments.
+ *
+ * Note: When encountered in 'clang_command_line_args', the following options
+ * are ignored:
+ *
+ *   '-c'
+ *   '-emit-ast'
+ *   '-fsyntax-only'
+ *   '-o \<output file>'  (both '-o' and '\<output file>' are ignored)
+ *
+ * \param CIdx The index object with which the translation unit will be
+ * associated.
+ *
+ * \param source_filename The name of the source file to load, or NULL if the
+ * source file is included in \p clang_command_line_args.
+ *
+ * \param num_clang_command_line_args The number of command-line arguments in
+ * \p clang_command_line_args.
+ *
+ * \param clang_command_line_args The command-line arguments that would be
+ * passed to the \c clang executable if it were being invoked out-of-process.
+ * These command-line options will be parsed and will affect how the translation
+ * unit is parsed. Note that the following options are ignored: '-c',
+ * '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
+ *
+ * \param num_unsaved_files the number of unsaved file entries in \p
+ * unsaved_files.
+ *
+ * \param unsaved_files the files that have not yet been saved to disk
+ * but may be required for code completion, including the contents of
+ * those files.  The contents and name of these files (as specified by
+ * CXUnsavedFile) are copied when necessary, so the client only needs to
+ * guarantee their validity until the call to this function returns.
+ */
+CINDEX_LINKAGE CXTranslationUnit clang_createTranslationUnitFromSourceFile(
+    CXIndex CIdx, const char *source_filename, int num_clang_command_line_args,
+    const char *const *clang_command_line_args, unsigned num_unsaved_files,
+    struct CXUnsavedFile *unsaved_files);
+
+/**
+ * Same as \c clang_createTranslationUnit2, but returns
+ * the \c CXTranslationUnit instead of an error code.  In case of an error this
+ * routine returns a \c NULL \c CXTranslationUnit, without further detailed
+ * error codes.
+ */
+CINDEX_LINKAGE CXTranslationUnit
+clang_createTranslationUnit(CXIndex CIdx, const char *ast_filename);
+
+/**
+ * Create a translation unit from an AST file (\c -emit-ast).
+ *
+ * \param[out] out_TU A non-NULL pointer to store the created
+ * \c CXTranslationUnit.
+ *
+ * \returns Zero on success, otherwise returns an error code.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_createTranslationUnit2(CXIndex CIdx, const char *ast_filename,
+                             CXTranslationUnit *out_TU);
+
+/**
+ * Flags that control the creation of translation units.
+ *
+ * The enumerators in this enumeration type are meant to be bitwise
+ * ORed together to specify which options should be used when
+ * constructing the translation unit.
+ */
+enum CXTranslationUnit_Flags {
+  /**
+   * Used to indicate that no special translation-unit options are
+   * needed.
+   */
+  CXTranslationUnit_None = 0x0,
+
+  /**
+   * Used to indicate that the parser should construct a "detailed"
+   * preprocessing record, including all macro definitions and instantiations.
+   *
+   * Constructing a detailed preprocessing record requires more memory
+   * and time to parse, since the information contained in the record
+   * is usually not retained. However, it can be useful for
+   * applications that require more detailed information about the
+   * behavior of the preprocessor.
+   */
+  CXTranslationUnit_DetailedPreprocessingRecord = 0x01,
+
+  /**
+   * Used to indicate that the translation unit is incomplete.
+   *
+   * When a translation unit is considered "incomplete", semantic
+   * analysis that is typically performed at the end of the
+   * translation unit will be suppressed. For example, this suppresses
+   * the completion of tentative declarations in C and of
+   * instantiation of implicitly-instantiation function templates in
+   * C++. This option is typically used when parsing a header with the
+   * intent of producing a precompiled header.
+   */
+  CXTranslationUnit_Incomplete = 0x02,
+
+  /**
+   * Used to indicate that the translation unit should be built with an
+   * implicit precompiled header for the preamble.
+   *
+   * An implicit precompiled header is used as an optimization when a
+   * particular translation unit is likely to be reparsed many times
+   * when the sources aren't changing that often. In this case, an
+   * implicit precompiled header will be built containing all of the
+   * initial includes at the top of the main file (what we refer to as
+   * the "preamble" of the file). In subsequent parses, if the
+   * preamble or the files in it have not changed, \c
+   * clang_reparseTranslationUnit() will re-use the implicit
+   * precompiled header to improve parsing performance.
+   */
+  CXTranslationUnit_PrecompiledPreamble = 0x04,
+
+  /**
+   * Used to indicate that the translation unit should cache some
+   * code-completion results with each reparse of the source file.
+   *
+   * Caching of code-completion results is a performance optimization that
+   * introduces some overhead to reparsing but improves the performance of
+   * code-completion operations.
+   */
+  CXTranslationUnit_CacheCompletionResults = 0x08,
+
+  /**
+   * Used to indicate that the translation unit will be serialized with
+   * \c clang_saveTranslationUnit.
+   *
+   * This option is typically used when parsing a header with the intent of
+   * producing a precompiled header.
+   */
+  CXTranslationUnit_ForSerialization = 0x10,
+
+  /**
+   * DEPRECATED: Enabled chained precompiled preambles in C++.
+   *
+   * Note: this is a *temporary* option that is available only while
+   * we are testing C++ precompiled preamble support. It is deprecated.
+   */
+  CXTranslationUnit_CXXChainedPCH = 0x20,
+
+  /**
+   * Used to indicate that function/method bodies should be skipped while
+   * parsing.
+   *
+   * This option can be used to search for declarations/definitions while
+   * ignoring the usages.
+   */
+  CXTranslationUnit_SkipFunctionBodies = 0x40,
+
+  /**
+   * Used to indicate that brief documentation comments should be
+   * included into the set of code completions returned from this translation
+   * unit.
+   */
+  CXTranslationUnit_IncludeBriefCommentsInCodeCompletion = 0x80,
+
+  /**
+   * Used to indicate that the precompiled preamble should be created on
+   * the first parse. Otherwise it will be created on the first reparse. This
+   * trades runtime on the first parse (serializing the preamble takes time) for
+   * reduced runtime on the second parse (can now reuse the preamble).
+   */
+  CXTranslationUnit_CreatePreambleOnFirstParse = 0x100,
+
+  /**
+   * Do not stop processing when fatal errors are encountered.
+   *
+   * When fatal errors are encountered while parsing a translation unit,
+   * semantic analysis is typically stopped early when compiling code. A common
+   * source for fatal errors are unresolvable include files. For the
+   * purposes of an IDE, this is undesirable behavior and as much information
+   * as possible should be reported. Use this flag to enable this behavior.
+   */
+  CXTranslationUnit_KeepGoing = 0x200,
+
+  /**
+   * Sets the preprocessor in a mode for parsing a single file only.
+   */
+  CXTranslationUnit_SingleFileParse = 0x400,
+
+  /**
+   * Used in combination with CXTranslationUnit_SkipFunctionBodies to
+   * constrain the skipping of function bodies to the preamble.
+   *
+   * The function bodies of the main file are not skipped.
+   */
+  CXTranslationUnit_LimitSkipFunctionBodiesToPreamble = 0x800,
+
+  /**
+   * Used to indicate that attributed types should be included in CXType.
+   */
+  CXTranslationUnit_IncludeAttributedTypes = 0x1000,
+
+  /**
+   * Used to indicate that implicit attributes should be visited.
+   */
+  CXTranslationUnit_VisitImplicitAttributes = 0x2000,
+
+  /**
+   * Used to indicate that non-errors from included files should be ignored.
+   *
+   * If set, clang_getDiagnosticSetFromTU() will not report e.g. warnings from
+   * included files anymore. This speeds up clang_getDiagnosticSetFromTU() for
+   * the case where these warnings are not of interest, as for an IDE for
+   * example, which typically shows only the diagnostics in the main file.
+   */
+  CXTranslationUnit_IgnoreNonErrorsFromIncludedFiles = 0x4000,
+
+  /**
+   * Tells the preprocessor not to skip excluded conditional blocks.
+   */
+  CXTranslationUnit_RetainExcludedConditionalBlocks = 0x8000
+};
+
+/**
+ * Returns the set of flags that is suitable for parsing a translation
+ * unit that is being edited.
+ *
+ * The set of flags returned provide options for \c clang_parseTranslationUnit()
+ * to indicate that the translation unit is likely to be reparsed many times,
+ * either explicitly (via \c clang_reparseTranslationUnit()) or implicitly
+ * (e.g., by code completion (\c clang_codeCompletionAt())). The returned flag
+ * set contains an unspecified set of optimizations (e.g., the precompiled
+ * preamble) geared toward improving the performance of these routines. The
+ * set of optimizations enabled may change from one version to the next.
+ */
+CINDEX_LINKAGE unsigned clang_defaultEditingTranslationUnitOptions(void);
+
+/**
+ * Same as \c clang_parseTranslationUnit2, but returns
+ * the \c CXTranslationUnit instead of an error code.  In case of an error this
+ * routine returns a \c NULL \c CXTranslationUnit, without further detailed
+ * error codes.
+ */
+CINDEX_LINKAGE CXTranslationUnit clang_parseTranslationUnit(
+    CXIndex CIdx, const char *source_filename,
+    const char *const *command_line_args, int num_command_line_args,
+    struct CXUnsavedFile *unsaved_files, unsigned num_unsaved_files,
+    unsigned options);
+
+/**
+ * Parse the given source file and the translation unit corresponding
+ * to that file.
+ *
+ * This routine is the main entry point for the Clang C API, providing the
+ * ability to parse a source file into a translation unit that can then be
+ * queried by other functions in the API. This routine accepts a set of
+ * command-line arguments so that the compilation can be configured in the same
+ * way that the compiler is configured on the command line.
+ *
+ * \param CIdx The index object with which the translation unit will be
+ * associated.
+ *
+ * \param source_filename The name of the source file to load, or NULL if the
+ * source file is included in \c command_line_args.
+ *
+ * \param command_line_args The command-line arguments that would be
+ * passed to the \c clang executable if it were being invoked out-of-process.
+ * These command-line options will be parsed and will affect how the translation
+ * unit is parsed. Note that the following options are ignored: '-c',
+ * '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
+ *
+ * \param num_command_line_args The number of command-line arguments in
+ * \c command_line_args.
+ *
+ * \param unsaved_files the files that have not yet been saved to disk
+ * but may be required for parsing, including the contents of
+ * those files.  The contents and name of these files (as specified by
+ * CXUnsavedFile) are copied when necessary, so the client only needs to
+ * guarantee their validity until the call to this function returns.
+ *
+ * \param num_unsaved_files the number of unsaved file entries in \p
+ * unsaved_files.
+ *
+ * \param options A bitmask of options that affects how the translation unit
+ * is managed but not its compilation. This should be a bitwise OR of the
+ * CXTranslationUnit_XXX flags.
+ *
+ * \param[out] out_TU A non-NULL pointer to store the created
+ * \c CXTranslationUnit, describing the parsed code and containing any
+ * diagnostics produced by the compiler.
+ *
+ * \returns Zero on success, otherwise returns an error code.
+ */
+CINDEX_LINKAGE enum CXErrorCode clang_parseTranslationUnit2(
+    CXIndex CIdx, const char *source_filename,
+    const char *const *command_line_args, int num_command_line_args,
+    struct CXUnsavedFile *unsaved_files, unsigned num_unsaved_files,
+    unsigned options, CXTranslationUnit *out_TU);
+
+/**
+ * Same as clang_parseTranslationUnit2 but requires a full command line
+ * for \c command_line_args including argv[0]. This is useful if the standard
+ * library paths are relative to the binary.
+ */
+CINDEX_LINKAGE enum CXErrorCode clang_parseTranslationUnit2FullArgv(
+    CXIndex CIdx, const char *source_filename,
+    const char *const *command_line_args, int num_command_line_args,
+    struct CXUnsavedFile *unsaved_files, unsigned num_unsaved_files,
+    unsigned options, CXTranslationUnit *out_TU);
+
+/**
+ * Flags that control how translation units are saved.
+ *
+ * The enumerators in this enumeration type are meant to be bitwise
+ * ORed together to specify which options should be used when
+ * saving the translation unit.
+ */
+enum CXSaveTranslationUnit_Flags {
+  /**
+   * Used to indicate that no special saving options are needed.
+   */
+  CXSaveTranslationUnit_None = 0x0
+};
+
+/**
+ * Returns the set of flags that is suitable for saving a translation
+ * unit.
+ *
+ * The set of flags returned provide options for
+ * \c clang_saveTranslationUnit() by default. The returned flag
+ * set contains an unspecified set of options that save translation units with
+ * the most commonly-requested data.
+ */
+CINDEX_LINKAGE unsigned clang_defaultSaveOptions(CXTranslationUnit TU);
+
+/**
+ * Describes the kind of error that occurred (if any) in a call to
+ * \c clang_saveTranslationUnit().
+ */
+enum CXSaveError {
+  /**
+   * Indicates that no error occurred while saving a translation unit.
+   */
+  CXSaveError_None = 0,
+
+  /**
+   * Indicates that an unknown error occurred while attempting to save
+   * the file.
+   *
+   * This error typically indicates that file I/O failed when attempting to
+   * write the file.
+   */
+  CXSaveError_Unknown = 1,
+
+  /**
+   * Indicates that errors during translation prevented this attempt
+   * to save the translation unit.
+   *
+   * Errors that prevent the translation unit from being saved can be
+   * extracted using \c clang_getNumDiagnostics() and \c clang_getDiagnostic().
+   */
+  CXSaveError_TranslationErrors = 2,
+
+  /**
+   * Indicates that the translation unit to be saved was somehow
+   * invalid (e.g., NULL).
+   */
+  CXSaveError_InvalidTU = 3
+};
+
+/**
+ * Saves a translation unit into a serialized representation of
+ * that translation unit on disk.
+ *
+ * Any translation unit that was parsed without error can be saved
+ * into a file. The translation unit can then be deserialized into a
+ * new \c CXTranslationUnit with \c clang_createTranslationUnit() or,
+ * if it is an incomplete translation unit that corresponds to a
+ * header, used as a precompiled header when parsing other translation
+ * units.
+ *
+ * \param TU The translation unit to save.
+ *
+ * \param FileName The file to which the translation unit will be saved.
+ *
+ * \param options A bitmask of options that affects how the translation unit
+ * is saved. This should be a bitwise OR of the
+ * CXSaveTranslationUnit_XXX flags.
+ *
+ * \returns A value that will match one of the enumerators of the CXSaveError
+ * enumeration. Zero (CXSaveError_None) indicates that the translation unit was
+ * saved successfully, while a non-zero value indicates that a problem occurred.
+ */
+CINDEX_LINKAGE int clang_saveTranslationUnit(CXTranslationUnit TU,
+                                             const char *FileName,
+                                             unsigned options);
+
+/**
+ * Suspend a translation unit in order to free memory associated with it.
+ *
+ * A suspended translation unit uses significantly less memory but on the other
+ * side does not support any other calls than \c clang_reparseTranslationUnit
+ * to resume it or \c clang_disposeTranslationUnit to dispose it completely.
+ */
+CINDEX_LINKAGE unsigned clang_suspendTranslationUnit(CXTranslationUnit);
+
+/**
+ * Destroy the specified CXTranslationUnit object.
+ */
+CINDEX_LINKAGE void clang_disposeTranslationUnit(CXTranslationUnit);
+
+/**
+ * Flags that control the reparsing of translation units.
+ *
+ * The enumerators in this enumeration type are meant to be bitwise
+ * ORed together to specify which options should be used when
+ * reparsing the translation unit.
+ */
+enum CXReparse_Flags {
+  /**
+   * Used to indicate that no special reparsing options are needed.
+   */
+  CXReparse_None = 0x0
+};
+
+/**
+ * Returns the set of flags that is suitable for reparsing a translation
+ * unit.
+ *
+ * The set of flags returned provide options for
+ * \c clang_reparseTranslationUnit() by default. The returned flag
+ * set contains an unspecified set of optimizations geared toward common uses
+ * of reparsing. The set of optimizations enabled may change from one version
+ * to the next.
+ */
+CINDEX_LINKAGE unsigned clang_defaultReparseOptions(CXTranslationUnit TU);
+
+/**
+ * Reparse the source files that produced this translation unit.
+ *
+ * This routine can be used to re-parse the source files that originally
+ * created the given translation unit, for example because those source files
+ * have changed (either on disk or as passed via \p unsaved_files). The
+ * source code will be reparsed with the same command-line options as it
+ * was originally parsed.
+ *
+ * Reparsing a translation unit invalidates all cursors and source locations
+ * that refer into that translation unit. This makes reparsing a translation
+ * unit semantically equivalent to destroying the translation unit and then
+ * creating a new translation unit with the same command-line arguments.
+ * However, it may be more efficient to reparse a translation
+ * unit using this routine.
+ *
+ * \param TU The translation unit whose contents will be re-parsed. The
+ * translation unit must originally have been built with
+ * \c clang_createTranslationUnitFromSourceFile().
+ *
+ * \param num_unsaved_files The number of unsaved file entries in \p
+ * unsaved_files.
+ *
+ * \param unsaved_files The files that have not yet been saved to disk
+ * but may be required for parsing, including the contents of
+ * those files.  The contents and name of these files (as specified by
+ * CXUnsavedFile) are copied when necessary, so the client only needs to
+ * guarantee their validity until the call to this function returns.
+ *
+ * \param options A bitset of options composed of the flags in CXReparse_Flags.
+ * The function \c clang_defaultReparseOptions() produces a default set of
+ * options recommended for most uses, based on the translation unit.
+ *
+ * \returns 0 if the sources could be reparsed.  A non-zero error code will be
+ * returned if reparsing was impossible, such that the translation unit is
+ * invalid. In such cases, the only valid call for \c TU is
+ * \c clang_disposeTranslationUnit(TU).  The error codes returned by this
+ * routine are described by the \c CXErrorCode enum.
+ */
+CINDEX_LINKAGE int
+clang_reparseTranslationUnit(CXTranslationUnit TU, unsigned num_unsaved_files,
+                             struct CXUnsavedFile *unsaved_files,
+                             unsigned options);
+
+/**
+ * Categorizes how memory is being used by a translation unit.
+ */
+enum CXTUResourceUsageKind {
+  CXTUResourceUsage_AST = 1,
+  CXTUResourceUsage_Identifiers = 2,
+  CXTUResourceUsage_Selectors = 3,
+  CXTUResourceUsage_GlobalCompletionResults = 4,
+  CXTUResourceUsage_SourceManagerContentCache = 5,
+  CXTUResourceUsage_AST_SideTables = 6,
+  CXTUResourceUsage_SourceManager_Membuffer_Malloc = 7,
+  CXTUResourceUsage_SourceManager_Membuffer_MMap = 8,
+  CXTUResourceUsage_ExternalASTSource_Membuffer_Malloc = 9,
+  CXTUResourceUsage_ExternalASTSource_Membuffer_MMap = 10,
+  CXTUResourceUsage_Preprocessor = 11,
+  CXTUResourceUsage_PreprocessingRecord = 12,
+  CXTUResourceUsage_SourceManager_DataStructures = 13,
+  CXTUResourceUsage_Preprocessor_HeaderSearch = 14,
+  CXTUResourceUsage_MEMORY_IN_BYTES_BEGIN = CXTUResourceUsage_AST,
+  CXTUResourceUsage_MEMORY_IN_BYTES_END =
+      CXTUResourceUsage_Preprocessor_HeaderSearch,
+
+  CXTUResourceUsage_First = CXTUResourceUsage_AST,
+  CXTUResourceUsage_Last = CXTUResourceUsage_Preprocessor_HeaderSearch
+};
+
+/**
+ * Returns the human-readable null-terminated C string that represents
+ *  the name of the memory category.  This string should never be freed.
+ */
+CINDEX_LINKAGE
+const char *clang_getTUResourceUsageName(enum CXTUResourceUsageKind kind);
+
+typedef struct CXTUResourceUsageEntry {
+  /* The memory usage category. */
+  enum CXTUResourceUsageKind kind;
+  /* Amount of resources used.
+      The units will depend on the resource kind. */
+  unsigned long amount;
+} CXTUResourceUsageEntry;
+
+/**
+ * The memory usage of a CXTranslationUnit, broken into categories.
+ */
+typedef struct CXTUResourceUsage {
+  /* Private data member, used for queries. */
+  void *data;
+
+  /* The number of entries in the 'entries' array. */
+  unsigned numEntries;
+
+  /* An array of key-value pairs, representing the breakdown of memory
+            usage. */
+  CXTUResourceUsageEntry *entries;
+
+} CXTUResourceUsage;
+
+/**
+ * Return the memory usage of a translation unit.  This object
+ *  should be released with clang_disposeCXTUResourceUsage().
+ */
+CINDEX_LINKAGE CXTUResourceUsage
+clang_getCXTUResourceUsage(CXTranslationUnit TU);
+
+CINDEX_LINKAGE void clang_disposeCXTUResourceUsage(CXTUResourceUsage usage);
+
+/**
+ * Get target information for this translation unit.
+ *
+ * The CXTargetInfo object cannot outlive the CXTranslationUnit object.
+ */
+CINDEX_LINKAGE CXTargetInfo
+clang_getTranslationUnitTargetInfo(CXTranslationUnit CTUnit);
+
+/**
+ * Destroy the CXTargetInfo object.
+ */
+CINDEX_LINKAGE void clang_TargetInfo_dispose(CXTargetInfo Info);
+
+/**
+ * Get the normalized target triple as a string.
+ *
+ * Returns the empty string in case of any error.
+ */
+CINDEX_LINKAGE CXString clang_TargetInfo_getTriple(CXTargetInfo Info);
+
+/**
+ * Get the pointer width of the target in bits.
+ *
+ * Returns -1 in case of error.
+ */
+CINDEX_LINKAGE int clang_TargetInfo_getPointerWidth(CXTargetInfo Info);
+
+/**
+ * @}
+ */
+
+/**
+ * Describes the kind of entity that a cursor refers to.
+ */
+enum CXCursorKind {
+  /* Declarations */
+  /**
+   * A declaration whose specific kind is not exposed via this
+   * interface.
+   *
+   * Unexposed declarations have the same operations as any other kind
+   * of declaration; one can extract their location information,
+   * spelling, find their definitions, etc. However, the specific kind
+   * of the declaration is not reported.
+   */
+  CXCursor_UnexposedDecl = 1,
+  /** A C or C++ struct. */
+  CXCursor_StructDecl = 2,
+  /** A C or C++ union. */
+  CXCursor_UnionDecl = 3,
+  /** A C++ class. */
+  CXCursor_ClassDecl = 4,
+  /** An enumeration. */
+  CXCursor_EnumDecl = 5,
+  /**
+   * A field (in C) or non-static data member (in C++) in a
+   * struct, union, or C++ class.
+   */
+  CXCursor_FieldDecl = 6,
+  /** An enumerator constant. */
+  CXCursor_EnumConstantDecl = 7,
+  /** A function. */
+  CXCursor_FunctionDecl = 8,
+  /** A variable. */
+  CXCursor_VarDecl = 9,
+  /** A function or method parameter. */
+  CXCursor_ParmDecl = 10,
+  /** An Objective-C \@interface. */
+  CXCursor_ObjCInterfaceDecl = 11,
+  /** An Objective-C \@interface for a category. */
+  CXCursor_ObjCCategoryDecl = 12,
+  /** An Objective-C \@protocol declaration. */
+  CXCursor_ObjCProtocolDecl = 13,
+  /** An Objective-C \@property declaration. */
+  CXCursor_ObjCPropertyDecl = 14,
+  /** An Objective-C instance variable. */
+  CXCursor_ObjCIvarDecl = 15,
+  /** An Objective-C instance method. */
+  CXCursor_ObjCInstanceMethodDecl = 16,
+  /** An Objective-C class method. */
+  CXCursor_ObjCClassMethodDecl = 17,
+  /** An Objective-C \@implementation. */
+  CXCursor_ObjCImplementationDecl = 18,
+  /** An Objective-C \@implementation for a category. */
+  CXCursor_ObjCCategoryImplDecl = 19,
+  /** A typedef. */
+  CXCursor_TypedefDecl = 20,
+  /** A C++ class method. */
+  CXCursor_CXXMethod = 21,
+  /** A C++ namespace. */
+  CXCursor_Namespace = 22,
+  /** A linkage specification, e.g. 'extern "C"'. */
+  CXCursor_LinkageSpec = 23,
+  /** A C++ constructor. */
+  CXCursor_Constructor = 24,
+  /** A C++ destructor. */
+  CXCursor_Destructor = 25,
+  /** A C++ conversion function. */
+  CXCursor_ConversionFunction = 26,
+  /** A C++ template type parameter. */
+  CXCursor_TemplateTypeParameter = 27,
+  /** A C++ non-type template parameter. */
+  CXCursor_NonTypeTemplateParameter = 28,
+  /** A C++ template template parameter. */
+  CXCursor_TemplateTemplateParameter = 29,
+  /** A C++ function template. */
+  CXCursor_FunctionTemplate = 30,
+  /** A C++ class template. */
+  CXCursor_ClassTemplate = 31,
+  /** A C++ class template partial specialization. */
+  CXCursor_ClassTemplatePartialSpecialization = 32,
+  /** A C++ namespace alias declaration. */
+  CXCursor_NamespaceAlias = 33,
+  /** A C++ using directive. */
+  CXCursor_UsingDirective = 34,
+  /** A C++ using declaration. */
+  CXCursor_UsingDeclaration = 35,
+  /** A C++ alias declaration */
+  CXCursor_TypeAliasDecl = 36,
+  /** An Objective-C \@synthesize definition. */
+  CXCursor_ObjCSynthesizeDecl = 37,
+  /** An Objective-C \@dynamic definition. */
+  CXCursor_ObjCDynamicDecl = 38,
+  /** An access specifier. */
+  CXCursor_CXXAccessSpecifier = 39,
+
+  CXCursor_FirstDecl = CXCursor_UnexposedDecl,
+  CXCursor_LastDecl = CXCursor_CXXAccessSpecifier,
+
+  /* References */
+  CXCursor_FirstRef = 40, /* Decl references */
+  CXCursor_ObjCSuperClassRef = 40,
+  CXCursor_ObjCProtocolRef = 41,
+  CXCursor_ObjCClassRef = 42,
+  /**
+   * A reference to a type declaration.
+   *
+   * A type reference occurs anywhere where a type is named but not
+   * declared. For example, given:
+   *
+   * \code
+   * typedef unsigned size_type;
+   * size_type size;
+   * \endcode
+   *
+   * The typedef is a declaration of size_type (CXCursor_TypedefDecl),
+   * while the type of the variable "size" is referenced. The cursor
+   * referenced by the type of size is the typedef for size_type.
+   */
+  CXCursor_TypeRef = 43,
+  CXCursor_CXXBaseSpecifier = 44,
+  /**
+   * A reference to a class template, function template, template
+   * template parameter, or class template partial specialization.
+   */
+  CXCursor_TemplateRef = 45,
+  /**
+   * A reference to a namespace or namespace alias.
+   */
+  CXCursor_NamespaceRef = 46,
+  /**
+   * A reference to a member of a struct, union, or class that occurs in
+   * some non-expression context, e.g., a designated initializer.
+   */
+  CXCursor_MemberRef = 47,
+  /**
+   * A reference to a labeled statement.
+   *
+   * This cursor kind is used to describe the jump to "start_over" in the
+   * goto statement in the following example:
+   *
+   * \code
+   *   start_over:
+   *     ++counter;
+   *
+   *     goto start_over;
+   * \endcode
+   *
+   * A label reference cursor refers to a label statement.
+   */
+  CXCursor_LabelRef = 48,
+
+  /**
+   * A reference to a set of overloaded functions or function templates
+   * that has not yet been resolved to a specific function or function template.
+   *
+   * An overloaded declaration reference cursor occurs in C++ templates where
+   * a dependent name refers to a function. For example:
+   *
+   * \code
+   * template<typename T> void swap(T&, T&);
+   *
+   * struct X { ... };
+   * void swap(X&, X&);
+   *
+   * template<typename T>
+   * void reverse(T* first, T* last) {
+   *   while (first < last - 1) {
+   *     swap(*first, *--last);
+   *     ++first;
+   *   }
+   * }
+   *
+   * struct Y { };
+   * void swap(Y&, Y&);
+   * \endcode
+   *
+   * Here, the identifier "swap" is associated with an overloaded declaration
+   * reference. In the template definition, "swap" refers to either of the two
+   * "swap" functions declared above, so both results will be available. At
+   * instantiation time, "swap" may also refer to other functions found via
+   * argument-dependent lookup (e.g., the "swap" function at the end of the
+   * example).
+   *
+   * The functions \c clang_getNumOverloadedDecls() and
+   * \c clang_getOverloadedDecl() can be used to retrieve the definitions
+   * referenced by this cursor.
+   */
+  CXCursor_OverloadedDeclRef = 49,
+
+  /**
+   * A reference to a variable that occurs in some non-expression
+   * context, e.g., a C++ lambda capture list.
+   */
+  CXCursor_VariableRef = 50,
+
+  CXCursor_LastRef = CXCursor_VariableRef,
+
+  /* Error conditions */
+  CXCursor_FirstInvalid = 70,
+  CXCursor_InvalidFile = 70,
+  CXCursor_NoDeclFound = 71,
+  CXCursor_NotImplemented = 72,
+  CXCursor_InvalidCode = 73,
+  CXCursor_LastInvalid = CXCursor_InvalidCode,
+
+  /* Expressions */
+  CXCursor_FirstExpr = 100,
+
+  /**
+   * An expression whose specific kind is not exposed via this
+   * interface.
+   *
+   * Unexposed expressions have the same operations as any other kind
+   * of expression; one can extract their location information,
+   * spelling, children, etc. However, the specific kind of the
+   * expression is not reported.
+   */
+  CXCursor_UnexposedExpr = 100,
+
+  /**
+   * An expression that refers to some value declaration, such
+   * as a function, variable, or enumerator.
+   */
+  CXCursor_DeclRefExpr = 101,
+
+  /**
+   * An expression that refers to a member of a struct, union,
+   * class, Objective-C class, etc.
+   */
+  CXCursor_MemberRefExpr = 102,
+
+  /** An expression that calls a function. */
+  CXCursor_CallExpr = 103,
+
+  /** An expression that sends a message to an Objective-C
+   object or class. */
+  CXCursor_ObjCMessageExpr = 104,
+
+  /** An expression that represents a block literal. */
+  CXCursor_BlockExpr = 105,
+
+  /** An integer literal.
+   */
+  CXCursor_IntegerLiteral = 106,
+
+  /** A floating point number literal.
+   */
+  CXCursor_FloatingLiteral = 107,
+
+  /** An imaginary number literal.
+   */
+  CXCursor_ImaginaryLiteral = 108,
+
+  /** A string literal.
+   */
+  CXCursor_StringLiteral = 109,
+
+  /** A character literal.
+   */
+  CXCursor_CharacterLiteral = 110,
+
+  /** A parenthesized expression, e.g. "(1)".
+   *
+   * This AST node is only formed if full location information is requested.
+   */
+  CXCursor_ParenExpr = 111,
+
+  /** This represents the unary-expression's (except sizeof and
+   * alignof).
+   */
+  CXCursor_UnaryOperator = 112,
+
+  /** [C99 6.5.2.1] Array Subscripting.
+   */
+  CXCursor_ArraySubscriptExpr = 113,
+
+  /** A builtin binary operation expression such as "x + y" or
+   * "x <= y".
+   */
+  CXCursor_BinaryOperator = 114,
+
+  /** Compound assignment such as "+=".
+   */
+  CXCursor_CompoundAssignOperator = 115,
+
+  /** The ?: ternary operator.
+   */
+  CXCursor_ConditionalOperator = 116,
+
+  /** An explicit cast in C (C99 6.5.4) or a C-style cast in C++
+   * (C++ [expr.cast]), which uses the syntax (Type)expr.
+   *
+   * For example: (int)f.
+   */
+  CXCursor_CStyleCastExpr = 117,
+
+  /** [C99 6.5.2.5]
+   */
+  CXCursor_CompoundLiteralExpr = 118,
+
+  /** Describes an C or C++ initializer list.
+   */
+  CXCursor_InitListExpr = 119,
+
+  /** The GNU address of label extension, representing &&label.
+   */
+  CXCursor_AddrLabelExpr = 120,
+
+  /** This is the GNU Statement Expression extension: ({int X=4; X;})
+   */
+  CXCursor_StmtExpr = 121,
+
+  /** Represents a C11 generic selection.
+   */
+  CXCursor_GenericSelectionExpr = 122,
+
+  /** Implements the GNU __null extension, which is a name for a null
+   * pointer constant that has integral type (e.g., int or long) and is the same
+   * size and alignment as a pointer.
+   *
+   * The __null extension is typically only used by system headers, which define
+   * NULL as __null in C++ rather than using 0 (which is an integer that may not
+   * match the size of a pointer).
+   */
+  CXCursor_GNUNullExpr = 123,
+
+  /** C++'s static_cast<> expression.
+   */
+  CXCursor_CXXStaticCastExpr = 124,
+
+  /** C++'s dynamic_cast<> expression.
+   */
+  CXCursor_CXXDynamicCastExpr = 125,
+
+  /** C++'s reinterpret_cast<> expression.
+   */
+  CXCursor_CXXReinterpretCastExpr = 126,
+
+  /** C++'s const_cast<> expression.
+   */
+  CXCursor_CXXConstCastExpr = 127,
+
+  /** Represents an explicit C++ type conversion that uses "functional"
+   * notion (C++ [expr.type.conv]).
+   *
+   * Example:
+   * \code
+   *   x = int(0.5);
+   * \endcode
+   */
+  CXCursor_CXXFunctionalCastExpr = 128,
+
+  /** A C++ typeid expression (C++ [expr.typeid]).
+   */
+  CXCursor_CXXTypeidExpr = 129,
+
+  /** [C++ 2.13.5] C++ Boolean Literal.
+   */
+  CXCursor_CXXBoolLiteralExpr = 130,
+
+  /** [C++0x 2.14.7] C++ Pointer Literal.
+   */
+  CXCursor_CXXNullPtrLiteralExpr = 131,
+
+  /** Represents the "this" expression in C++
+   */
+  CXCursor_CXXThisExpr = 132,
+
+  /** [C++ 15] C++ Throw Expression.
+   *
+   * This handles 'throw' and 'throw' assignment-expression. When
+   * assignment-expression isn't present, Op will be null.
+   */
+  CXCursor_CXXThrowExpr = 133,
+
+  /** A new expression for memory allocation and constructor calls, e.g:
+   * "new CXXNewExpr(foo)".
+   */
+  CXCursor_CXXNewExpr = 134,
+
+  /** A delete expression for memory deallocation and destructor calls,
+   * e.g. "delete[] pArray".
+   */
+  CXCursor_CXXDeleteExpr = 135,
+
+  /** A unary expression. (noexcept, sizeof, or other traits)
+   */
+  CXCursor_UnaryExpr = 136,
+
+  /** An Objective-C string literal i.e. @"foo".
+   */
+  CXCursor_ObjCStringLiteral = 137,
+
+  /** An Objective-C \@encode expression.
+   */
+  CXCursor_ObjCEncodeExpr = 138,
+
+  /** An Objective-C \@selector expression.
+   */
+  CXCursor_ObjCSelectorExpr = 139,
+
+  /** An Objective-C \@protocol expression.
+   */
+  CXCursor_ObjCProtocolExpr = 140,
+
+  /** An Objective-C "bridged" cast expression, which casts between
+   * Objective-C pointers and C pointers, transferring ownership in the process.
+   *
+   * \code
+   *   NSString *str = (__bridge_transfer NSString *)CFCreateString();
+   * \endcode
+   */
+  CXCursor_ObjCBridgedCastExpr = 141,
+
+  /** Represents a C++0x pack expansion that produces a sequence of
+   * expressions.
+   *
+   * A pack expansion expression contains a pattern (which itself is an
+   * expression) followed by an ellipsis. For example:
+   *
+   * \code
+   * template<typename F, typename ...Types>
+   * void forward(F f, Types &&...args) {
+   *  f(static_cast<Types&&>(args)...);
+   * }
+   * \endcode
+   */
+  CXCursor_PackExpansionExpr = 142,
+
+  /** Represents an expression that computes the length of a parameter
+   * pack.
+   *
+   * \code
+   * template<typename ...Types>
+   * struct count {
+   *   static const unsigned value = sizeof...(Types);
+   * };
+   * \endcode
+   */
+  CXCursor_SizeOfPackExpr = 143,
+
+  /* Represents a C++ lambda expression that produces a local function
+   * object.
+   *
+   * \code
+   * void abssort(float *x, unsigned N) {
+   *   std::sort(x, x + N,
+   *             [](float a, float b) {
+   *               return std::abs(a) < std::abs(b);
+   *             });
+   * }
+   * \endcode
+   */
+  CXCursor_LambdaExpr = 144,
+
+  /** Objective-c Boolean Literal.
+   */
+  CXCursor_ObjCBoolLiteralExpr = 145,
+
+  /** Represents the "self" expression in an Objective-C method.
+   */
+  CXCursor_ObjCSelfExpr = 146,
+
+  /** OpenMP 5.0 [2.1.5, Array Section].
+   * OpenACC 3.3 [2.7.1, Data Specification for Data Clauses (Sub Arrays)]
+   */
+  CXCursor_ArraySectionExpr = 147,
+
+  /** Represents an @available(...) check.
+   */
+  CXCursor_ObjCAvailabilityCheckExpr = 148,
+
+  /**
+   * Fixed point literal
+   */
+  CXCursor_FixedPointLiteral = 149,
+
+  /** OpenMP 5.0 [2.1.4, Array Shaping].
+   */
+  CXCursor_OMPArrayShapingExpr = 150,
+
+  /**
+   * OpenMP 5.0 [2.1.6 Iterators]
+   */
+  CXCursor_OMPIteratorExpr = 151,
+
+  /** OpenCL's addrspace_cast<> expression.
+   */
+  CXCursor_CXXAddrspaceCastExpr = 152,
+
+  /**
+   * Expression that references a C++20 concept.
+   */
+  CXCursor_ConceptSpecializationExpr = 153,
+
+  /**
+   * Expression that references a C++20 requires expression.
+   */
+  CXCursor_RequiresExpr = 154,
+
+  /**
+   * Expression that references a C++20 parenthesized list aggregate
+   * initializer.
+   */
+  CXCursor_CXXParenListInitExpr = 155,
+
+  /**
+   *  Represents a C++26 pack indexing expression.
+   */
+  CXCursor_PackIndexingExpr = 156,
+
+  CXCursor_LastExpr = CXCursor_PackIndexingExpr,
+
+  /* Statements */
+  CXCursor_FirstStmt = 200,
+  /**
+   * A statement whose specific kind is not exposed via this
+   * interface.
+   *
+   * Unexposed statements have the same operations as any other kind of
+   * statement; one can extract their location information, spelling,
+   * children, etc. However, the specific kind of the statement is not
+   * reported.
+   */
+  CXCursor_UnexposedStmt = 200,
+
+  /** A labelled statement in a function.
+   *
+   * This cursor kind is used to describe the "start_over:" label statement in
+   * the following example:
+   *
+   * \code
+   *   start_over:
+   *     ++counter;
+   * \endcode
+   *
+   */
+  CXCursor_LabelStmt = 201,
+
+  /** A group of statements like { stmt stmt }.
+   *
+   * This cursor kind is used to describe compound statements, e.g. function
+   * bodies.
+   */
+  CXCursor_CompoundStmt = 202,
+
+  /** A case statement.
+   */
+  CXCursor_CaseStmt = 203,
+
+  /** A default statement.
+   */
+  CXCursor_DefaultStmt = 204,
+
+  /** An if statement
+   */
+  CXCursor_IfStmt = 205,
+
+  /** A switch statement.
+   */
+  CXCursor_SwitchStmt = 206,
+
+  /** A while statement.
+   */
+  CXCursor_WhileStmt = 207,
+
+  /** A do statement.
+   */
+  CXCursor_DoStmt = 208,
+
+  /** A for statement.
+   */
+  CXCursor_ForStmt = 209,
+
+  /** A goto statement.
+   */
+  CXCursor_GotoStmt = 210,
+
+  /** An indirect goto statement.
+   */
+  CXCursor_IndirectGotoStmt = 211,
+
+  /** A continue statement.
+   */
+  CXCursor_ContinueStmt = 212,
+
+  /** A break statement.
+   */
+  CXCursor_BreakStmt = 213,
+
+  /** A return statement.
+   */
+  CXCursor_ReturnStmt = 214,
+
+  /** A GCC inline assembly statement extension.
+   */
+  CXCursor_GCCAsmStmt = 215,
+  CXCursor_AsmStmt = CXCursor_GCCAsmStmt,
+
+  /** Objective-C's overall \@try-\@catch-\@finally statement.
+   */
+  CXCursor_ObjCAtTryStmt = 216,
+
+  /** Objective-C's \@catch statement.
+   */
+  CXCursor_ObjCAtCatchStmt = 217,
+
+  /** Objective-C's \@finally statement.
+   */
+  CXCursor_ObjCAtFinallyStmt = 218,
+
+  /** Objective-C's \@throw statement.
+   */
+  CXCursor_ObjCAtThrowStmt = 219,
+
+  /** Objective-C's \@synchronized statement.
+   */
+  CXCursor_ObjCAtSynchronizedStmt = 220,
+
+  /** Objective-C's autorelease pool statement.
+   */
+  CXCursor_ObjCAutoreleasePoolStmt = 221,
+
+  /** Objective-C's collection statement.
+   */
+  CXCursor_ObjCForCollectionStmt = 222,
+
+  /** C++'s catch statement.
+   */
+  CXCursor_CXXCatchStmt = 223,
+
+  /** C++'s try statement.
+   */
+  CXCursor_CXXTryStmt = 224,
+
+  /** C++'s for (* : *) statement.
+   */
+  CXCursor_CXXForRangeStmt = 225,
+
+  /** Windows Structured Exception Handling's try statement.
+   */
+  CXCursor_SEHTryStmt = 226,
+
+  /** Windows Structured Exception Handling's except statement.
+   */
+  CXCursor_SEHExceptStmt = 227,
+
+  /** Windows Structured Exception Handling's finally statement.
+   */
+  CXCursor_SEHFinallyStmt = 228,
+
+  /** A MS inline assembly statement extension.
+   */
+  CXCursor_MSAsmStmt = 229,
+
+  /** The null statement ";": C99 6.8.3p3.
+   *
+   * This cursor kind is used to describe the null statement.
+   */
+  CXCursor_NullStmt = 230,
+
+  /** Adaptor class for mixing declarations with statements and
+   * expressions.
+   */
+  CXCursor_DeclStmt = 231,
+
+  /** OpenMP parallel directive.
+   */
+  CXCursor_OMPParallelDirective = 232,
+
+  /** OpenMP SIMD directive.
+   */
+  CXCursor_OMPSimdDirective = 233,
+
+  /** OpenMP for directive.
+   */
+  CXCursor_OMPForDirective = 234,
+
+  /** OpenMP sections directive.
+   */
+  CXCursor_OMPSectionsDirective = 235,
+
+  /** OpenMP section directive.
+   */
+  CXCursor_OMPSectionDirective = 236,
+
+  /** OpenMP single directive.
+   */
+  CXCursor_OMPSingleDirective = 237,
+
+  /** OpenMP parallel for directive.
+   */
+  CXCursor_OMPParallelForDirective = 238,
+
+  /** OpenMP parallel sections directive.
+   */
+  CXCursor_OMPParallelSectionsDirective = 239,
+
+  /** OpenMP task directive.
+   */
+  CXCursor_OMPTaskDirective = 240,
+
+  /** OpenMP master directive.
+   */
+  CXCursor_OMPMasterDirective = 241,
+
+  /** OpenMP critical directive.
+   */
+  CXCursor_OMPCriticalDirective = 242,
+
+  /** OpenMP taskyield directive.
+   */
+  CXCursor_OMPTaskyieldDirective = 243,
+
+  /** OpenMP barrier directive.
+   */
+  CXCursor_OMPBarrierDirective = 244,
+
+  /** OpenMP taskwait directive.
+   */
+  CXCursor_OMPTaskwaitDirective = 245,
+
+  /** OpenMP flush directive.
+   */
+  CXCursor_OMPFlushDirective = 246,
+
+  /** Windows Structured Exception Handling's leave statement.
+   */
+  CXCursor_SEHLeaveStmt = 247,
+
+  /** OpenMP ordered directive.
+   */
+  CXCursor_OMPOrderedDirective = 248,
+
+  /** OpenMP atomic directive.
+   */
+  CXCursor_OMPAtomicDirective = 249,
+
+  /** OpenMP for SIMD directive.
+   */
+  CXCursor_OMPForSimdDirective = 250,
+
+  /** OpenMP parallel for SIMD directive.
+   */
+  CXCursor_OMPParallelForSimdDirective = 251,
+
+  /** OpenMP target directive.
+   */
+  CXCursor_OMPTargetDirective = 252,
+
+  /** OpenMP teams directive.
+   */
+  CXCursor_OMPTeamsDirective = 253,
+
+  /** OpenMP taskgroup directive.
+   */
+  CXCursor_OMPTaskgroupDirective = 254,
+
+  /** OpenMP cancellation point directive.
+   */
+  CXCursor_OMPCancellationPointDirective = 255,
+
+  /** OpenMP cancel directive.
+   */
+  CXCursor_OMPCancelDirective = 256,
+
+  /** OpenMP target data directive.
+   */
+  CXCursor_OMPTargetDataDirective = 257,
+
+  /** OpenMP taskloop directive.
+   */
+  CXCursor_OMPTaskLoopDirective = 258,
+
+  /** OpenMP taskloop simd directive.
+   */
+  CXCursor_OMPTaskLoopSimdDirective = 259,
+
+  /** OpenMP distribute directive.
+   */
+  CXCursor_OMPDistributeDirective = 260,
+
+  /** OpenMP target enter data directive.
+   */
+  CXCursor_OMPTargetEnterDataDirective = 261,
+
+  /** OpenMP target exit data directive.
+   */
+  CXCursor_OMPTargetExitDataDirective = 262,
+
+  /** OpenMP target parallel directive.
+   */
+  CXCursor_OMPTargetParallelDirective = 263,
+
+  /** OpenMP target parallel for directive.
+   */
+  CXCursor_OMPTargetParallelForDirective = 264,
+
+  /** OpenMP target update directive.
+   */
+  CXCursor_OMPTargetUpdateDirective = 265,
+
+  /** OpenMP distribute parallel for directive.
+   */
+  CXCursor_OMPDistributeParallelForDirective = 266,
+
+  /** OpenMP distribute parallel for simd directive.
+   */
+  CXCursor_OMPDistributeParallelForSimdDirective = 267,
+
+  /** OpenMP distribute simd directive.
+   */
+  CXCursor_OMPDistributeSimdDirective = 268,
+
+  /** OpenMP target parallel for simd directive.
+   */
+  CXCursor_OMPTargetParallelForSimdDirective = 269,
+
+  /** OpenMP target simd directive.
+   */
+  CXCursor_OMPTargetSimdDirective = 270,
+
+  /** OpenMP teams distribute directive.
+   */
+  CXCursor_OMPTeamsDistributeDirective = 271,
+
+  /** OpenMP teams distribute simd directive.
+   */
+  CXCursor_OMPTeamsDistributeSimdDirective = 272,
+
+  /** OpenMP teams distribute parallel for simd directive.
+   */
+  CXCursor_OMPTeamsDistributeParallelForSimdDirective = 273,
+
+  /** OpenMP teams distribute parallel for directive.
+   */
+  CXCursor_OMPTeamsDistributeParallelForDirective = 274,
+
+  /** OpenMP target teams directive.
+   */
+  CXCursor_OMPTargetTeamsDirective = 275,
+
+  /** OpenMP target teams distribute directive.
+   */
+  CXCursor_OMPTargetTeamsDistributeDirective = 276,
+
+  /** OpenMP target teams distribute parallel for directive.
+   */
+  CXCursor_OMPTargetTeamsDistributeParallelForDirective = 277,
+
+  /** OpenMP target teams distribute parallel for simd directive.
+   */
+  CXCursor_OMPTargetTeamsDistributeParallelForSimdDirective = 278,
+
+  /** OpenMP target teams distribute simd directive.
+   */
+  CXCursor_OMPTargetTeamsDistributeSimdDirective = 279,
+
+  /** C++2a std::bit_cast expression.
+   */
+  CXCursor_BuiltinBitCastExpr = 280,
+
+  /** OpenMP master taskloop directive.
+   */
+  CXCursor_OMPMasterTaskLoopDirective = 281,
+
+  /** OpenMP parallel master taskloop directive.
+   */
+  CXCursor_OMPParallelMasterTaskLoopDirective = 282,
+
+  /** OpenMP master taskloop simd directive.
+   */
+  CXCursor_OMPMasterTaskLoopSimdDirective = 283,
+
+  /** OpenMP parallel master taskloop simd directive.
+   */
+  CXCursor_OMPParallelMasterTaskLoopSimdDirective = 284,
+
+  /** OpenMP parallel master directive.
+   */
+  CXCursor_OMPParallelMasterDirective = 285,
+
+  /** OpenMP depobj directive.
+   */
+  CXCursor_OMPDepobjDirective = 286,
+
+  /** OpenMP scan directive.
+   */
+  CXCursor_OMPScanDirective = 287,
+
+  /** OpenMP tile directive.
+   */
+  CXCursor_OMPTileDirective = 288,
+
+  /** OpenMP canonical loop.
+   */
+  CXCursor_OMPCanonicalLoop = 289,
+
+  /** OpenMP interop directive.
+   */
+  CXCursor_OMPInteropDirective = 290,
+
+  /** OpenMP dispatch directive.
+   */
+  CXCursor_OMPDispatchDirective = 291,
+
+  /** OpenMP masked directive.
+   */
+  CXCursor_OMPMaskedDirective = 292,
+
+  /** OpenMP unroll directive.
+   */
+  CXCursor_OMPUnrollDirective = 293,
+
+  /** OpenMP metadirective directive.
+   */
+  CXCursor_OMPMetaDirective = 294,
+
+  /** OpenMP loop directive.
+   */
+  CXCursor_OMPGenericLoopDirective = 295,
+
+  /** OpenMP teams loop directive.
+   */
+  CXCursor_OMPTeamsGenericLoopDirective = 296,
+
+  /** OpenMP target teams loop directive.
+   */
+  CXCursor_OMPTargetTeamsGenericLoopDirective = 297,
+
+  /** OpenMP parallel loop directive.
+   */
+  CXCursor_OMPParallelGenericLoopDirective = 298,
+
+  /** OpenMP target parallel loop directive.
+   */
+  CXCursor_OMPTargetParallelGenericLoopDirective = 299,
+
+  /** OpenMP parallel masked directive.
+   */
+  CXCursor_OMPParallelMaskedDirective = 300,
+
+  /** OpenMP masked taskloop directive.
+   */
+  CXCursor_OMPMaskedTaskLoopDirective = 301,
+
+  /** OpenMP masked taskloop simd directive.
+   */
+  CXCursor_OMPMaskedTaskLoopSimdDirective = 302,
+
+  /** OpenMP parallel masked taskloop directive.
+   */
+  CXCursor_OMPParallelMaskedTaskLoopDirective = 303,
+
+  /** OpenMP parallel masked taskloop simd directive.
+   */
+  CXCursor_OMPParallelMaskedTaskLoopSimdDirective = 304,
+
+  /** OpenMP error directive.
+   */
+  CXCursor_OMPErrorDirective = 305,
+
+  /** OpenMP scope directive.
+   */
+  CXCursor_OMPScopeDirective = 306,
+
+  /** OpenMP reverse directive.
+   */
+  CXCursor_OMPReverseDirective = 307,
+
+  /** OpenMP interchange directive.
+   */
+  CXCursor_OMPInterchangeDirective = 308,
+
+  /** OpenMP assume directive.
+   */
+  CXCursor_OMPAssumeDirective = 309,
+
+  /** OpenMP assume directive.
+   */
+  CXCursor_OMPStripeDirective = 310,
+
+  /** OpenMP fuse directive
+   */
+  CXCursor_OMPFuseDirective = 311,
+
+  /** OpenACC Compute Construct.
+   */
+  CXCursor_OpenACCComputeConstruct = 320,
+
+  /** OpenACC Loop Construct.
+   */
+  CXCursor_OpenACCLoopConstruct = 321,
+
+  /** OpenACC Combined Constructs.
+   */
+  CXCursor_OpenACCCombinedConstruct = 322,
+
+  /** OpenACC data Construct.
+   */
+  CXCursor_OpenACCDataConstruct = 323,
+
+  /** OpenACC enter data Construct.
+   */
+  CXCursor_OpenACCEnterDataConstruct = 324,
+
+  /** OpenACC exit data Construct.
+   */
+  CXCursor_OpenACCExitDataConstruct = 325,
+
+  /** OpenACC host_data Construct.
+   */
+  CXCursor_OpenACCHostDataConstruct = 326,
+
+  /** OpenACC wait Construct.
+   */
+  CXCursor_OpenACCWaitConstruct = 327,
+
+  /** OpenACC init Construct.
+   */
+  CXCursor_OpenACCInitConstruct = 328,
+
+  /** OpenACC shutdown Construct.
+   */
+  CXCursor_OpenACCShutdownConstruct = 329,
+
+  /** OpenACC set Construct.
+   */
+  CXCursor_OpenACCSetConstruct = 330,
+
+  /** OpenACC update Construct.
+   */
+  CXCursor_OpenACCUpdateConstruct = 331,
+
+  /** OpenACC atomic Construct.
+   */
+  CXCursor_OpenACCAtomicConstruct = 332,
+
+  /** OpenACC cache Construct.
+   */
+  CXCursor_OpenACCCacheConstruct = 333,
+
+  CXCursor_LastStmt = CXCursor_OpenACCCacheConstruct,
+
+  /**
+   * Cursor that represents the translation unit itself.
+   *
+   * The translation unit cursor exists primarily to act as the root
+   * cursor for traversing the contents of a translation unit.
+   */
+  CXCursor_TranslationUnit = 350,
+
+  /* Attributes */
+  CXCursor_FirstAttr = 400,
+  /**
+   * An attribute whose specific kind is not exposed via this
+   * interface.
+   */
+  CXCursor_UnexposedAttr = 400,
+
+  CXCursor_IBActionAttr = 401,
+  CXCursor_IBOutletAttr = 402,
+  CXCursor_IBOutletCollectionAttr = 403,
+  CXCursor_CXXFinalAttr = 404,
+  CXCursor_CXXOverrideAttr = 405,
+  CXCursor_AnnotateAttr = 406,
+  CXCursor_AsmLabelAttr = 407,
+  CXCursor_PackedAttr = 408,
+  CXCursor_PureAttr = 409,
+  CXCursor_ConstAttr = 410,
+  CXCursor_NoDuplicateAttr = 411,
+  CXCursor_CUDAConstantAttr = 412,
+  CXCursor_CUDADeviceAttr = 413,
+  CXCursor_CUDAGlobalAttr = 414,
+  CXCursor_CUDAHostAttr = 415,
+  CXCursor_CUDASharedAttr = 416,
+  CXCursor_VisibilityAttr = 417,
+  CXCursor_DLLExport = 418,
+  CXCursor_DLLImport = 419,
+  CXCursor_NSReturnsRetained = 420,
+  CXCursor_NSReturnsNotRetained = 421,
+  CXCursor_NSReturnsAutoreleased = 422,
+  CXCursor_NSConsumesSelf = 423,
+  CXCursor_NSConsumed = 424,
+  CXCursor_ObjCException = 425,
+  CXCursor_ObjCNSObject = 426,
+  CXCursor_ObjCIndependentClass = 427,
+  CXCursor_ObjCPreciseLifetime = 428,
+  CXCursor_ObjCReturnsInnerPointer = 429,
+  CXCursor_ObjCRequiresSuper = 430,
+  CXCursor_ObjCRootClass = 431,
+  CXCursor_ObjCSubclassingRestricted = 432,
+  CXCursor_ObjCExplicitProtocolImpl = 433,
+  CXCursor_ObjCDesignatedInitializer = 434,
+  CXCursor_ObjCRuntimeVisible = 435,
+  CXCursor_ObjCBoxable = 436,
+  CXCursor_FlagEnum = 437,
+  CXCursor_ConvergentAttr = 438,
+  CXCursor_WarnUnusedAttr = 439,
+  CXCursor_WarnUnusedResultAttr = 440,
+  CXCursor_AlignedAttr = 441,
+  CXCursor_LastAttr = CXCursor_AlignedAttr,
+
+  /* Preprocessing */
+  CXCursor_PreprocessingDirective = 500,
+  CXCursor_MacroDefinition = 501,
+  CXCursor_MacroExpansion = 502,
+  CXCursor_MacroInstantiation = CXCursor_MacroExpansion,
+  CXCursor_InclusionDirective = 503,
+  CXCursor_FirstPreprocessing = CXCursor_PreprocessingDirective,
+  CXCursor_LastPreprocessing = CXCursor_InclusionDirective,
+
+  /* Extra Declarations */
+  /**
+   * A module import declaration.
+   */
+  CXCursor_ModuleImportDecl = 600,
+  CXCursor_TypeAliasTemplateDecl = 601,
+  /**
+   * A static_assert or _Static_assert node
+   */
+  CXCursor_StaticAssert = 602,
+  /**
+   * a friend declaration.
+   */
+  CXCursor_FriendDecl = 603,
+  /**
+   * a concept declaration.
+   */
+  CXCursor_ConceptDecl = 604,
+
+  CXCursor_FirstExtraDecl = CXCursor_ModuleImportDecl,
+  CXCursor_LastExtraDecl = CXCursor_ConceptDecl,
+
+  /**
+   * A code completion overload candidate.
+   */
+  CXCursor_OverloadCandidate = 700
+};
+
+/**
+ * A cursor representing some element in the abstract syntax tree for
+ * a translation unit.
+ *
+ * The cursor abstraction unifies the different kinds of entities in a
+ * program--declaration, statements, expressions, references to declarations,
+ * etc.--under a single "cursor" abstraction with a common set of operations.
+ * Common operation for a cursor include: getting the physical location in
+ * a source file where the cursor points, getting the name associated with a
+ * cursor, and retrieving cursors for any child nodes of a particular cursor.
+ *
+ * Cursors can be produced in two specific ways.
+ * clang_getTranslationUnitCursor() produces a cursor for a translation unit,
+ * from which one can use clang_visitChildren() to explore the rest of the
+ * translation unit. clang_getCursor() maps from a physical source location
+ * to the entity that resides at that location, allowing one to map from the
+ * source code into the AST.
+ */
+typedef struct {
+  enum CXCursorKind kind;
+  int xdata;
+  const void *data[3];
+} CXCursor;
+
+/**
+ * \defgroup CINDEX_CURSOR_MANIP Cursor manipulations
+ *
+ * @{
+ */
+
+/**
+ * Retrieve the NULL cursor, which represents no entity.
+ */
+CINDEX_LINKAGE CXCursor clang_getNullCursor(void);
+
+/**
+ * Retrieve the cursor that represents the given translation unit.
+ *
+ * The translation unit cursor can be used to start traversing the
+ * various declarations within the given translation unit.
+ */
+CINDEX_LINKAGE CXCursor clang_getTranslationUnitCursor(CXTranslationUnit);
+
+/**
+ * Determine whether two cursors are equivalent.
+ */
+CINDEX_LINKAGE unsigned clang_equalCursors(CXCursor, CXCursor);
+
+/**
+ * Returns non-zero if \p cursor is null.
+ */
+CINDEX_LINKAGE int clang_Cursor_isNull(CXCursor cursor);
+
+/**
+ * Compute a hash value for the given cursor.
+ */
+CINDEX_LINKAGE unsigned clang_hashCursor(CXCursor);
+
+/**
+ * Retrieve the kind of the given cursor.
+ */
+CINDEX_LINKAGE enum CXCursorKind clang_getCursorKind(CXCursor);
+
+/**
+ * Determine whether the given cursor kind represents a declaration.
+ */
+CINDEX_LINKAGE unsigned clang_isDeclaration(enum CXCursorKind);
+
+/**
+ * Determine whether the given declaration is invalid.
+ *
+ * A declaration is invalid if it could not be parsed successfully.
+ *
+ * \returns non-zero if the cursor represents a declaration and it is
+ * invalid, otherwise NULL.
+ */
+CINDEX_LINKAGE unsigned clang_isInvalidDeclaration(CXCursor);
+
+/**
+ * Determine whether the given cursor kind represents a simple
+ * reference.
+ *
+ * Note that other kinds of cursors (such as expressions) can also refer to
+ * other cursors. Use clang_getCursorReferenced() to determine whether a
+ * particular cursor refers to another entity.
+ */
+CINDEX_LINKAGE unsigned clang_isReference(enum CXCursorKind);
+
+/**
+ * Determine whether the given cursor kind represents an expression.
+ */
+CINDEX_LINKAGE unsigned clang_isExpression(enum CXCursorKind);
+
+/**
+ * Determine whether the given cursor kind represents a statement.
+ */
+CINDEX_LINKAGE unsigned clang_isStatement(enum CXCursorKind);
+
+/**
+ * Determine whether the given cursor kind represents an attribute.
+ */
+CINDEX_LINKAGE unsigned clang_isAttribute(enum CXCursorKind);
+
+/**
+ * Determine whether the given cursor has any attributes.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_hasAttrs(CXCursor C);
+
+/**
+ * Determine whether the given cursor kind represents an invalid
+ * cursor.
+ */
+CINDEX_LINKAGE unsigned clang_isInvalid(enum CXCursorKind);
+
+/**
+ * Determine whether the given cursor kind represents a translation
+ * unit.
+ */
+CINDEX_LINKAGE unsigned clang_isTranslationUnit(enum CXCursorKind);
+
+/***
+ * Determine whether the given cursor represents a preprocessing
+ * element, such as a preprocessor directive or macro instantiation.
+ */
+CINDEX_LINKAGE unsigned clang_isPreprocessing(enum CXCursorKind);
+
+/***
+ * Determine whether the given cursor represents a currently
+ *  unexposed piece of the AST (e.g., CXCursor_UnexposedStmt).
+ */
+CINDEX_LINKAGE unsigned clang_isUnexposed(enum CXCursorKind);
+
+/**
+ * Describe the linkage of the entity referred to by a cursor.
+ */
+enum CXLinkageKind {
+  /** This value indicates that no linkage information is available
+   * for a provided CXCursor. */
+  CXLinkage_Invalid,
+  /**
+   * This is the linkage for variables, parameters, and so on that
+   *  have automatic storage.  This covers normal (non-extern) local variables.
+   */
+  CXLinkage_NoLinkage,
+  /** This is the linkage for static variables and static functions. */
+  CXLinkage_Internal,
+  /** This is the linkage for entities with external linkage that live
+   * in C++ anonymous namespaces.*/
+  CXLinkage_UniqueExternal,
+  /** This is the linkage for entities with true, external linkage. */
+  CXLinkage_External
+};
+
+/**
+ * Determine the linkage of the entity referred to by a given cursor.
+ */
+CINDEX_LINKAGE enum CXLinkageKind clang_getCursorLinkage(CXCursor cursor);
+
+enum CXVisibilityKind {
+  /** This value indicates that no visibility information is available
+   * for a provided CXCursor. */
+  CXVisibility_Invalid,
+
+  /** Symbol not seen by the linker. */
+  CXVisibility_Hidden,
+  /** Symbol seen by the linker but resolves to a symbol inside this object. */
+  CXVisibility_Protected,
+  /** Symbol seen by the linker and acts like a normal symbol. */
+  CXVisibility_Default
+};
+
+/**
+ * Describe the visibility of the entity referred to by a cursor.
+ *
+ * This returns the default visibility if not explicitly specified by
+ * a visibility attribute. The default visibility may be changed by
+ * commandline arguments.
+ *
+ * \param cursor The cursor to query.
+ *
+ * \returns The visibility of the cursor.
+ */
+CINDEX_LINKAGE enum CXVisibilityKind clang_getCursorVisibility(CXCursor cursor);
+
+/**
+ * Determine the availability of the entity that this cursor refers to,
+ * taking the current target platform into account.
+ *
+ * \param cursor The cursor to query.
+ *
+ * \returns The availability of the cursor.
+ */
+CINDEX_LINKAGE enum CXAvailabilityKind
+clang_getCursorAvailability(CXCursor cursor);
+
+/**
+ * Describes the availability of a given entity on a particular platform, e.g.,
+ * a particular class might only be available on Mac OS 10.7 or newer.
+ */
+typedef struct CXPlatformAvailability {
+  /**
+   * A string that describes the platform for which this structure
+   * provides availability information.
+   *
+   * Possible values are "ios" or "macos".
+   */
+  CXString Platform;
+  /**
+   * The version number in which this entity was introduced.
+   */
+  CXVersion Introduced;
+  /**
+   * The version number in which this entity was deprecated (but is
+   * still available).
+   */
+  CXVersion Deprecated;
+  /**
+   * The version number in which this entity was obsoleted, and therefore
+   * is no longer available.
+   */
+  CXVersion Obsoleted;
+  /**
+   * Whether the entity is unconditionally unavailable on this platform.
+   */
+  int Unavailable;
+  /**
+   * An optional message to provide to a user of this API, e.g., to
+   * suggest replacement APIs.
+   */
+  CXString Message;
+} CXPlatformAvailability;
+
+/**
+ * Determine the availability of the entity that this cursor refers to
+ * on any platforms for which availability information is known.
+ *
+ * \param cursor The cursor to query.
+ *
+ * \param always_deprecated If non-NULL, will be set to indicate whether the
+ * entity is deprecated on all platforms.
+ *
+ * \param deprecated_message If non-NULL, will be set to the message text
+ * provided along with the unconditional deprecation of this entity. The client
+ * is responsible for deallocating this string.
+ *
+ * \param always_unavailable If non-NULL, will be set to indicate whether the
+ * entity is unavailable on all platforms.
+ *
+ * \param unavailable_message If non-NULL, will be set to the message text
+ * provided along with the unconditional unavailability of this entity. The
+ * client is responsible for deallocating this string.
+ *
+ * \param availability If non-NULL, an array of CXPlatformAvailability instances
+ * that will be populated with platform availability information, up to either
+ * the number of platforms for which availability information is available (as
+ * returned by this function) or \c availability_size, whichever is smaller.
+ *
+ * \param availability_size The number of elements available in the
+ * \c availability array.
+ *
+ * \returns The number of platforms (N) for which availability information is
+ * available (which is unrelated to \c availability_size).
+ *
+ * Note that the client is responsible for calling
+ * \c clang_disposeCXPlatformAvailability to free each of the
+ * platform-availability structures returned. There are
+ * \c min(N, availability_size) such structures.
+ */
+CINDEX_LINKAGE int clang_getCursorPlatformAvailability(
+    CXCursor cursor, int *always_deprecated, CXString *deprecated_message,
+    int *always_unavailable, CXString *unavailable_message,
+    CXPlatformAvailability *availability, int availability_size);
+
+/**
+ * Free the memory associated with a \c CXPlatformAvailability structure.
+ */
+CINDEX_LINKAGE void
+clang_disposeCXPlatformAvailability(CXPlatformAvailability *availability);
+
+/**
+ * If cursor refers to a variable declaration and it has initializer returns
+ * cursor referring to the initializer otherwise return null cursor.
+ */
+CINDEX_LINKAGE CXCursor clang_Cursor_getVarDeclInitializer(CXCursor cursor);
+
+/**
+ * If cursor refers to a variable declaration that has global storage returns 1.
+ * If cursor refers to a variable declaration that doesn't have global storage
+ * returns 0. Otherwise returns -1.
+ */
+CINDEX_LINKAGE int clang_Cursor_hasVarDeclGlobalStorage(CXCursor cursor);
+
+/**
+ * If cursor refers to a variable declaration that has external storage
+ * returns 1. If cursor refers to a variable declaration that doesn't have
+ * external storage returns 0. Otherwise returns -1.
+ */
+CINDEX_LINKAGE int clang_Cursor_hasVarDeclExternalStorage(CXCursor cursor);
+
+/**
+ * Describe the "language" of the entity referred to by a cursor.
+ */
+enum CXLanguageKind {
+  CXLanguage_Invalid = 0,
+  CXLanguage_C,
+  CXLanguage_ObjC,
+  CXLanguage_CPlusPlus
+};
+
+/**
+ * Determine the "language" of the entity referred to by a given cursor.
+ */
+CINDEX_LINKAGE enum CXLanguageKind clang_getCursorLanguage(CXCursor cursor);
+
+/**
+ * Describe the "thread-local storage (TLS) kind" of the declaration
+ * referred to by a cursor.
+ */
+enum CXTLSKind { CXTLS_None = 0, CXTLS_Dynamic, CXTLS_Static };
+
+/**
+ * Determine the "thread-local storage (TLS) kind" of the declaration
+ * referred to by a cursor.
+ */
+CINDEX_LINKAGE enum CXTLSKind clang_getCursorTLSKind(CXCursor cursor);
+
+/**
+ * Returns the translation unit that a cursor originated from.
+ */
+CINDEX_LINKAGE CXTranslationUnit clang_Cursor_getTranslationUnit(CXCursor);
+
+/**
+ * A fast container representing a set of CXCursors.
+ */
+typedef struct CXCursorSetImpl *CXCursorSet;
+
+/**
+ * Creates an empty CXCursorSet.
+ */
+CINDEX_LINKAGE CXCursorSet clang_createCXCursorSet(void);
+
+/**
+ * Disposes a CXCursorSet and releases its associated memory.
+ */
+CINDEX_LINKAGE void clang_disposeCXCursorSet(CXCursorSet cset);
+
+/**
+ * Queries a CXCursorSet to see if it contains a specific CXCursor.
+ *
+ * \returns non-zero if the set contains the specified cursor.
+ */
+CINDEX_LINKAGE unsigned clang_CXCursorSet_contains(CXCursorSet cset,
+                                                   CXCursor cursor);
+
+/**
+ * Inserts a CXCursor into a CXCursorSet.
+ *
+ * \returns zero if the CXCursor was already in the set, and non-zero otherwise.
+ */
+CINDEX_LINKAGE unsigned clang_CXCursorSet_insert(CXCursorSet cset,
+                                                 CXCursor cursor);
+
+/**
+ * Determine the semantic parent of the given cursor.
+ *
+ * The semantic parent of a cursor is the cursor that semantically contains
+ * the given \p cursor. For many declarations, the lexical and semantic parents
+ * are equivalent (the lexical parent is returned by
+ * \c clang_getCursorLexicalParent()). They diverge when declarations or
+ * definitions are provided out-of-line. For example:
+ *
+ * \code
+ * class C {
+ *  void f();
+ * };
+ *
+ * void C::f() { }
+ * \endcode
+ *
+ * In the out-of-line definition of \c C::f, the semantic parent is
+ * the class \c C, of which this function is a member. The lexical parent is
+ * the place where the declaration actually occurs in the source code; in this
+ * case, the definition occurs in the translation unit. In general, the
+ * lexical parent for a given entity can change without affecting the semantics
+ * of the program, and the lexical parent of different declarations of the
+ * same entity may be different. Changing the semantic parent of a declaration,
+ * on the other hand, can have a major impact on semantics, and redeclarations
+ * of a particular entity should all have the same semantic context.
+ *
+ * In the example above, both declarations of \c C::f have \c C as their
+ * semantic context, while the lexical context of the first \c C::f is \c C
+ * and the lexical context of the second \c C::f is the translation unit.
+ *
+ * For global declarations, the semantic parent is the translation unit.
+ */
+CINDEX_LINKAGE CXCursor clang_getCursorSemanticParent(CXCursor cursor);
+
+/**
+ * Determine the lexical parent of the given cursor.
+ *
+ * The lexical parent of a cursor is the cursor in which the given \p cursor
+ * was actually written. For many declarations, the lexical and semantic parents
+ * are equivalent (the semantic parent is returned by
+ * \c clang_getCursorSemanticParent()). They diverge when declarations or
+ * definitions are provided out-of-line. For example:
+ *
+ * \code
+ * class C {
+ *  void f();
+ * };
+ *
+ * void C::f() { }
+ * \endcode
+ *
+ * In the out-of-line definition of \c C::f, the semantic parent is
+ * the class \c C, of which this function is a member. The lexical parent is
+ * the place where the declaration actually occurs in the source code; in this
+ * case, the definition occurs in the translation unit. In general, the
+ * lexical parent for a given entity can change without affecting the semantics
+ * of the program, and the lexical parent of different declarations of the
+ * same entity may be different. Changing the semantic parent of a declaration,
+ * on the other hand, can have a major impact on semantics, and redeclarations
+ * of a particular entity should all have the same semantic context.
+ *
+ * In the example above, both declarations of \c C::f have \c C as their
+ * semantic context, while the lexical context of the first \c C::f is \c C
+ * and the lexical context of the second \c C::f is the translation unit.
+ *
+ * For declarations written in the global scope, the lexical parent is
+ * the translation unit.
+ */
+CINDEX_LINKAGE CXCursor clang_getCursorLexicalParent(CXCursor cursor);
+
+/**
+ * Determine the set of methods that are overridden by the given
+ * method.
+ *
+ * In both Objective-C and C++, a method (aka virtual member function,
+ * in C++) can override a virtual method in a base class. For
+ * Objective-C, a method is said to override any method in the class's
+ * base class, its protocols, or its categories' protocols, that has the same
+ * selector and is of the same kind (class or instance).
+ * If no such method exists, the search continues to the class's superclass,
+ * its protocols, and its categories, and so on. A method from an Objective-C
+ * implementation is considered to override the same methods as its
+ * corresponding method in the interface.
+ *
+ * For C++, a virtual member function overrides any virtual member
+ * function with the same signature that occurs in its base
+ * classes. With multiple inheritance, a virtual member function can
+ * override several virtual member functions coming from different
+ * base classes.
+ *
+ * In all cases, this function determines the immediate overridden
+ * method, rather than all of the overridden methods. For example, if
+ * a method is originally declared in a class A, then overridden in B
+ * (which in inherits from A) and also in C (which inherited from B),
+ * then the only overridden method returned from this function when
+ * invoked on C's method will be B's method. The client may then
+ * invoke this function again, given the previously-found overridden
+ * methods, to map out the complete method-override set.
+ *
+ * \param cursor A cursor representing an Objective-C or C++
+ * method. This routine will compute the set of methods that this
+ * method overrides.
+ *
+ * \param overridden A pointer whose pointee will be replaced with a
+ * pointer to an array of cursors, representing the set of overridden
+ * methods. If there are no overridden methods, the pointee will be
+ * set to NULL. The pointee must be freed via a call to
+ * \c clang_disposeOverriddenCursors().
+ *
+ * \param num_overridden A pointer to the number of overridden
+ * functions, will be set to the number of overridden functions in the
+ * array pointed to by \p overridden.
+ */
+CINDEX_LINKAGE void clang_getOverriddenCursors(CXCursor cursor,
+                                               CXCursor **overridden,
+                                               unsigned *num_overridden);
+
+/**
+ * Free the set of overridden cursors returned by \c
+ * clang_getOverriddenCursors().
+ */
+CINDEX_LINKAGE void clang_disposeOverriddenCursors(CXCursor *overridden);
+
+/**
+ * Retrieve the file that is included by the given inclusion directive
+ * cursor.
+ */
+CINDEX_LINKAGE CXFile clang_getIncludedFile(CXCursor cursor);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_CURSOR_SOURCE Mapping between cursors and source code
+ *
+ * Cursors represent a location within the Abstract Syntax Tree (AST). These
+ * routines help map between cursors and the physical locations where the
+ * described entities occur in the source code. The mapping is provided in
+ * both directions, so one can map from source code to the AST and back.
+ *
+ * @{
+ */
+
+/**
+ * Map a source location to the cursor that describes the entity at that
+ * location in the source code.
+ *
+ * clang_getCursor() maps an arbitrary source location within a translation
+ * unit down to the most specific cursor that describes the entity at that
+ * location. For example, given an expression \c x + y, invoking
+ * clang_getCursor() with a source location pointing to "x" will return the
+ * cursor for "x"; similarly for "y". If the cursor points anywhere between
+ * "x" or "y" (e.g., on the + or the whitespace around it), clang_getCursor()
+ * will return a cursor referring to the "+" expression.
+ *
+ * \returns a cursor representing the entity at the given source location, or
+ * a NULL cursor if no such entity can be found.
+ */
+CINDEX_LINKAGE CXCursor clang_getCursor(CXTranslationUnit, CXSourceLocation);
+
+/**
+ * Retrieve the physical location of the source constructor referenced
+ * by the given cursor.
+ *
+ * The location of a declaration is typically the location of the name of that
+ * declaration, where the name of that declaration would occur if it is
+ * unnamed, or some keyword that introduces that particular declaration.
+ * The location of a reference is where that reference occurs within the
+ * source code.
+ */
+CINDEX_LINKAGE CXSourceLocation clang_getCursorLocation(CXCursor);
+
+/**
+ * Retrieve the physical extent of the source construct referenced by
+ * the given cursor.
+ *
+ * The extent of a cursor starts with the file/line/column pointing at the
+ * first character within the source construct that the cursor refers to and
+ * ends with the last character within that source construct. For a
+ * declaration, the extent covers the declaration itself. For a reference,
+ * the extent covers the location of the reference (e.g., where the referenced
+ * entity was actually used).
+ */
+CINDEX_LINKAGE CXSourceRange clang_getCursorExtent(CXCursor);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_TYPES Type information for CXCursors
+ *
+ * @{
+ */
+
+/**
+ * Describes the kind of type
+ */
+enum CXTypeKind {
+  /**
+   * Represents an invalid type (e.g., where no type is available).
+   */
+  CXType_Invalid = 0,
+
+  /**
+   * A type whose specific kind is not exposed via this
+   * interface.
+   */
+  CXType_Unexposed = 1,
+
+  /* Builtin types */
+  CXType_Void = 2,
+  CXType_Bool = 3,
+  CXType_Char_U = 4,
+  CXType_UChar = 5,
+  CXType_Char16 = 6,
+  CXType_Char32 = 7,
+  CXType_UShort = 8,
+  CXType_UInt = 9,
+  CXType_ULong = 10,
+  CXType_ULongLong = 11,
+  CXType_UInt128 = 12,
+  CXType_Char_S = 13,
+  CXType_SChar = 14,
+  CXType_WChar = 15,
+  CXType_Short = 16,
+  CXType_Int = 17,
+  CXType_Long = 18,
+  CXType_LongLong = 19,
+  CXType_Int128 = 20,
+  CXType_Float = 21,
+  CXType_Double = 22,
+  CXType_LongDouble = 23,
+  CXType_NullPtr = 24,
+  CXType_Overload = 25,
+  CXType_Dependent = 26,
+  CXType_ObjCId = 27,
+  CXType_ObjCClass = 28,
+  CXType_ObjCSel = 29,
+  CXType_Float128 = 30,
+  CXType_Half = 31,
+  CXType_Float16 = 32,
+  CXType_ShortAccum = 33,
+  CXType_Accum = 34,
+  CXType_LongAccum = 35,
+  CXType_UShortAccum = 36,
+  CXType_UAccum = 37,
+  CXType_ULongAccum = 38,
+  CXType_BFloat16 = 39,
+  CXType_Ibm128 = 40,
+  CXType_FirstBuiltin = CXType_Void,
+  CXType_LastBuiltin = CXType_Ibm128,
+
+  CXType_Complex = 100,
+  CXType_Pointer = 101,
+  CXType_BlockPointer = 102,
+  CXType_LValueReference = 103,
+  CXType_RValueReference = 104,
+  CXType_Record = 105,
+  CXType_Enum = 106,
+  CXType_Typedef = 107,
+  CXType_ObjCInterface = 108,
+  CXType_ObjCObjectPointer = 109,
+  CXType_FunctionNoProto = 110,
+  CXType_FunctionProto = 111,
+  CXType_ConstantArray = 112,
+  CXType_Vector = 113,
+  CXType_IncompleteArray = 114,
+  CXType_VariableArray = 115,
+  CXType_DependentSizedArray = 116,
+  CXType_MemberPointer = 117,
+  CXType_Auto = 118,
+
+  /**
+   * Represents a type that was referred to using an elaborated type keyword.
+   *
+   * E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+   */
+  CXType_Elaborated = 119,
+
+  /* OpenCL PipeType. */
+  CXType_Pipe = 120,
+
+  /* OpenCL builtin types. */
+  CXType_OCLImage1dRO = 121,
+  CXType_OCLImage1dArrayRO = 122,
+  CXType_OCLImage1dBufferRO = 123,
+  CXType_OCLImage2dRO = 124,
+  CXType_OCLImage2dArrayRO = 125,
+  CXType_OCLImage2dDepthRO = 126,
+  CXType_OCLImage2dArrayDepthRO = 127,
+  CXType_OCLImage2dMSAARO = 128,
+  CXType_OCLImage2dArrayMSAARO = 129,
+  CXType_OCLImage2dMSAADepthRO = 130,
+  CXType_OCLImage2dArrayMSAADepthRO = 131,
+  CXType_OCLImage3dRO = 132,
+  CXType_OCLImage1dWO = 133,
+  CXType_OCLImage1dArrayWO = 134,
+  CXType_OCLImage1dBufferWO = 135,
+  CXType_OCLImage2dWO = 136,
+  CXType_OCLImage2dArrayWO = 137,
+  CXType_OCLImage2dDepthWO = 138,
+  CXType_OCLImage2dArrayDepthWO = 139,
+  CXType_OCLImage2dMSAAWO = 140,
+  CXType_OCLImage2dArrayMSAAWO = 141,
+  CXType_OCLImage2dMSAADepthWO = 142,
+  CXType_OCLImage2dArrayMSAADepthWO = 143,
+  CXType_OCLImage3dWO = 144,
+  CXType_OCLImage1dRW = 145,
+  CXType_OCLImage1dArrayRW = 146,
+  CXType_OCLImage1dBufferRW = 147,
+  CXType_OCLImage2dRW = 148,
+  CXType_OCLImage2dArrayRW = 149,
+  CXType_OCLImage2dDepthRW = 150,
+  CXType_OCLImage2dArrayDepthRW = 151,
+  CXType_OCLImage2dMSAARW = 152,
+  CXType_OCLImage2dArrayMSAARW = 153,
+  CXType_OCLImage2dMSAADepthRW = 154,
+  CXType_OCLImage2dArrayMSAADepthRW = 155,
+  CXType_OCLImage3dRW = 156,
+  CXType_OCLSampler = 157,
+  CXType_OCLEvent = 158,
+  CXType_OCLQueue = 159,
+  CXType_OCLReserveID = 160,
+
+  CXType_ObjCObject = 161,
+  CXType_ObjCTypeParam = 162,
+  CXType_Attributed = 163,
+
+  CXType_OCLIntelSubgroupAVCMcePayload = 164,
+  CXType_OCLIntelSubgroupAVCImePayload = 165,
+  CXType_OCLIntelSubgroupAVCRefPayload = 166,
+  CXType_OCLIntelSubgroupAVCSicPayload = 167,
+  CXType_OCLIntelSubgroupAVCMceResult = 168,
+  CXType_OCLIntelSubgroupAVCImeResult = 169,
+  CXType_OCLIntelSubgroupAVCRefResult = 170,
+  CXType_OCLIntelSubgroupAVCSicResult = 171,
+  CXType_OCLIntelSubgroupAVCImeResultSingleReferenceStreamout = 172,
+  CXType_OCLIntelSubgroupAVCImeResultDualReferenceStreamout = 173,
+  CXType_OCLIntelSubgroupAVCImeSingleReferenceStreamin = 174,
+  CXType_OCLIntelSubgroupAVCImeDualReferenceStreamin = 175,
+
+  /* Old aliases for AVC OpenCL extension types. */
+  CXType_OCLIntelSubgroupAVCImeResultSingleRefStreamout = 172,
+  CXType_OCLIntelSubgroupAVCImeResultDualRefStreamout = 173,
+  CXType_OCLIntelSubgroupAVCImeSingleRefStreamin = 174,
+  CXType_OCLIntelSubgroupAVCImeDualRefStreamin = 175,
+
+  CXType_ExtVector = 176,
+  CXType_Atomic = 177,
+  CXType_BTFTagAttributed = 178,
+
+  /* HLSL Types */
+  CXType_HLSLResource = 179,
+  CXType_HLSLAttributedResource = 180,
+  CXType_HLSLInlineSpirv = 181
+};
+
+/**
+ * Describes the calling convention of a function type
+ */
+enum CXCallingConv {
+  CXCallingConv_Default = 0,
+  CXCallingConv_C = 1,
+  CXCallingConv_X86StdCall = 2,
+  CXCallingConv_X86FastCall = 3,
+  CXCallingConv_X86ThisCall = 4,
+  CXCallingConv_X86Pascal = 5,
+  CXCallingConv_AAPCS = 6,
+  CXCallingConv_AAPCS_VFP = 7,
+  CXCallingConv_X86RegCall = 8,
+  CXCallingConv_IntelOclBicc = 9,
+  CXCallingConv_Win64 = 10,
+  /* Alias for compatibility with older versions of API. */
+  CXCallingConv_X86_64Win64 = CXCallingConv_Win64,
+  CXCallingConv_X86_64SysV = 11,
+  CXCallingConv_X86VectorCall = 12,
+  CXCallingConv_Swift = 13,
+  CXCallingConv_PreserveMost = 14,
+  CXCallingConv_PreserveAll = 15,
+  CXCallingConv_AArch64VectorCall = 16,
+  CXCallingConv_SwiftAsync = 17,
+  CXCallingConv_AArch64SVEPCS = 18,
+  CXCallingConv_M68kRTD = 19,
+  CXCallingConv_PreserveNone = 20,
+  CXCallingConv_RISCVVectorCall = 21,
+  CXCallingConv_RISCVVLSCall_32 = 22,
+  CXCallingConv_RISCVVLSCall_64 = 23,
+  CXCallingConv_RISCVVLSCall_128 = 24,
+  CXCallingConv_RISCVVLSCall_256 = 25,
+  CXCallingConv_RISCVVLSCall_512 = 26,
+  CXCallingConv_RISCVVLSCall_1024 = 27,
+  CXCallingConv_RISCVVLSCall_2048 = 28,
+  CXCallingConv_RISCVVLSCall_4096 = 29,
+  CXCallingConv_RISCVVLSCall_8192 = 30,
+  CXCallingConv_RISCVVLSCall_16384 = 31,
+  CXCallingConv_RISCVVLSCall_32768 = 32,
+  CXCallingConv_RISCVVLSCall_65536 = 33,
+
+  CXCallingConv_Invalid = 100,
+  CXCallingConv_Unexposed = 200
+};
+
+/**
+ * The type of an element in the abstract syntax tree.
+ *
+ */
+typedef struct {
+  enum CXTypeKind kind;
+  void *data[2];
+} CXType;
+
+/**
+ * Retrieve the type of a CXCursor (if any).
+ */
+CINDEX_LINKAGE CXType clang_getCursorType(CXCursor C);
+
+/**
+ * Pretty-print the underlying type using the rules of the
+ * language of the translation unit from which it came.
+ *
+ * If the type is invalid, an empty string is returned.
+ */
+CINDEX_LINKAGE CXString clang_getTypeSpelling(CXType CT);
+
+/**
+ * Retrieve the underlying type of a typedef declaration.
+ *
+ * If the cursor does not reference a typedef declaration, an invalid type is
+ * returned.
+ */
+CINDEX_LINKAGE CXType clang_getTypedefDeclUnderlyingType(CXCursor C);
+
+/**
+ * Retrieve the integer type of an enum declaration.
+ *
+ * If the cursor does not reference an enum declaration, an invalid type is
+ * returned.
+ */
+CINDEX_LINKAGE CXType clang_getEnumDeclIntegerType(CXCursor C);
+
+/**
+ * Retrieve the integer value of an enum constant declaration as a signed
+ *  long long.
+ *
+ * If the cursor does not reference an enum constant declaration, LLONG_MIN is
+ * returned. Since this is also potentially a valid constant value, the kind of
+ * the cursor must be verified before calling this function.
+ */
+CINDEX_LINKAGE long long clang_getEnumConstantDeclValue(CXCursor C);
+
+/**
+ * Retrieve the integer value of an enum constant declaration as an unsigned
+ *  long long.
+ *
+ * If the cursor does not reference an enum constant declaration, ULLONG_MAX is
+ * returned. Since this is also potentially a valid constant value, the kind of
+ * the cursor must be verified before calling this function.
+ */
+CINDEX_LINKAGE unsigned long long
+clang_getEnumConstantDeclUnsignedValue(CXCursor C);
+
+/**
+ * Returns non-zero if the cursor specifies a Record member that is a bit-field.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isBitField(CXCursor C);
+
+/**
+ * Retrieve the bit width of a bit-field declaration as an integer.
+ *
+ * If the cursor does not reference a bit-field, or if the bit-field's width
+ * expression cannot be evaluated, -1 is returned.
+ *
+ * For example:
+ * \code
+ * if (clang_Cursor_isBitField(Cursor)) {
+ *   int Width = clang_getFieldDeclBitWidth(Cursor);
+ *   if (Width != -1) {
+ *     // The bit-field width is not value-dependent.
+ *   }
+ * }
+ * \endcode
+ */
+CINDEX_LINKAGE int clang_getFieldDeclBitWidth(CXCursor C);
+
+/**
+ * Retrieve the number of non-variadic arguments associated with a given
+ * cursor.
+ *
+ * The number of arguments can be determined for calls as well as for
+ * declarations of functions or methods. For other cursors -1 is returned.
+ */
+CINDEX_LINKAGE int clang_Cursor_getNumArguments(CXCursor C);
+
+/**
+ * Retrieve the argument cursor of a function or method.
+ *
+ * The argument cursor can be determined for calls as well as for declarations
+ * of functions or methods. For other cursors and for invalid indices, an
+ * invalid cursor is returned.
+ */
+CINDEX_LINKAGE CXCursor clang_Cursor_getArgument(CXCursor C, unsigned i);
+
+/**
+ * Describes the kind of a template argument.
+ *
+ * See the definition of llvm::clang::TemplateArgument::ArgKind for full
+ * element descriptions.
+ */
+enum CXTemplateArgumentKind {
+  CXTemplateArgumentKind_Null,
+  CXTemplateArgumentKind_Type,
+  CXTemplateArgumentKind_Declaration,
+  CXTemplateArgumentKind_NullPtr,
+  CXTemplateArgumentKind_Integral,
+  CXTemplateArgumentKind_Template,
+  CXTemplateArgumentKind_TemplateExpansion,
+  CXTemplateArgumentKind_Expression,
+  CXTemplateArgumentKind_Pack,
+  /* Indicates an error case, preventing the kind from being deduced. */
+  CXTemplateArgumentKind_Invalid
+};
+
+/**
+ * Returns the number of template args of a function, struct, or class decl
+ * representing a template specialization.
+ *
+ * If the argument cursor cannot be converted into a template function
+ * declaration, -1 is returned.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * The value 3 would be returned from this call.
+ */
+CINDEX_LINKAGE int clang_Cursor_getNumTemplateArguments(CXCursor C);
+
+/**
+ * Retrieve the kind of the I'th template argument of the CXCursor C.
+ *
+ * If the argument CXCursor does not represent a FunctionDecl, StructDecl, or
+ * ClassTemplatePartialSpecialization, an invalid template argument kind is
+ * returned.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * For I = 0, 1, and 2, Type, Integral, and Integral will be returned,
+ * respectively.
+ */
+CINDEX_LINKAGE enum CXTemplateArgumentKind
+clang_Cursor_getTemplateArgumentKind(CXCursor C, unsigned I);
+
+/**
+ * Retrieve a CXType representing the type of a TemplateArgument of a
+ *  function decl representing a template specialization.
+ *
+ * If the argument CXCursor does not represent a FunctionDecl, StructDecl,
+ * ClassDecl or ClassTemplatePartialSpecialization whose I'th template argument
+ * has a kind of CXTemplateArgKind_Integral, an invalid type is returned.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * If called with I = 0, "float", will be returned.
+ * Invalid types will be returned for I == 1 or 2.
+ */
+CINDEX_LINKAGE CXType clang_Cursor_getTemplateArgumentType(CXCursor C,
+                                                           unsigned I);
+
+/**
+ * Retrieve the value of an Integral TemplateArgument (of a function
+ *  decl representing a template specialization) as a signed long long.
+ *
+ * It is undefined to call this function on a CXCursor that does not represent a
+ * FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization
+ * whose I'th template argument is not an integral value.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * If called with I = 1 or 2, -7 or true will be returned, respectively.
+ * For I == 0, this function's behavior is undefined.
+ */
+CINDEX_LINKAGE long long clang_Cursor_getTemplateArgumentValue(CXCursor C,
+                                                               unsigned I);
+
+/**
+ * Retrieve the value of an Integral TemplateArgument (of a function
+ *  decl representing a template specialization) as an unsigned long long.
+ *
+ * It is undefined to call this function on a CXCursor that does not represent a
+ * FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization or
+ * whose I'th template argument is not an integral value.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, 2147483649, true>();
+ *
+ * If called with I = 1 or 2, 2147483649 or true will be returned, respectively.
+ * For I == 0, this function's behavior is undefined.
+ */
+CINDEX_LINKAGE unsigned long long
+clang_Cursor_getTemplateArgumentUnsignedValue(CXCursor C, unsigned I);
+
+/**
+ * Determine whether two CXTypes represent the same type.
+ *
+ * \returns non-zero if the CXTypes represent the same type and
+ *          zero otherwise.
+ */
+CINDEX_LINKAGE unsigned clang_equalTypes(CXType A, CXType B);
+
+/**
+ * Return the canonical type for a CXType.
+ *
+ * Clang's type system explicitly models typedefs and all the ways
+ * a specific type can be represented.  The canonical type is the underlying
+ * type with all the "sugar" removed.  For example, if 'T' is a typedef
+ * for 'int', the canonical type for 'T' would be 'int'.
+ */
+CINDEX_LINKAGE CXType clang_getCanonicalType(CXType T);
+
+/**
+ * Determine whether a CXType has the "const" qualifier set,
+ * without looking through typedefs that may have added "const" at a
+ * different level.
+ */
+CINDEX_LINKAGE unsigned clang_isConstQualifiedType(CXType T);
+
+/**
+ * Determine whether a  CXCursor that is a macro, is
+ * function like.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isMacroFunctionLike(CXCursor C);
+
+/**
+ * Determine whether a  CXCursor that is a macro, is a
+ * builtin one.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isMacroBuiltin(CXCursor C);
+
+/**
+ * Determine whether a  CXCursor that is a function declaration, is an
+ * inline declaration.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isFunctionInlined(CXCursor C);
+
+/**
+ * Determine whether a CXType has the "volatile" qualifier set,
+ * without looking through typedefs that may have added "volatile" at
+ * a different level.
+ */
+CINDEX_LINKAGE unsigned clang_isVolatileQualifiedType(CXType T);
+
+/**
+ * Determine whether a CXType has the "restrict" qualifier set,
+ * without looking through typedefs that may have added "restrict" at a
+ * different level.
+ */
+CINDEX_LINKAGE unsigned clang_isRestrictQualifiedType(CXType T);
+
+/**
+ * Returns the address space of the given type.
+ */
+CINDEX_LINKAGE unsigned clang_getAddressSpace(CXType T);
+
+/**
+ * Returns the typedef name of the given type.
+ */
+CINDEX_LINKAGE CXString clang_getTypedefName(CXType CT);
+
+/**
+ * For pointer types, returns the type of the pointee.
+ */
+CINDEX_LINKAGE CXType clang_getPointeeType(CXType T);
+
+/**
+ * Retrieve the unqualified variant of the given type, removing as
+ * little sugar as possible.
+ *
+ * For example, given the following series of typedefs:
+ *
+ * \code
+ * typedef int Integer;
+ * typedef const Integer CInteger;
+ * typedef CInteger DifferenceType;
+ * \endcode
+ *
+ * Executing \c clang_getUnqualifiedType() on a \c CXType that
+ * represents \c DifferenceType, will desugar to a type representing
+ * \c Integer, that has no qualifiers.
+ *
+ * And, executing \c clang_getUnqualifiedType() on the type of the
+ * first argument of the following function declaration:
+ *
+ * \code
+ * void foo(const int);
+ * \endcode
+ *
+ * Will return a type representing \c int, removing the \c const
+ * qualifier.
+ *
+ * Sugar over array types is not desugared.
+ *
+ * A type can be checked for qualifiers with \c
+ * clang_isConstQualifiedType(), \c clang_isVolatileQualifiedType()
+ * and \c clang_isRestrictQualifiedType().
+ *
+ * A type that resulted from a call to \c clang_getUnqualifiedType
+ * will return \c false for all of the above calls.
+ */
+CINDEX_LINKAGE CXType clang_getUnqualifiedType(CXType CT);
+
+/**
+ * For reference types (e.g., "const int&"), returns the type that the
+ * reference refers to (e.g "const int").
+ *
+ * Otherwise, returns the type itself.
+ *
+ * A type that has kind \c CXType_LValueReference or
+ * \c CXType_RValueReference is a reference type.
+ */
+CINDEX_LINKAGE CXType clang_getNonReferenceType(CXType CT);
+
+/**
+ * Return the cursor for the declaration of the given type.
+ */
+CINDEX_LINKAGE CXCursor clang_getTypeDeclaration(CXType T);
+
+/**
+ * Returns the Objective-C type encoding for the specified declaration.
+ */
+CINDEX_LINKAGE CXString clang_getDeclObjCTypeEncoding(CXCursor C);
+
+/**
+ * Returns the Objective-C type encoding for the specified CXType.
+ */
+CINDEX_LINKAGE CXString clang_Type_getObjCEncoding(CXType type);
+
+/**
+ * Retrieve the spelling of a given CXTypeKind.
+ */
+CINDEX_LINKAGE CXString clang_getTypeKindSpelling(enum CXTypeKind K);
+
+/**
+ * Retrieve the calling convention associated with a function type.
+ *
+ * If a non-function type is passed in, CXCallingConv_Invalid is returned.
+ */
+CINDEX_LINKAGE enum CXCallingConv clang_getFunctionTypeCallingConv(CXType T);
+
+/**
+ * Retrieve the return type associated with a function type.
+ *
+ * If a non-function type is passed in, an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_getResultType(CXType T);
+
+/**
+ * Retrieve the exception specification type associated with a function type.
+ * This is a value of type CXCursor_ExceptionSpecificationKind.
+ *
+ * If a non-function type is passed in, an error code of -1 is returned.
+ */
+CINDEX_LINKAGE int clang_getExceptionSpecificationType(CXType T);
+
+/**
+ * Retrieve the number of non-variadic parameters associated with a
+ * function type.
+ *
+ * If a non-function type is passed in, -1 is returned.
+ */
+CINDEX_LINKAGE int clang_getNumArgTypes(CXType T);
+
+/**
+ * Retrieve the type of a parameter of a function type.
+ *
+ * If a non-function type is passed in or the function does not have enough
+ * parameters, an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_getArgType(CXType T, unsigned i);
+
+/**
+ * Retrieves the base type of the ObjCObjectType.
+ *
+ * If the type is not an ObjC object, an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_Type_getObjCObjectBaseType(CXType T);
+
+/**
+ * Retrieve the number of protocol references associated with an ObjC object/id.
+ *
+ * If the type is not an ObjC object, 0 is returned.
+ */
+CINDEX_LINKAGE unsigned clang_Type_getNumObjCProtocolRefs(CXType T);
+
+/**
+ * Retrieve the decl for a protocol reference for an ObjC object/id.
+ *
+ * If the type is not an ObjC object or there are not enough protocol
+ * references, an invalid cursor is returned.
+ */
+CINDEX_LINKAGE CXCursor clang_Type_getObjCProtocolDecl(CXType T, unsigned i);
+
+/**
+ * Retrieve the number of type arguments associated with an ObjC object.
+ *
+ * If the type is not an ObjC object, 0 is returned.
+ */
+CINDEX_LINKAGE unsigned clang_Type_getNumObjCTypeArgs(CXType T);
+
+/**
+ * Retrieve a type argument associated with an ObjC object.
+ *
+ * If the type is not an ObjC or the index is not valid,
+ * an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_Type_getObjCTypeArg(CXType T, unsigned i);
+
+/**
+ * Return 1 if the CXType is a variadic function type, and 0 otherwise.
+ */
+CINDEX_LINKAGE unsigned clang_isFunctionTypeVariadic(CXType T);
+
+/**
+ * Retrieve the return type associated with a given cursor.
+ *
+ * This only returns a valid type if the cursor refers to a function or method.
+ */
+CINDEX_LINKAGE CXType clang_getCursorResultType(CXCursor C);
+
+/**
+ * Retrieve the exception specification type associated with a given cursor.
+ * This is a value of type CXCursor_ExceptionSpecificationKind.
+ *
+ * This only returns a valid result if the cursor refers to a function or
+ * method.
+ */
+CINDEX_LINKAGE int clang_getCursorExceptionSpecificationType(CXCursor C);
+
+/**
+ * Return 1 if the CXType is a POD (plain old data) type, and 0
+ *  otherwise.
+ */
+CINDEX_LINKAGE unsigned clang_isPODType(CXType T);
+
+/**
+ * Return the element type of an array, complex, or vector type.
+ *
+ * If a type is passed in that is not an array, complex, or vector type,
+ * an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_getElementType(CXType T);
+
+/**
+ * Return the number of elements of an array or vector type.
+ *
+ * If a type is passed in that is not an array or vector type,
+ * -1 is returned.
+ */
+CINDEX_LINKAGE long long clang_getNumElements(CXType T);
+
+/**
+ * Return the element type of an array type.
+ *
+ * If a non-array type is passed in, an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_getArrayElementType(CXType T);
+
+/**
+ * Return the array size of a constant array.
+ *
+ * If a non-array type is passed in, -1 is returned.
+ */
+CINDEX_LINKAGE long long clang_getArraySize(CXType T);
+
+/**
+ * Retrieve the type named by the qualified-id.
+ *
+ * If a non-elaborated type is passed in, an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_Type_getNamedType(CXType T);
+
+/**
+ * Determine if a typedef is 'transparent' tag.
+ *
+ * A typedef is considered 'transparent' if it shares a name and spelling
+ * location with its underlying tag type, as is the case with the NS_ENUM macro.
+ *
+ * \returns non-zero if transparent and zero otherwise.
+ */
+CINDEX_LINKAGE unsigned clang_Type_isTransparentTagTypedef(CXType T);
+
+enum CXTypeNullabilityKind {
+  /**
+   * Values of this type can never be null.
+   */
+  CXTypeNullability_NonNull = 0,
+  /**
+   * Values of this type can be null.
+   */
+  CXTypeNullability_Nullable = 1,
+  /**
+   * Whether values of this type can be null is (explicitly)
+   * unspecified. This captures a (fairly rare) case where we
+   * can't conclude anything about the nullability of the type even
+   * though it has been considered.
+   */
+  CXTypeNullability_Unspecified = 2,
+  /**
+   * Nullability is not applicable to this type.
+   */
+  CXTypeNullability_Invalid = 3,
+
+  /**
+   * Generally behaves like Nullable, except when used in a block parameter that
+   * was imported into a swift async method. There, swift will assume that the
+   * parameter can get null even if no error occurred. _Nullable parameters are
+   * assumed to only get null on error.
+   */
+  CXTypeNullability_NullableResult = 4
+};
+
+/**
+ * Retrieve the nullability kind of a pointer type.
+ */
+CINDEX_LINKAGE enum CXTypeNullabilityKind clang_Type_getNullability(CXType T);
+
+/**
+ * List the possible error codes for \c clang_Type_getSizeOf,
+ *   \c clang_Type_getAlignOf, \c clang_Type_getOffsetOf,
+ *   \c clang_Cursor_getOffsetOf, and \c clang_getOffsetOfBase.
+ *
+ * A value of this enumeration type can be returned if the target type is not
+ * a valid argument to sizeof, alignof or offsetof.
+ */
+enum CXTypeLayoutError {
+  /**
+   * Type is of kind CXType_Invalid.
+   */
+  CXTypeLayoutError_Invalid = -1,
+  /**
+   * The type is an incomplete Type.
+   */
+  CXTypeLayoutError_Incomplete = -2,
+  /**
+   * The type is a dependent Type.
+   */
+  CXTypeLayoutError_Dependent = -3,
+  /**
+   * The type is not a constant size type.
+   */
+  CXTypeLayoutError_NotConstantSize = -4,
+  /**
+   * The Field name is not valid for this record.
+   */
+  CXTypeLayoutError_InvalidFieldName = -5,
+  /**
+   * The type is undeduced.
+   */
+  CXTypeLayoutError_Undeduced = -6
+};
+
+/**
+ * Return the alignment of a type in bytes as per C++[expr.alignof]
+ *   standard.
+ *
+ * If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
+ * If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
+ *   is returned.
+ * If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
+ *   returned.
+ * If the type declaration is not a constant size type,
+ *   CXTypeLayoutError_NotConstantSize is returned.
+ */
+CINDEX_LINKAGE long long clang_Type_getAlignOf(CXType T);
+
+/**
+ * Return the class type of an member pointer type.
+ *
+ * If a non-member-pointer type is passed in, an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_Type_getClassType(CXType T);
+
+/**
+ * Return the size of a type in bytes as per C++[expr.sizeof] standard.
+ *
+ * If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
+ * If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
+ *   is returned.
+ * If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
+ *   returned.
+ */
+CINDEX_LINKAGE long long clang_Type_getSizeOf(CXType T);
+
+/**
+ * Return the offset of a field named S in a record of type T in bits
+ *   as it would be returned by __offsetof__ as per C++11[18.2p4]
+ *
+ * If the cursor is not a record field declaration, CXTypeLayoutError_Invalid
+ *   is returned.
+ * If the field's type declaration is an incomplete type,
+ *   CXTypeLayoutError_Incomplete is returned.
+ * If the field's type declaration is a dependent type,
+ *   CXTypeLayoutError_Dependent is returned.
+ * If the field's name S is not found,
+ *   CXTypeLayoutError_InvalidFieldName is returned.
+ */
+CINDEX_LINKAGE long long clang_Type_getOffsetOf(CXType T, const char *S);
+
+/**
+ * Return the type that was modified by this attributed type.
+ *
+ * If the type is not an attributed type, an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_Type_getModifiedType(CXType T);
+
+/**
+ * Gets the type contained by this atomic type.
+ *
+ * If a non-atomic type is passed in, an invalid type is returned.
+ */
+CINDEX_LINKAGE CXType clang_Type_getValueType(CXType CT);
+
+/**
+ * Return the offset of the field represented by the Cursor.
+ *
+ * If the cursor is not a field declaration, -1 is returned.
+ * If the cursor semantic parent is not a record field declaration,
+ *   CXTypeLayoutError_Invalid is returned.
+ * If the field's type declaration is an incomplete type,
+ *   CXTypeLayoutError_Incomplete is returned.
+ * If the field's type declaration is a dependent type,
+ *   CXTypeLayoutError_Dependent is returned.
+ * If the field's name S is not found,
+ *   CXTypeLayoutError_InvalidFieldName is returned.
+ */
+CINDEX_LINKAGE long long clang_Cursor_getOffsetOfField(CXCursor C);
+
+/**
+ * Determine whether the given cursor represents an anonymous
+ * tag or namespace
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isAnonymous(CXCursor C);
+
+/**
+ * Determine whether the given cursor represents an anonymous record
+ * declaration.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isAnonymousRecordDecl(CXCursor C);
+
+/**
+ * Determine whether the given cursor represents an inline namespace
+ * declaration.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isInlineNamespace(CXCursor C);
+
+enum CXRefQualifierKind {
+  /** No ref-qualifier was provided. */
+  CXRefQualifier_None = 0,
+  /** An lvalue ref-qualifier was provided (\c &). */
+  CXRefQualifier_LValue,
+  /** An rvalue ref-qualifier was provided (\c &&). */
+  CXRefQualifier_RValue
+};
+
+/**
+ * Returns the number of template arguments for given template
+ * specialization, or -1 if type \c T is not a template specialization.
+ */
+CINDEX_LINKAGE int clang_Type_getNumTemplateArguments(CXType T);
+
+/**
+ * Returns the type template argument of a template class specialization
+ * at given index.
+ *
+ * This function only returns template type arguments and does not handle
+ * template template arguments or variadic packs.
+ */
+CINDEX_LINKAGE CXType clang_Type_getTemplateArgumentAsType(CXType T,
+                                                           unsigned i);
+
+/**
+ * Retrieve the ref-qualifier kind of a function or method.
+ *
+ * The ref-qualifier is returned for C++ functions or methods. For other types
+ * or non-C++ declarations, CXRefQualifier_None is returned.
+ */
+CINDEX_LINKAGE enum CXRefQualifierKind clang_Type_getCXXRefQualifier(CXType T);
+
+/**
+ * Returns 1 if the base class specified by the cursor with kind
+ *   CX_CXXBaseSpecifier is virtual.
+ */
+CINDEX_LINKAGE unsigned clang_isVirtualBase(CXCursor);
+
+/**
+ * Returns the offset in bits of a CX_CXXBaseSpecifier relative to the parent
+ * class.
+ *
+ * Returns a small negative number if the offset cannot be computed. See
+ * CXTypeLayoutError for error codes.
+ */
+CINDEX_LINKAGE long long clang_getOffsetOfBase(CXCursor Parent, CXCursor Base);
+
+/**
+ * Represents the C++ access control level to a base class for a
+ * cursor with kind CX_CXXBaseSpecifier.
+ */
+enum CX_CXXAccessSpecifier {
+  CX_CXXInvalidAccessSpecifier,
+  CX_CXXPublic,
+  CX_CXXProtected,
+  CX_CXXPrivate
+};
+
+/**
+ * Returns the access control level for the referenced object.
+ *
+ * If the cursor refers to a C++ declaration, its access control level within
+ * its parent scope is returned. Otherwise, if the cursor refers to a base
+ * specifier or access specifier, the specifier itself is returned.
+ */
+CINDEX_LINKAGE enum CX_CXXAccessSpecifier clang_getCXXAccessSpecifier(CXCursor);
+
+/**
+ * Represents the storage classes as declared in the source. CX_SC_Invalid
+ * was added for the case that the passed cursor in not a declaration.
+ */
+enum CX_StorageClass {
+  CX_SC_Invalid,
+  CX_SC_None,
+  CX_SC_Extern,
+  CX_SC_Static,
+  CX_SC_PrivateExtern,
+  CX_SC_OpenCLWorkGroupLocal,
+  CX_SC_Auto,
+  CX_SC_Register
+};
+
+/**
+ * Represents a specific kind of binary operator which can appear at a cursor.
+ */
+enum CX_BinaryOperatorKind {
+  CX_BO_Invalid = 0,
+  CX_BO_PtrMemD = 1,
+  CX_BO_PtrMemI = 2,
+  CX_BO_Mul = 3,
+  CX_BO_Div = 4,
+  CX_BO_Rem = 5,
+  CX_BO_Add = 6,
+  CX_BO_Sub = 7,
+  CX_BO_Shl = 8,
+  CX_BO_Shr = 9,
+  CX_BO_Cmp = 10,
+  CX_BO_LT = 11,
+  CX_BO_GT = 12,
+  CX_BO_LE = 13,
+  CX_BO_GE = 14,
+  CX_BO_EQ = 15,
+  CX_BO_NE = 16,
+  CX_BO_And = 17,
+  CX_BO_Xor = 18,
+  CX_BO_Or = 19,
+  CX_BO_LAnd = 20,
+  CX_BO_LOr = 21,
+  CX_BO_Assign = 22,
+  CX_BO_MulAssign = 23,
+  CX_BO_DivAssign = 24,
+  CX_BO_RemAssign = 25,
+  CX_BO_AddAssign = 26,
+  CX_BO_SubAssign = 27,
+  CX_BO_ShlAssign = 28,
+  CX_BO_ShrAssign = 29,
+  CX_BO_AndAssign = 30,
+  CX_BO_XorAssign = 31,
+  CX_BO_OrAssign = 32,
+  CX_BO_Comma = 33,
+  CX_BO_LAST = CX_BO_Comma
+};
+
+/**
+ * \brief Returns the operator code for the binary operator.
+ *
+ * @deprecated: use clang_getCursorBinaryOperatorKind instead.
+ */
+CINDEX_LINKAGE enum CX_BinaryOperatorKind
+clang_Cursor_getBinaryOpcode(CXCursor C);
+
+/**
+ * \brief Returns a string containing the spelling of the binary operator.
+ *
+ * @deprecated: use clang_getBinaryOperatorKindSpelling instead
+ */
+CINDEX_LINKAGE CXString
+clang_Cursor_getBinaryOpcodeStr(enum CX_BinaryOperatorKind Op);
+
+/**
+ * Returns the storage class for a function or variable declaration.
+ *
+ * If the passed in Cursor is not a function or variable declaration,
+ * CX_SC_Invalid is returned else the storage class.
+ */
+CINDEX_LINKAGE enum CX_StorageClass clang_Cursor_getStorageClass(CXCursor);
+
+/**
+ * Determine the number of overloaded declarations referenced by a
+ * \c CXCursor_OverloadedDeclRef cursor.
+ *
+ * \param cursor The cursor whose overloaded declarations are being queried.
+ *
+ * \returns The number of overloaded declarations referenced by \c cursor. If it
+ * is not a \c CXCursor_OverloadedDeclRef cursor, returns 0.
+ */
+CINDEX_LINKAGE unsigned clang_getNumOverloadedDecls(CXCursor cursor);
+
+/**
+ * Retrieve a cursor for one of the overloaded declarations referenced
+ * by a \c CXCursor_OverloadedDeclRef cursor.
+ *
+ * \param cursor The cursor whose overloaded declarations are being queried.
+ *
+ * \param index The zero-based index into the set of overloaded declarations in
+ * the cursor.
+ *
+ * \returns A cursor representing the declaration referenced by the given
+ * \c cursor at the specified \c index. If the cursor does not have an
+ * associated set of overloaded declarations, or if the index is out of bounds,
+ * returns \c clang_getNullCursor();
+ */
+CINDEX_LINKAGE CXCursor clang_getOverloadedDecl(CXCursor cursor,
+                                                unsigned index);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_ATTRIBUTES Information for attributes
+ *
+ * @{
+ */
+
+/**
+ * For cursors representing an iboutletcollection attribute,
+ *  this function returns the collection element type.
+ *
+ */
+CINDEX_LINKAGE CXType clang_getIBOutletCollectionType(CXCursor);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_CURSOR_TRAVERSAL Traversing the AST with cursors
+ *
+ * These routines provide the ability to traverse the abstract syntax tree
+ * using cursors.
+ *
+ * @{
+ */
+
+/**
+ * Describes how the traversal of the children of a particular
+ * cursor should proceed after visiting a particular child cursor.
+ *
+ * A value of this enumeration type should be returned by each
+ * \c CXCursorVisitor to indicate how clang_visitChildren() proceed.
+ */
+enum CXChildVisitResult {
+  /**
+   * Terminates the cursor traversal.
+   */
+  CXChildVisit_Break,
+  /**
+   * Continues the cursor traversal with the next sibling of
+   * the cursor just visited, without visiting its children.
+   */
+  CXChildVisit_Continue,
+  /**
+   * Recursively traverse the children of this cursor, using
+   * the same visitor and client data.
+   */
+  CXChildVisit_Recurse
+};
+
+/**
+ * Visitor invoked for each cursor found by a traversal.
+ *
+ * This visitor function will be invoked for each cursor found by
+ * clang_visitCursorChildren(). Its first argument is the cursor being
+ * visited, its second argument is the parent visitor for that cursor,
+ * and its third argument is the client data provided to
+ * clang_visitCursorChildren().
+ *
+ * The visitor should return one of the \c CXChildVisitResult values
+ * to direct clang_visitCursorChildren().
+ */
+typedef enum CXChildVisitResult (*CXCursorVisitor)(CXCursor cursor,
+                                                   CXCursor parent,
+                                                   CXClientData client_data);
+
+/**
+ * Visit the children of a particular cursor.
+ *
+ * This function visits all the direct children of the given cursor,
+ * invoking the given \p visitor function with the cursors of each
+ * visited child. The traversal may be recursive, if the visitor returns
+ * \c CXChildVisit_Recurse. The traversal may also be ended prematurely, if
+ * the visitor returns \c CXChildVisit_Break.
+ *
+ * \param parent the cursor whose child may be visited. All kinds of
+ * cursors can be visited, including invalid cursors (which, by
+ * definition, have no children).
+ *
+ * \param visitor the visitor function that will be invoked for each
+ * child of \p parent.
+ *
+ * \param client_data pointer data supplied by the client, which will
+ * be passed to the visitor each time it is invoked.
+ *
+ * \returns a non-zero value if the traversal was terminated
+ * prematurely by the visitor returning \c CXChildVisit_Break.
+ */
+CINDEX_LINKAGE unsigned clang_visitChildren(CXCursor parent,
+                                            CXCursorVisitor visitor,
+                                            CXClientData client_data);
+/**
+ * Visitor invoked for each cursor found by a traversal.
+ *
+ * This visitor block will be invoked for each cursor found by
+ * clang_visitChildrenWithBlock(). Its first argument is the cursor being
+ * visited, its second argument is the parent visitor for that cursor.
+ *
+ * The visitor should return one of the \c CXChildVisitResult values
+ * to direct clang_visitChildrenWithBlock().
+ */
+#if __has_feature(blocks)
+typedef enum CXChildVisitResult (^CXCursorVisitorBlock)(CXCursor cursor,
+                                                        CXCursor parent);
+#else
+typedef struct _CXChildVisitResult *CXCursorVisitorBlock;
+#endif
+
+/**
+ * Visits the children of a cursor using the specified block.  Behaves
+ * identically to clang_visitChildren() in all other respects.
+ */
+CINDEX_LINKAGE unsigned
+clang_visitChildrenWithBlock(CXCursor parent, CXCursorVisitorBlock block);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_CURSOR_XREF Cross-referencing in the AST
+ *
+ * These routines provide the ability to determine references within and
+ * across translation units, by providing the names of the entities referenced
+ * by cursors, follow reference cursors to the declarations they reference,
+ * and associate declarations with their definitions.
+ *
+ * @{
+ */
+
+/**
+ * Retrieve a Unified Symbol Resolution (USR) for the entity referenced
+ * by the given cursor.
+ *
+ * A Unified Symbol Resolution (USR) is a string that identifies a particular
+ * entity (function, class, variable, etc.) within a program. USRs can be
+ * compared across translation units to determine, e.g., when references in
+ * one translation refer to an entity defined in another translation unit.
+ */
+CINDEX_LINKAGE CXString clang_getCursorUSR(CXCursor);
+
+/**
+ * Construct a USR for a specified Objective-C class.
+ */
+CINDEX_LINKAGE CXString clang_constructUSR_ObjCClass(const char *class_name);
+
+/**
+ * Construct a USR for a specified Objective-C category.
+ */
+CINDEX_LINKAGE CXString clang_constructUSR_ObjCCategory(
+    const char *class_name, const char *category_name);
+
+/**
+ * Construct a USR for a specified Objective-C protocol.
+ */
+CINDEX_LINKAGE CXString
+clang_constructUSR_ObjCProtocol(const char *protocol_name);
+
+/**
+ * Construct a USR for a specified Objective-C instance variable and
+ *   the USR for its containing class.
+ */
+CINDEX_LINKAGE CXString clang_constructUSR_ObjCIvar(const char *name,
+                                                    CXString classUSR);
+
+/**
+ * Construct a USR for a specified Objective-C method and
+ *   the USR for its containing class.
+ */
+CINDEX_LINKAGE CXString clang_constructUSR_ObjCMethod(const char *name,
+                                                      unsigned isInstanceMethod,
+                                                      CXString classUSR);
+
+/**
+ * Construct a USR for a specified Objective-C property and the USR
+ *  for its containing class.
+ */
+CINDEX_LINKAGE CXString clang_constructUSR_ObjCProperty(const char *property,
+                                                        CXString classUSR);
+
+/**
+ * Retrieve a name for the entity referenced by this cursor.
+ */
+CINDEX_LINKAGE CXString clang_getCursorSpelling(CXCursor);
+
+/**
+ * Retrieve a range for a piece that forms the cursors spelling name.
+ * Most of the times there is only one range for the complete spelling but for
+ * Objective-C methods and Objective-C message expressions, there are multiple
+ * pieces for each selector identifier.
+ *
+ * \param pieceIndex the index of the spelling name piece. If this is greater
+ * than the actual number of pieces, it will return a NULL (invalid) range.
+ *
+ * \param options Reserved.
+ */
+CINDEX_LINKAGE CXSourceRange clang_Cursor_getSpellingNameRange(
+    CXCursor, unsigned pieceIndex, unsigned options);
+
+/**
+ * Opaque pointer representing a policy that controls pretty printing
+ * for \c clang_getCursorPrettyPrinted.
+ */
+typedef void *CXPrintingPolicy;
+
+/**
+ * Properties for the printing policy.
+ *
+ * See \c clang::PrintingPolicy for more information.
+ */
+enum CXPrintingPolicyProperty {
+  CXPrintingPolicy_Indentation,
+  CXPrintingPolicy_SuppressSpecifiers,
+  CXPrintingPolicy_SuppressTagKeyword,
+  CXPrintingPolicy_IncludeTagDefinition,
+  CXPrintingPolicy_SuppressScope,
+  CXPrintingPolicy_SuppressUnwrittenScope,
+  CXPrintingPolicy_SuppressInitializers,
+  CXPrintingPolicy_ConstantArraySizeAsWritten,
+  CXPrintingPolicy_AnonymousTagLocations,
+  CXPrintingPolicy_SuppressStrongLifetime,
+  CXPrintingPolicy_SuppressLifetimeQualifiers,
+  CXPrintingPolicy_SuppressTemplateArgsInCXXConstructors,
+  CXPrintingPolicy_Bool,
+  CXPrintingPolicy_Restrict,
+  CXPrintingPolicy_Alignof,
+  CXPrintingPolicy_UnderscoreAlignof,
+  CXPrintingPolicy_UseVoidForZeroParams,
+  CXPrintingPolicy_TerseOutput,
+  CXPrintingPolicy_PolishForDeclaration,
+  CXPrintingPolicy_Half,
+  CXPrintingPolicy_MSWChar,
+  CXPrintingPolicy_IncludeNewlines,
+  CXPrintingPolicy_MSVCFormatting,
+  CXPrintingPolicy_ConstantsAsWritten,
+  CXPrintingPolicy_SuppressImplicitBase,
+  CXPrintingPolicy_FullyQualifiedName,
+
+  CXPrintingPolicy_LastProperty = CXPrintingPolicy_FullyQualifiedName
+};
+
+/**
+ * Get a property value for the given printing policy.
+ */
+CINDEX_LINKAGE unsigned
+clang_PrintingPolicy_getProperty(CXPrintingPolicy Policy,
+                                 enum CXPrintingPolicyProperty Property);
+
+/**
+ * Set a property value for the given printing policy.
+ */
+CINDEX_LINKAGE void
+clang_PrintingPolicy_setProperty(CXPrintingPolicy Policy,
+                                 enum CXPrintingPolicyProperty Property,
+                                 unsigned Value);
+
+/**
+ * Retrieve the default policy for the cursor.
+ *
+ * The policy should be released after use with \c
+ * clang_PrintingPolicy_dispose.
+ */
+CINDEX_LINKAGE CXPrintingPolicy clang_getCursorPrintingPolicy(CXCursor);
+
+/**
+ * Release a printing policy.
+ */
+CINDEX_LINKAGE void clang_PrintingPolicy_dispose(CXPrintingPolicy Policy);
+
+/**
+ * Pretty print declarations.
+ *
+ * \param Cursor The cursor representing a declaration.
+ *
+ * \param Policy The policy to control the entities being printed. If
+ * NULL, a default policy is used.
+ *
+ * \returns The pretty printed declaration or the empty string for
+ * other cursors.
+ */
+CINDEX_LINKAGE CXString clang_getCursorPrettyPrinted(CXCursor Cursor,
+                                                     CXPrintingPolicy Policy);
+
+/**
+ * Pretty-print the underlying type using a custom printing policy.
+ *
+ * If the type is invalid, an empty string is returned.
+ */
+CINDEX_LINKAGE CXString clang_getTypePrettyPrinted(CXType CT,
+                                                   CXPrintingPolicy cxPolicy);
+
+/**
+ * Get the fully qualified name for a type.
+ *
+ * This includes full qualification of all template parameters.
+ *
+ * Policy - Further refine the type formatting
+ * WithGlobalNsPrefix - If non-zero, function will prepend a '::' to qualified
+ * names
+ */
+CINDEX_LINKAGE CXString clang_getFullyQualifiedName(
+    CXType CT, CXPrintingPolicy Policy, unsigned WithGlobalNsPrefix);
+
+/**
+ * Retrieve the display name for the entity referenced by this cursor.
+ *
+ * The display name contains extra information that helps identify the cursor,
+ * such as the parameters of a function or template or the arguments of a
+ * class template specialization.
+ */
+CINDEX_LINKAGE CXString clang_getCursorDisplayName(CXCursor);
+
+/** For a cursor that is a reference, retrieve a cursor representing the
+ * entity that it references.
+ *
+ * Reference cursors refer to other entities in the AST. For example, an
+ * Objective-C superclass reference cursor refers to an Objective-C class.
+ * This function produces the cursor for the Objective-C class from the
+ * cursor for the superclass reference. If the input cursor is a declaration or
+ * definition, it returns that declaration or definition unchanged.
+ * Otherwise, returns the NULL cursor.
+ */
+CINDEX_LINKAGE CXCursor clang_getCursorReferenced(CXCursor);
+
+/**
+ *  For a cursor that is either a reference to or a declaration
+ *  of some entity, retrieve a cursor that describes the definition of
+ *  that entity.
+ *
+ *  Some entities can be declared multiple times within a translation
+ *  unit, but only one of those declarations can also be a
+ *  definition. For example, given:
+ *
+ *  \code
+ *  int f(int, int);
+ *  int g(int x, int y) { return f(x, y); }
+ *  int f(int a, int b) { return a + b; }
+ *  int f(int, int);
+ *  \endcode
+ *
+ *  there are three declarations of the function "f", but only the
+ *  second one is a definition. The clang_getCursorDefinition()
+ *  function will take any cursor pointing to a declaration of "f"
+ *  (the first or fourth lines of the example) or a cursor referenced
+ *  that uses "f" (the call to "f' inside "g") and will return a
+ *  declaration cursor pointing to the definition (the second "f"
+ *  declaration).
+ *
+ *  If given a cursor for which there is no corresponding definition,
+ *  e.g., because there is no definition of that entity within this
+ *  translation unit, returns a NULL cursor.
+ */
+CINDEX_LINKAGE CXCursor clang_getCursorDefinition(CXCursor);
+
+/**
+ * Determine whether the declaration pointed to by this cursor
+ * is also a definition of that entity.
+ */
+CINDEX_LINKAGE unsigned clang_isCursorDefinition(CXCursor);
+
+/**
+ * Retrieve the canonical cursor corresponding to the given cursor.
+ *
+ * In the C family of languages, many kinds of entities can be declared several
+ * times within a single translation unit. For example, a structure type can
+ * be forward-declared (possibly multiple times) and later defined:
+ *
+ * \code
+ * struct X;
+ * struct X;
+ * struct X {
+ *   int member;
+ * };
+ * \endcode
+ *
+ * The declarations and the definition of \c X are represented by three
+ * different cursors, all of which are declarations of the same underlying
+ * entity. One of these cursor is considered the "canonical" cursor, which
+ * is effectively the representative for the underlying entity. One can
+ * determine if two cursors are declarations of the same underlying entity by
+ * comparing their canonical cursors.
+ *
+ * \returns The canonical cursor for the entity referred to by the given cursor.
+ */
+CINDEX_LINKAGE CXCursor clang_getCanonicalCursor(CXCursor);
+
+/**
+ * If the cursor points to a selector identifier in an Objective-C
+ * method or message expression, this returns the selector index.
+ *
+ * After getting a cursor with #clang_getCursor, this can be called to
+ * determine if the location points to a selector identifier.
+ *
+ * \returns The selector index if the cursor is an Objective-C method or message
+ * expression and the cursor is pointing to a selector identifier, or -1
+ * otherwise.
+ */
+CINDEX_LINKAGE int clang_Cursor_getObjCSelectorIndex(CXCursor);
+
+/**
+ * Given a cursor pointing to a C++ method call or an Objective-C
+ * message, returns non-zero if the method/message is "dynamic", meaning:
+ *
+ * For a C++ method: the call is virtual.
+ * For an Objective-C message: the receiver is an object instance, not 'super'
+ * or a specific class.
+ *
+ * If the method/message is "static" or the cursor does not point to a
+ * method/message, it will return zero.
+ */
+CINDEX_LINKAGE int clang_Cursor_isDynamicCall(CXCursor C);
+
+/**
+ * Given a cursor pointing to an Objective-C message or property
+ * reference, or C++ method call, returns the CXType of the receiver.
+ */
+CINDEX_LINKAGE CXType clang_Cursor_getReceiverType(CXCursor C);
+
+/**
+ * Property attributes for a \c CXCursor_ObjCPropertyDecl.
+ */
+typedef enum {
+  CXObjCPropertyAttr_noattr = 0x00,
+  CXObjCPropertyAttr_readonly = 0x01,
+  CXObjCPropertyAttr_getter = 0x02,
+  CXObjCPropertyAttr_assign = 0x04,
+  CXObjCPropertyAttr_readwrite = 0x08,
+  CXObjCPropertyAttr_retain = 0x10,
+  CXObjCPropertyAttr_copy = 0x20,
+  CXObjCPropertyAttr_nonatomic = 0x40,
+  CXObjCPropertyAttr_setter = 0x80,
+  CXObjCPropertyAttr_atomic = 0x100,
+  CXObjCPropertyAttr_weak = 0x200,
+  CXObjCPropertyAttr_strong = 0x400,
+  CXObjCPropertyAttr_unsafe_unretained = 0x800,
+  CXObjCPropertyAttr_class = 0x1000
+} CXObjCPropertyAttrKind;
+
+/**
+ * Given a cursor that represents a property declaration, return the
+ * associated property attributes. The bits are formed from
+ * \c CXObjCPropertyAttrKind.
+ *
+ * \param reserved Reserved for future use, pass 0.
+ */
+CINDEX_LINKAGE unsigned
+clang_Cursor_getObjCPropertyAttributes(CXCursor C, unsigned reserved);
+
+/**
+ * Given a cursor that represents a property declaration, return the
+ * name of the method that implements the getter.
+ */
+CINDEX_LINKAGE CXString clang_Cursor_getObjCPropertyGetterName(CXCursor C);
+
+/**
+ * Given a cursor that represents a property declaration, return the
+ * name of the method that implements the setter, if any.
+ */
+CINDEX_LINKAGE CXString clang_Cursor_getObjCPropertySetterName(CXCursor C);
+
+/**
+ * 'Qualifiers' written next to the return and parameter types in
+ * Objective-C method declarations.
+ */
+typedef enum {
+  CXObjCDeclQualifier_None = 0x0,
+  CXObjCDeclQualifier_In = 0x1,
+  CXObjCDeclQualifier_Inout = 0x2,
+  CXObjCDeclQualifier_Out = 0x4,
+  CXObjCDeclQualifier_Bycopy = 0x8,
+  CXObjCDeclQualifier_Byref = 0x10,
+  CXObjCDeclQualifier_Oneway = 0x20
+} CXObjCDeclQualifierKind;
+
+/**
+ * Given a cursor that represents an Objective-C method or parameter
+ * declaration, return the associated Objective-C qualifiers for the return
+ * type or the parameter respectively. The bits are formed from
+ * CXObjCDeclQualifierKind.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_getObjCDeclQualifiers(CXCursor C);
+
+/**
+ * Given a cursor that represents an Objective-C method or property
+ * declaration, return non-zero if the declaration was affected by "\@optional".
+ * Returns zero if the cursor is not such a declaration or it is "\@required".
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isObjCOptional(CXCursor C);
+
+/**
+ * Returns non-zero if the given cursor is a variadic function or method.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isVariadic(CXCursor C);
+
+/**
+ * Returns non-zero if the given cursor points to a symbol marked with
+ * external_source_symbol attribute.
+ *
+ * \param language If non-NULL, and the attribute is present, will be set to
+ * the 'language' string from the attribute.
+ *
+ * \param definedIn If non-NULL, and the attribute is present, will be set to
+ * the 'definedIn' string from the attribute.
+ *
+ * \param isGenerated If non-NULL, and the attribute is present, will be set to
+ * non-zero if the 'generated_declaration' is set in the attribute.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isExternalSymbol(CXCursor C,
+                                                      CXString *language,
+                                                      CXString *definedIn,
+                                                      unsigned *isGenerated);
+
+/**
+ * Given a cursor that represents a declaration, return the associated
+ * comment's source range.  The range may include multiple consecutive comments
+ * with whitespace in between.
+ */
+CINDEX_LINKAGE CXSourceRange clang_Cursor_getCommentRange(CXCursor C);
+
+/**
+ * Given a cursor that represents a declaration, return the associated
+ * comment text, including comment markers.
+ */
+CINDEX_LINKAGE CXString clang_Cursor_getRawCommentText(CXCursor C);
+
+/**
+ * Given a cursor that represents a documentable entity (e.g.,
+ * declaration), return the associated \paragraph; otherwise return the
+ * first paragraph.
+ */
+CINDEX_LINKAGE CXString clang_Cursor_getBriefCommentText(CXCursor C);
+
+/**
+ * @}
+ */
+
+/** \defgroup CINDEX_MANGLE Name Mangling API Functions
+ *
+ * @{
+ */
+
+/**
+ * Retrieve the CXString representing the mangled name of the cursor.
+ */
+CINDEX_LINKAGE CXString clang_Cursor_getMangling(CXCursor);
+
+/**
+ * Retrieve the CXStrings representing the mangled symbols of the C++
+ * constructor or destructor at the cursor.
+ */
+CINDEX_LINKAGE CXStringSet *clang_Cursor_getCXXManglings(CXCursor);
+
+/**
+ * Retrieve the CXStrings representing the mangled symbols of the ObjC
+ * class interface or implementation at the cursor.
+ */
+CINDEX_LINKAGE CXStringSet *clang_Cursor_getObjCManglings(CXCursor);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_MODULE Inline Assembly introspection
+ *
+ * The functions in this group provide access to information about GCC-style
+ * inline assembly statements.
+ *
+ * @{
+ */
+
+/**
+ * Given a CXCursor_GCCAsmStmt cursor, return the assembly template string.
+ * As per LLVM IR Assembly Template language, template placeholders for
+ * inputs and outputs are either of the form $N where N is a decimal number
+ * as an index into the input-output specification,
+ * or ${N:M} where N is a decimal number also as an index into the
+ * input-output specification and M is the template argument modifier.
+ * The index N in both cases points into the the total inputs and outputs,
+ * or more specifically, into the list of outputs followed by the inputs,
+ * starting from index 0 as the first available template argument.
+ *
+ * This function also returns a valid empty string if the cursor does not point
+ * at a GCC inline assembly block.
+ *
+ * Users are responsible for releasing the allocation of returned string via
+ * \c clang_disposeString.
+ */
+
+CINDEX_LINKAGE CXString clang_Cursor_getGCCAssemblyTemplate(CXCursor);
+
+/**
+ * Given a CXCursor_GCCAsmStmt cursor, check if the assembly block has goto
+ * labels.
+ * This function also returns 0 if the cursor does not point at a GCC inline
+ * assembly block.
+ */
+
+CINDEX_LINKAGE unsigned clang_Cursor_isGCCAssemblyHasGoto(CXCursor);
+
+/**
+ * Given a CXCursor_GCCAsmStmt cursor, count the number of outputs.
+ * This function also returns 0 if the cursor does not point at a GCC inline
+ * assembly block.
+ */
+
+CINDEX_LINKAGE unsigned clang_Cursor_getGCCAssemblyNumOutputs(CXCursor);
+
+/**
+ * Given a CXCursor_GCCAsmStmt cursor, count the number of inputs.
+ * This function also returns 0 if the cursor does not point at a GCC inline
+ * assembly block.
+ */
+
+CINDEX_LINKAGE unsigned clang_Cursor_getGCCAssemblyNumInputs(CXCursor);
+
+/**
+ * Given a CXCursor_GCCAsmStmt cursor, get the constraint and expression cursor
+ * to the Index-th input.
+ * This function returns 1 when the cursor points at a GCC inline assembly
+ * statement, `Index` is within bounds and both the `Constraint` and `Expr` are
+ * not NULL.
+ * Otherwise, this function returns 0 but leaves `Constraint` and `Expr`
+ * intact.
+ *
+ * Users are responsible for releasing the allocation of `Constraint` via
+ * \c clang_disposeString.
+ */
+
+CINDEX_LINKAGE unsigned clang_Cursor_getGCCAssemblyInput(CXCursor Cursor,
+                                                         unsigned Index,
+                                                         CXString *Constraint,
+                                                         CXCursor *Expr);
+
+/**
+ * Given a CXCursor_GCCAsmStmt cursor, get the constraint and expression cursor
+ * to the Index-th output.
+ * This function returns 1 when the cursor points at a GCC inline assembly
+ * statement, `Index` is within bounds and both the `Constraint` and `Expr` are
+ * not NULL.
+ * Otherwise, this function returns 0 but leaves `Constraint` and `Expr`
+ * intact.
+ *
+ * Users are responsible for releasing the allocation of `Constraint` via
+ * \c clang_disposeString.
+ */
+
+CINDEX_LINKAGE unsigned clang_Cursor_getGCCAssemblyOutput(CXCursor Cursor,
+                                                          unsigned Index,
+                                                          CXString *Constraint,
+                                                          CXCursor *Expr);
+
+/**
+ * Given a CXCursor_GCCAsmStmt cursor, count the clobbers in it.
+ * This function also returns 0 if the cursor does not point at a GCC inline
+ * assembly block.
+ */
+
+CINDEX_LINKAGE unsigned clang_Cursor_getGCCAssemblyNumClobbers(CXCursor Cursor);
+
+/**
+ * Given a CXCursor_GCCAsmStmt cursor, get the Index-th clobber of it.
+ * This function returns a valid empty string if the cursor does not point
+ * at a GCC inline assembly block or `Index` is out of bounds.
+ *
+ * Users are responsible for releasing the allocation of returned string via
+ * \c clang_disposeString.
+ */
+
+CINDEX_LINKAGE CXString clang_Cursor_getGCCAssemblyClobber(CXCursor Cursor,
+                                                           unsigned Index);
+
+/**
+ * Given a CXCursor_GCCAsmStmt cursor, check if the inline assembly is
+ * `volatile`.
+ * This function returns 0 if the cursor does not point at a GCC inline
+ * assembly block.
+ */
+
+CINDEX_LINKAGE unsigned clang_Cursor_isGCCAssemblyVolatile(CXCursor Cursor);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_MODULE Module introspection
+ *
+ * The functions in this group provide access to information about modules.
+ *
+ * @{
+ */
+
+typedef void *CXModule;
+
+/**
+ * Given a CXCursor_ModuleImportDecl cursor, return the associated module.
+ */
+CINDEX_LINKAGE CXModule clang_Cursor_getModule(CXCursor C);
+
+/**
+ * Given a CXFile header file, return the module that contains it, if one
+ * exists.
+ */
+CINDEX_LINKAGE CXModule clang_getModuleForFile(CXTranslationUnit, CXFile);
+
+/**
+ * \param Module a module object.
+ *
+ * \returns the module file where the provided module object came from.
+ */
+CINDEX_LINKAGE CXFile clang_Module_getASTFile(CXModule Module);
+
+/**
+ * \param Module a module object.
+ *
+ * \returns the parent of a sub-module or NULL if the given module is top-level,
+ * e.g. for 'std.vector' it will return the 'std' module.
+ */
+CINDEX_LINKAGE CXModule clang_Module_getParent(CXModule Module);
+
+/**
+ * \param Module a module object.
+ *
+ * \returns the name of the module, e.g. for the 'std.vector' sub-module it
+ * will return "vector".
+ */
+CINDEX_LINKAGE CXString clang_Module_getName(CXModule Module);
+
+/**
+ * \param Module a module object.
+ *
+ * \returns the full name of the module, e.g. "std.vector".
+ */
+CINDEX_LINKAGE CXString clang_Module_getFullName(CXModule Module);
+
+/**
+ * \param Module a module object.
+ *
+ * \returns non-zero if the module is a system one.
+ */
+CINDEX_LINKAGE int clang_Module_isSystem(CXModule Module);
+
+/**
+ * \param Module a module object.
+ *
+ * \returns the number of top level headers associated with this module.
+ */
+CINDEX_LINKAGE unsigned clang_Module_getNumTopLevelHeaders(CXTranslationUnit,
+                                                           CXModule Module);
+
+/**
+ * \param Module a module object.
+ *
+ * \param Index top level header index (zero-based).
+ *
+ * \returns the specified top level header associated with the module.
+ */
+CINDEX_LINKAGE
+CXFile clang_Module_getTopLevelHeader(CXTranslationUnit, CXModule Module,
+                                      unsigned Index);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_CPP C++ AST introspection
+ *
+ * The routines in this group provide access information in the ASTs specific
+ * to C++ language features.
+ *
+ * @{
+ */
+
+/**
+ * Determine if a C++ constructor is a converting constructor.
+ */
+CINDEX_LINKAGE unsigned
+clang_CXXConstructor_isConvertingConstructor(CXCursor C);
+
+/**
+ * Determine if a C++ constructor is a copy constructor.
+ */
+CINDEX_LINKAGE unsigned clang_CXXConstructor_isCopyConstructor(CXCursor C);
+
+/**
+ * Determine if a C++ constructor is the default constructor.
+ */
+CINDEX_LINKAGE unsigned clang_CXXConstructor_isDefaultConstructor(CXCursor C);
+
+/**
+ * Determine if a C++ constructor is a move constructor.
+ */
+CINDEX_LINKAGE unsigned clang_CXXConstructor_isMoveConstructor(CXCursor C);
+
+/**
+ * Determine if a C++ field is declared 'mutable'.
+ */
+CINDEX_LINKAGE unsigned clang_CXXField_isMutable(CXCursor C);
+
+/**
+ * Determine if a C++ method is declared '= default'.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isDefaulted(CXCursor C);
+
+/**
+ * Determine if a C++ method is declared '= delete'.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isDeleted(CXCursor C);
+
+/**
+ * Determine if a C++ member function or member function template is
+ * pure virtual.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isPureVirtual(CXCursor C);
+
+/**
+ * Determine if a C++ member function or member function template is
+ * declared 'static'.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isStatic(CXCursor C);
+
+/**
+ * Determine if a C++ member function or member function template is
+ * explicitly declared 'virtual' or if it overrides a virtual method from
+ * one of the base classes.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isVirtual(CXCursor C);
+
+/**
+ * Determine if a C++ member function is a copy-assignment operator,
+ * returning 1 if such is the case and 0 otherwise.
+ *
+ * > A copy-assignment operator `X::operator=` is a non-static,
+ * > non-template member function of _class_ `X` with exactly one
+ * > parameter of type `X`, `X&`, `const X&`, `volatile X&` or `const
+ * > volatile X&`.
+ *
+ * That is, for example, the `operator=` in:
+ *
+ *    class Foo {
+ *        bool operator=(const volatile Foo&);
+ *    };
+ *
+ * Is a copy-assignment operator, while the `operator=` in:
+ *
+ *    class Bar {
+ *        bool operator=(const int&);
+ *    };
+ *
+ * Is not.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isCopyAssignmentOperator(CXCursor C);
+
+/**
+ * Determine if a C++ member function is a move-assignment operator,
+ * returning 1 if such is the case and 0 otherwise.
+ *
+ * > A move-assignment operator `X::operator=` is a non-static,
+ * > non-template member function of _class_ `X` with exactly one
+ * > parameter of type `X&&`, `const X&&`, `volatile X&&` or `const
+ * > volatile X&&`.
+ *
+ * That is, for example, the `operator=` in:
+ *
+ *    class Foo {
+ *        bool operator=(const volatile Foo&&);
+ *    };
+ *
+ * Is a move-assignment operator, while the `operator=` in:
+ *
+ *    class Bar {
+ *        bool operator=(const int&&);
+ *    };
+ *
+ * Is not.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isMoveAssignmentOperator(CXCursor C);
+
+/**
+ * Determines if a C++ constructor or conversion function was declared
+ * explicit, returning 1 if such is the case and 0 otherwise.
+ *
+ * Constructors or conversion functions are declared explicit through
+ * the use of the explicit specifier.
+ *
+ * For example, the following constructor and conversion function are
+ * not explicit as they lack the explicit specifier:
+ *
+ *     class Foo {
+ *         Foo();
+ *         operator int();
+ *     };
+ *
+ * While the following constructor and conversion function are
+ * explicit as they are declared with the explicit specifier.
+ *
+ *     class Foo {
+ *         explicit Foo();
+ *         explicit operator int();
+ *     };
+ *
+ * This function will return 0 when given a cursor pointing to one of
+ * the former declarations and it will return 1 for a cursor pointing
+ * to the latter declarations.
+ *
+ * The explicit specifier allows the user to specify a
+ * conditional compile-time expression whose value decides
+ * whether the marked element is explicit or not.
+ *
+ * For example:
+ *
+ *     constexpr bool foo(int i) { return i % 2 == 0; }
+ *
+ *     class Foo {
+ *          explicit(foo(1)) Foo();
+ *          explicit(foo(2)) operator int();
+ *     }
+ *
+ * This function will return 0 for the constructor and 1 for
+ * the conversion function.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isExplicit(CXCursor C);
+
+/**
+ * Determine if a C++ record is abstract, i.e. whether a class or struct
+ * has a pure virtual member function.
+ */
+CINDEX_LINKAGE unsigned clang_CXXRecord_isAbstract(CXCursor C);
+
+/**
+ * Determine if an enum declaration refers to a scoped enum.
+ */
+CINDEX_LINKAGE unsigned clang_EnumDecl_isScoped(CXCursor C);
+
+/**
+ * Determine if a C++ member function or member function template is
+ * declared 'const'.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isConst(CXCursor C);
+
+/**
+ * Given a cursor that represents a template, determine
+ * the cursor kind of the specializations would be generated by instantiating
+ * the template.
+ *
+ * This routine can be used to determine what flavor of function template,
+ * class template, or class template partial specialization is stored in the
+ * cursor. For example, it can describe whether a class template cursor is
+ * declared with "struct", "class" or "union".
+ *
+ * \param C The cursor to query. This cursor should represent a template
+ * declaration.
+ *
+ * \returns The cursor kind of the specializations that would be generated
+ * by instantiating the template \p C. If \p C is not a template, returns
+ * \c CXCursor_NoDeclFound.
+ */
+CINDEX_LINKAGE enum CXCursorKind clang_getTemplateCursorKind(CXCursor C);
+
+/**
+ * Given a cursor that may represent a specialization or instantiation
+ * of a template, retrieve the cursor that represents the template that it
+ * specializes or from which it was instantiated.
+ *
+ * This routine determines the template involved both for explicit
+ * specializations of templates and for implicit instantiations of the template,
+ * both of which are referred to as "specializations". For a class template
+ * specialization (e.g., \c std::vector<bool>), this routine will return
+ * either the primary template (\c std::vector) or, if the specialization was
+ * instantiated from a class template partial specialization, the class template
+ * partial specialization. For a class template partial specialization and a
+ * function template specialization (including instantiations), this
+ * this routine will return the specialized template.
+ *
+ * For members of a class template (e.g., member functions, member classes, or
+ * static data members), returns the specialized or instantiated member.
+ * Although not strictly "templates" in the C++ language, members of class
+ * templates have the same notions of specializations and instantiations that
+ * templates do, so this routine treats them similarly.
+ *
+ * \param C A cursor that may be a specialization of a template or a member
+ * of a template.
+ *
+ * \returns If the given cursor is a specialization or instantiation of a
+ * template or a member thereof, the template or member that it specializes or
+ * from which it was instantiated. Otherwise, returns a NULL cursor.
+ */
+CINDEX_LINKAGE CXCursor clang_getSpecializedCursorTemplate(CXCursor C);
+
+/**
+ * Given a cursor that references something else, return the source range
+ * covering that reference.
+ *
+ * \param C A cursor pointing to a member reference, a declaration reference, or
+ * an operator call.
+ * \param NameFlags A bitset with three independent flags:
+ * CXNameRange_WantQualifier, CXNameRange_WantTemplateArgs, and
+ * CXNameRange_WantSinglePiece.
+ * \param PieceIndex For contiguous names or when passing the flag
+ * CXNameRange_WantSinglePiece, only one piece with index 0 is
+ * available. When the CXNameRange_WantSinglePiece flag is not passed for a
+ * non-contiguous names, this index can be used to retrieve the individual
+ * pieces of the name. See also CXNameRange_WantSinglePiece.
+ *
+ * \returns The piece of the name pointed to by the given cursor. If there is no
+ * name, or if the PieceIndex is out-of-range, a null-cursor will be returned.
+ */
+CINDEX_LINKAGE CXSourceRange clang_getCursorReferenceNameRange(
+    CXCursor C, unsigned NameFlags, unsigned PieceIndex);
+
+enum CXNameRefFlags {
+  /**
+   * Include the nested-name-specifier, e.g. Foo:: in x.Foo::y, in the
+   * range.
+   */
+  CXNameRange_WantQualifier = 0x1,
+
+  /**
+   * Include the explicit template arguments, e.g. \<int> in x.f<int>,
+   * in the range.
+   */
+  CXNameRange_WantTemplateArgs = 0x2,
+
+  /**
+   * If the name is non-contiguous, return the full spanning range.
+   *
+   * Non-contiguous names occur in Objective-C when a selector with two or more
+   * parameters is used, or in C++ when using an operator:
+   * \code
+   * [object doSomething:here withValue:there]; // Objective-C
+   * return some_vector[1]; // C++
+   * \endcode
+   */
+  CXNameRange_WantSinglePiece = 0x4
+};
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_LEX Token extraction and manipulation
+ *
+ * The routines in this group provide access to the tokens within a
+ * translation unit, along with a semantic mapping of those tokens to
+ * their corresponding cursors.
+ *
+ * @{
+ */
+
+/**
+ * Describes a kind of token.
+ */
+typedef enum CXTokenKind {
+  /**
+   * A token that contains some kind of punctuation.
+   */
+  CXToken_Punctuation,
+
+  /**
+   * A language keyword.
+   */
+  CXToken_Keyword,
+
+  /**
+   * An identifier (that is not a keyword).
+   */
+  CXToken_Identifier,
+
+  /**
+   * A numeric, string, or character literal.
+   */
+  CXToken_Literal,
+
+  /**
+   * A comment.
+   */
+  CXToken_Comment
+} CXTokenKind;
+
+/**
+ * Describes a single preprocessing token.
+ */
+typedef struct {
+  unsigned int_data[4];
+  void *ptr_data;
+} CXToken;
+
+/**
+ * Get the raw lexical token starting with the given location.
+ *
+ * \param TU the translation unit whose text is being tokenized.
+ *
+ * \param Location the source location with which the token starts.
+ *
+ * \returns The token starting with the given location or NULL if no such token
+ * exist. The returned pointer must be freed with clang_disposeTokens before the
+ * translation unit is destroyed.
+ */
+CINDEX_LINKAGE CXToken *clang_getToken(CXTranslationUnit TU,
+                                       CXSourceLocation Location);
+
+/**
+ * Determine the kind of the given token.
+ */
+CINDEX_LINKAGE CXTokenKind clang_getTokenKind(CXToken);
+
+/**
+ * Determine the spelling of the given token.
+ *
+ * The spelling of a token is the textual representation of that token, e.g.,
+ * the text of an identifier or keyword.
+ */
+CINDEX_LINKAGE CXString clang_getTokenSpelling(CXTranslationUnit, CXToken);
+
+/**
+ * Retrieve the source location of the given token.
+ */
+CINDEX_LINKAGE CXSourceLocation clang_getTokenLocation(CXTranslationUnit,
+                                                       CXToken);
+
+/**
+ * Retrieve a source range that covers the given token.
+ */
+CINDEX_LINKAGE CXSourceRange clang_getTokenExtent(CXTranslationUnit, CXToken);
+
+/**
+ * Tokenize the source code described by the given range into raw
+ * lexical tokens.
+ *
+ * \param TU the translation unit whose text is being tokenized.
+ *
+ * \param Range the source range in which text should be tokenized. All of the
+ * tokens produced by tokenization will fall within this source range,
+ *
+ * \param Tokens this pointer will be set to point to the array of tokens
+ * that occur within the given source range. The returned pointer must be
+ * freed with clang_disposeTokens() before the translation unit is destroyed.
+ *
+ * \param NumTokens will be set to the number of tokens in the \c *Tokens
+ * array.
+ *
+ */
+CINDEX_LINKAGE void clang_tokenize(CXTranslationUnit TU, CXSourceRange Range,
+                                   CXToken **Tokens, unsigned *NumTokens);
+
+/**
+ * Annotate the given set of tokens by providing cursors for each token
+ * that can be mapped to a specific entity within the abstract syntax tree.
+ *
+ * This token-annotation routine is equivalent to invoking
+ * clang_getCursor() for the source locations of each of the
+ * tokens. The cursors provided are filtered, so that only those
+ * cursors that have a direct correspondence to the token are
+ * accepted. For example, given a function call \c f(x),
+ * clang_getCursor() would provide the following cursors:
+ *
+ *   * when the cursor is over the 'f', a DeclRefExpr cursor referring to 'f'.
+ *   * when the cursor is over the '(' or the ')', a CallExpr referring to 'f'.
+ *   * when the cursor is over the 'x', a DeclRefExpr cursor referring to 'x'.
+ *
+ * Only the first and last of these cursors will occur within the
+ * annotate, since the tokens "f" and "x' directly refer to a function
+ * and a variable, respectively, but the parentheses are just a small
+ * part of the full syntax of the function call expression, which is
+ * not provided as an annotation.
+ *
+ * \param TU the translation unit that owns the given tokens.
+ *
+ * \param Tokens the set of tokens to annotate.
+ *
+ * \param NumTokens the number of tokens in \p Tokens.
+ *
+ * \param Cursors an array of \p NumTokens cursors, whose contents will be
+ * replaced with the cursors corresponding to each token.
+ */
+CINDEX_LINKAGE void clang_annotateTokens(CXTranslationUnit TU, CXToken *Tokens,
+                                         unsigned NumTokens, CXCursor *Cursors);
+
+/**
+ * Free the given set of tokens.
+ */
+CINDEX_LINKAGE void clang_disposeTokens(CXTranslationUnit TU, CXToken *Tokens,
+                                        unsigned NumTokens);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_DEBUG Debugging facilities
+ *
+ * These routines are used for testing and debugging, only, and should not
+ * be relied upon.
+ *
+ * @{
+ */
+
+/* for debug/testing */
+CINDEX_LINKAGE CXString clang_getCursorKindSpelling(enum CXCursorKind Kind);
+CINDEX_LINKAGE void clang_getDefinitionSpellingAndExtent(
+    CXCursor, const char **startBuf, const char **endBuf, unsigned *startLine,
+    unsigned *startColumn, unsigned *endLine, unsigned *endColumn);
+CINDEX_LINKAGE void clang_enableStackTraces(void);
+CINDEX_LINKAGE void clang_executeOnThread(void (*fn)(void *), void *user_data,
+                                          unsigned stack_size);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_CODE_COMPLET Code completion
+ *
+ * Code completion involves taking an (incomplete) source file, along with
+ * knowledge of where the user is actively editing that file, and suggesting
+ * syntactically- and semantically-valid constructs that the user might want to
+ * use at that particular point in the source code. These data structures and
+ * routines provide support for code completion.
+ *
+ * @{
+ */
+
+/**
+ * A semantic string that describes a code-completion result.
+ *
+ * A semantic string that describes the formatting of a code-completion
+ * result as a single "template" of text that should be inserted into the
+ * source buffer when a particular code-completion result is selected.
+ * Each semantic string is made up of some number of "chunks", each of which
+ * contains some text along with a description of what that text means, e.g.,
+ * the name of the entity being referenced, whether the text chunk is part of
+ * the template, or whether it is a "placeholder" that the user should replace
+ * with actual code,of a specific kind. See \c CXCompletionChunkKind for a
+ * description of the different kinds of chunks.
+ */
+typedef void *CXCompletionString;
+
+/**
+ * A single result of code completion.
+ */
+typedef struct {
+  /**
+   * The kind of entity that this completion refers to.
+   *
+   * The cursor kind will be a macro, keyword, or a declaration (one of the
+   * *Decl cursor kinds), describing the entity that the completion is
+   * referring to.
+   *
+   * \todo In the future, we would like to provide a full cursor, to allow
+   * the client to extract additional information from declaration.
+   */
+  enum CXCursorKind CursorKind;
+
+  /**
+   * The code-completion string that describes how to insert this
+   * code-completion result into the editing buffer.
+   */
+  CXCompletionString CompletionString;
+} CXCompletionResult;
+
+/**
+ * Describes a single piece of text within a code-completion string.
+ *
+ * Each "chunk" within a code-completion string (\c CXCompletionString) is
+ * either a piece of text with a specific "kind" that describes how that text
+ * should be interpreted by the client or is another completion string.
+ */
+enum CXCompletionChunkKind {
+  /**
+   * A code-completion string that describes "optional" text that
+   * could be a part of the template (but is not required).
+   *
+   * The Optional chunk is the only kind of chunk that has a code-completion
+   * string for its representation, which is accessible via
+   * \c clang_getCompletionChunkCompletionString(). The code-completion string
+   * describes an additional part of the template that is completely optional.
+   * For example, optional chunks can be used to describe the placeholders for
+   * arguments that match up with defaulted function parameters, e.g. given:
+   *
+   * \code
+   * void f(int x, float y = 3.14, double z = 2.71828);
+   * \endcode
+   *
+   * The code-completion string for this function would contain:
+   *   - a TypedText chunk for "f".
+   *   - a LeftParen chunk for "(".
+   *   - a Placeholder chunk for "int x"
+   *   - an Optional chunk containing the remaining defaulted arguments, e.g.,
+   *       - a Comma chunk for ","
+   *       - a Placeholder chunk for "float y"
+   *       - an Optional chunk containing the last defaulted argument:
+   *           - a Comma chunk for ","
+   *           - a Placeholder chunk for "double z"
+   *   - a RightParen chunk for ")"
+   *
+   * There are many ways to handle Optional chunks. Two simple approaches are:
+   *   - Completely ignore optional chunks, in which case the template for the
+   *     function "f" would only include the first parameter ("int x").
+   *   - Fully expand all optional chunks, in which case the template for the
+   *     function "f" would have all of the parameters.
+   */
+  CXCompletionChunk_Optional,
+  /**
+   * Text that a user would be expected to type to get this
+   * code-completion result.
+   *
+   * There will be exactly one "typed text" chunk in a semantic string, which
+   * will typically provide the spelling of a keyword or the name of a
+   * declaration that could be used at the current code point. Clients are
+   * expected to filter the code-completion results based on the text in this
+   * chunk.
+   */
+  CXCompletionChunk_TypedText,
+  /**
+   * Text that should be inserted as part of a code-completion result.
+   *
+   * A "text" chunk represents text that is part of the template to be
+   * inserted into user code should this particular code-completion result
+   * be selected.
+   */
+  CXCompletionChunk_Text,
+  /**
+   * Placeholder text that should be replaced by the user.
+   *
+   * A "placeholder" chunk marks a place where the user should insert text
+   * into the code-completion template. For example, placeholders might mark
+   * the function parameters for a function declaration, to indicate that the
+   * user should provide arguments for each of those parameters. The actual
+   * text in a placeholder is a suggestion for the text to display before
+   * the user replaces the placeholder with real code.
+   */
+  CXCompletionChunk_Placeholder,
+  /**
+   * Informative text that should be displayed but never inserted as
+   * part of the template.
+   *
+   * An "informative" chunk contains annotations that can be displayed to
+   * help the user decide whether a particular code-completion result is the
+   * right option, but which is not part of the actual template to be inserted
+   * by code completion.
+   */
+  CXCompletionChunk_Informative,
+  /**
+   * Text that describes the current parameter when code-completion is
+   * referring to function call, message send, or template specialization.
+   *
+   * A "current parameter" chunk occurs when code-completion is providing
+   * information about a parameter corresponding to the argument at the
+   * code-completion point. For example, given a function
+   *
+   * \code
+   * int add(int x, int y);
+   * \endcode
+   *
+   * and the source code \c add(, where the code-completion point is after the
+   * "(", the code-completion string will contain a "current parameter" chunk
+   * for "int x", indicating that the current argument will initialize that
+   * parameter. After typing further, to \c add(17, (where the code-completion
+   * point is after the ","), the code-completion string will contain a
+   * "current parameter" chunk to "int y".
+   */
+  CXCompletionChunk_CurrentParameter,
+  /**
+   * A left parenthesis ('('), used to initiate a function call or
+   * signal the beginning of a function parameter list.
+   */
+  CXCompletionChunk_LeftParen,
+  /**
+   * A right parenthesis (')'), used to finish a function call or
+   * signal the end of a function parameter list.
+   */
+  CXCompletionChunk_RightParen,
+  /**
+   * A left bracket ('[').
+   */
+  CXCompletionChunk_LeftBracket,
+  /**
+   * A right bracket (']').
+   */
+  CXCompletionChunk_RightBracket,
+  /**
+   * A left brace ('{').
+   */
+  CXCompletionChunk_LeftBrace,
+  /**
+   * A right brace ('}').
+   */
+  CXCompletionChunk_RightBrace,
+  /**
+   * A left angle bracket ('<').
+   */
+  CXCompletionChunk_LeftAngle,
+  /**
+   * A right angle bracket ('>').
+   */
+  CXCompletionChunk_RightAngle,
+  /**
+   * A comma separator (',').
+   */
+  CXCompletionChunk_Comma,
+  /**
+   * Text that specifies the result type of a given result.
+   *
+   * This special kind of informative chunk is not meant to be inserted into
+   * the text buffer. Rather, it is meant to illustrate the type that an
+   * expression using the given completion string would have.
+   */
+  CXCompletionChunk_ResultType,
+  /**
+   * A colon (':').
+   */
+  CXCompletionChunk_Colon,
+  /**
+   * A semicolon (';').
+   */
+  CXCompletionChunk_SemiColon,
+  /**
+   * An '=' sign.
+   */
+  CXCompletionChunk_Equal,
+  /**
+   * Horizontal space (' ').
+   */
+  CXCompletionChunk_HorizontalSpace,
+  /**
+   * Vertical space ('\\n'), after which it is generally a good idea to
+   * perform indentation.
+   */
+  CXCompletionChunk_VerticalSpace
+};
+
+/**
+ * Determine the kind of a particular chunk within a completion string.
+ *
+ * \param completion_string the completion string to query.
+ *
+ * \param chunk_number the 0-based index of the chunk in the completion string.
+ *
+ * \returns the kind of the chunk at the index \c chunk_number.
+ */
+CINDEX_LINKAGE enum CXCompletionChunkKind
+clang_getCompletionChunkKind(CXCompletionString completion_string,
+                             unsigned chunk_number);
+
+/**
+ * Retrieve the text associated with a particular chunk within a
+ * completion string.
+ *
+ * \param completion_string the completion string to query.
+ *
+ * \param chunk_number the 0-based index of the chunk in the completion string.
+ *
+ * \returns the text associated with the chunk at index \c chunk_number.
+ */
+CINDEX_LINKAGE CXString clang_getCompletionChunkText(
+    CXCompletionString completion_string, unsigned chunk_number);
+
+/**
+ * Retrieve the completion string associated with a particular chunk
+ * within a completion string.
+ *
+ * \param completion_string the completion string to query.
+ *
+ * \param chunk_number the 0-based index of the chunk in the completion string.
+ *
+ * \returns the completion string associated with the chunk at index
+ * \c chunk_number.
+ */
+CINDEX_LINKAGE CXCompletionString clang_getCompletionChunkCompletionString(
+    CXCompletionString completion_string, unsigned chunk_number);
+
+/**
+ * Retrieve the number of chunks in the given code-completion string.
+ */
+CINDEX_LINKAGE unsigned
+clang_getNumCompletionChunks(CXCompletionString completion_string);
+
+/**
+ * Determine the priority of this code completion.
+ *
+ * The priority of a code completion indicates how likely it is that this
+ * particular completion is the completion that the user will select. The
+ * priority is selected by various internal heuristics.
+ *
+ * \param completion_string The completion string to query.
+ *
+ * \returns The priority of this completion string. Smaller values indicate
+ * higher-priority (more likely) completions.
+ */
+CINDEX_LINKAGE unsigned
+clang_getCompletionPriority(CXCompletionString completion_string);
+
+/**
+ * Determine the availability of the entity that this code-completion
+ * string refers to.
+ *
+ * \param completion_string The completion string to query.
+ *
+ * \returns The availability of the completion string.
+ */
+CINDEX_LINKAGE enum CXAvailabilityKind
+clang_getCompletionAvailability(CXCompletionString completion_string);
+
+/**
+ * Retrieve the number of annotations associated with the given
+ * completion string.
+ *
+ * \param completion_string the completion string to query.
+ *
+ * \returns the number of annotations associated with the given completion
+ * string.
+ */
+CINDEX_LINKAGE unsigned
+clang_getCompletionNumAnnotations(CXCompletionString completion_string);
+
+/**
+ * Retrieve the annotation associated with the given completion string.
+ *
+ * \param completion_string the completion string to query.
+ *
+ * \param annotation_number the 0-based index of the annotation of the
+ * completion string.
+ *
+ * \returns annotation string associated with the completion at index
+ * \c annotation_number, or a NULL string if that annotation is not available.
+ */
+CINDEX_LINKAGE CXString clang_getCompletionAnnotation(
+    CXCompletionString completion_string, unsigned annotation_number);
+
+/**
+ * Retrieve the parent context of the given completion string.
+ *
+ * The parent context of a completion string is the semantic parent of
+ * the declaration (if any) that the code completion represents. For example,
+ * a code completion for an Objective-C method would have the method's class
+ * or protocol as its context.
+ *
+ * \param completion_string The code completion string whose parent is
+ * being queried.
+ *
+ * \param kind DEPRECATED: always set to CXCursor_NotImplemented if non-NULL.
+ *
+ * \returns The name of the completion parent, e.g., "NSObject" if
+ * the completion string represents a method in the NSObject class.
+ */
+CINDEX_LINKAGE CXString clang_getCompletionParent(
+    CXCompletionString completion_string, enum CXCursorKind *kind);
+
+/**
+ * Retrieve the brief documentation comment attached to the declaration
+ * that corresponds to the given completion string.
+ */
+CINDEX_LINKAGE CXString
+clang_getCompletionBriefComment(CXCompletionString completion_string);
+
+/**
+ * Retrieve a completion string for an arbitrary declaration or macro
+ * definition cursor.
+ *
+ * \param cursor The cursor to query.
+ *
+ * \returns A non-context-sensitive completion string for declaration and macro
+ * definition cursors, or NULL for other kinds of cursors.
+ */
+CINDEX_LINKAGE CXCompletionString
+clang_getCursorCompletionString(CXCursor cursor);
+
+/**
+ * Contains the results of code-completion.
+ *
+ * This data structure contains the results of code completion, as
+ * produced by \c clang_codeCompleteAt(). Its contents must be freed by
+ * \c clang_disposeCodeCompleteResults.
+ */
+typedef struct {
+  /**
+   * The code-completion results.
+   */
+  CXCompletionResult *Results;
+
+  /**
+   * The number of code-completion results stored in the
+   * \c Results array.
+   */
+  unsigned NumResults;
+} CXCodeCompleteResults;
+
+/**
+ * Retrieve the number of fix-its for the given completion index.
+ *
+ * Calling this makes sense only if CXCodeComplete_IncludeCompletionsWithFixIts
+ * option was set.
+ *
+ * \param results The structure keeping all completion results
+ *
+ * \param completion_index The index of the completion
+ *
+ * \return The number of fix-its which must be applied before the completion at
+ * completion_index can be applied
+ */
+CINDEX_LINKAGE unsigned
+clang_getCompletionNumFixIts(CXCodeCompleteResults *results,
+                             unsigned completion_index);
+
+/**
+ * Fix-its that *must* be applied before inserting the text for the
+ * corresponding completion.
+ *
+ * By default, clang_codeCompleteAt() only returns completions with empty
+ * fix-its. Extra completions with non-empty fix-its should be explicitly
+ * requested by setting CXCodeComplete_IncludeCompletionsWithFixIts.
+ *
+ * For the clients to be able to compute position of the cursor after applying
+ * fix-its, the following conditions are guaranteed to hold for
+ * replacement_range of the stored fix-its:
+ *  - Ranges in the fix-its are guaranteed to never contain the completion
+ *  point (or identifier under completion point, if any) inside them, except
+ *  at the start or at the end of the range.
+ *  - If a fix-it range starts or ends with completion point (or starts or
+ *  ends after the identifier under completion point), it will contain at
+ *  least one character. It allows to unambiguously recompute completion
+ *  point after applying the fix-it.
+ *
+ * The intuition is that provided fix-its change code around the identifier we
+ * complete, but are not allowed to touch the identifier itself or the
+ * completion point. One example of completions with corrections are the ones
+ * replacing '.' with '->' and vice versa:
+ *
+ * std::unique_ptr<std::vector<int>> vec_ptr;
+ * In 'vec_ptr.^', one of the completions is 'push_back', it requires
+ * replacing '.' with '->'.
+ * In 'vec_ptr->^', one of the completions is 'release', it requires
+ * replacing '->' with '.'.
+ *
+ * \param results The structure keeping all completion results
+ *
+ * \param completion_index The index of the completion
+ *
+ * \param fixit_index The index of the fix-it for the completion at
+ * completion_index
+ *
+ * \param replacement_range The fix-it range that must be replaced before the
+ * completion at completion_index can be applied
+ *
+ * \returns The fix-it string that must replace the code at replacement_range
+ * before the completion at completion_index can be applied
+ */
+CINDEX_LINKAGE CXString clang_getCompletionFixIt(
+    CXCodeCompleteResults *results, unsigned completion_index,
+    unsigned fixit_index, CXSourceRange *replacement_range);
+
+/**
+ * Flags that can be passed to \c clang_codeCompleteAt() to
+ * modify its behavior.
+ *
+ * The enumerators in this enumeration can be bitwise-OR'd together to
+ * provide multiple options to \c clang_codeCompleteAt().
+ */
+enum CXCodeComplete_Flags {
+  /**
+   * Whether to include macros within the set of code
+   * completions returned.
+   */
+  CXCodeComplete_IncludeMacros = 0x01,
+
+  /**
+   * Whether to include code patterns for language constructs
+   * within the set of code completions, e.g., for loops.
+   */
+  CXCodeComplete_IncludeCodePatterns = 0x02,
+
+  /**
+   * Whether to include brief documentation within the set of code
+   * completions returned.
+   */
+  CXCodeComplete_IncludeBriefComments = 0x04,
+
+  /**
+   * Whether to speed up completion by omitting top- or namespace-level entities
+   * defined in the preamble. There's no guarantee any particular entity is
+   * omitted. This may be useful if the headers are indexed externally.
+   */
+  CXCodeComplete_SkipPreamble = 0x08,
+
+  /**
+   * Whether to include completions with small
+   * fix-its, e.g. change '.' to '->' on member access, etc.
+   */
+  CXCodeComplete_IncludeCompletionsWithFixIts = 0x10
+};
+
+/**
+ * Bits that represent the context under which completion is occurring.
+ *
+ * The enumerators in this enumeration may be bitwise-OR'd together if multiple
+ * contexts are occurring simultaneously.
+ */
+enum CXCompletionContext {
+  /**
+   * The context for completions is unexposed, as only Clang results
+   * should be included. (This is equivalent to having no context bits set.)
+   */
+  CXCompletionContext_Unexposed = 0,
+
+  /**
+   * Completions for any possible type should be included in the results.
+   */
+  CXCompletionContext_AnyType = 1 << 0,
+
+  /**
+   * Completions for any possible value (variables, function calls, etc.)
+   * should be included in the results.
+   */
+  CXCompletionContext_AnyValue = 1 << 1,
+  /**
+   * Completions for values that resolve to an Objective-C object should
+   * be included in the results.
+   */
+  CXCompletionContext_ObjCObjectValue = 1 << 2,
+  /**
+   * Completions for values that resolve to an Objective-C selector
+   * should be included in the results.
+   */
+  CXCompletionContext_ObjCSelectorValue = 1 << 3,
+  /**
+   * Completions for values that resolve to a C++ class type should be
+   * included in the results.
+   */
+  CXCompletionContext_CXXClassTypeValue = 1 << 4,
+
+  /**
+   * Completions for fields of the member being accessed using the dot
+   * operator should be included in the results.
+   */
+  CXCompletionContext_DotMemberAccess = 1 << 5,
+  /**
+   * Completions for fields of the member being accessed using the arrow
+   * operator should be included in the results.
+   */
+  CXCompletionContext_ArrowMemberAccess = 1 << 6,
+  /**
+   * Completions for properties of the Objective-C object being accessed
+   * using the dot operator should be included in the results.
+   */
+  CXCompletionContext_ObjCPropertyAccess = 1 << 7,
+
+  /**
+   * Completions for enum tags should be included in the results.
+   */
+  CXCompletionContext_EnumTag = 1 << 8,
+  /**
+   * Completions for union tags should be included in the results.
+   */
+  CXCompletionContext_UnionTag = 1 << 9,
+  /**
+   * Completions for struct tags should be included in the results.
+   */
+  CXCompletionContext_StructTag = 1 << 10,
+
+  /**
+   * Completions for C++ class names should be included in the results.
+   */
+  CXCompletionContext_ClassTag = 1 << 11,
+  /**
+   * Completions for C++ namespaces and namespace aliases should be
+   * included in the results.
+   */
+  CXCompletionContext_Namespace = 1 << 12,
+  /**
+   * Completions for C++ nested name specifiers should be included in
+   * the results.
+   */
+  CXCompletionContext_NestedNameSpecifier = 1 << 13,
+
+  /**
+   * Completions for Objective-C interfaces (classes) should be included
+   * in the results.
+   */
+  CXCompletionContext_ObjCInterface = 1 << 14,
+  /**
+   * Completions for Objective-C protocols should be included in
+   * the results.
+   */
+  CXCompletionContext_ObjCProtocol = 1 << 15,
+  /**
+   * Completions for Objective-C categories should be included in
+   * the results.
+   */
+  CXCompletionContext_ObjCCategory = 1 << 16,
+  /**
+   * Completions for Objective-C instance messages should be included
+   * in the results.
+   */
+  CXCompletionContext_ObjCInstanceMessage = 1 << 17,
+  /**
+   * Completions for Objective-C class messages should be included in
+   * the results.
+   */
+  CXCompletionContext_ObjCClassMessage = 1 << 18,
+  /**
+   * Completions for Objective-C selector names should be included in
+   * the results.
+   */
+  CXCompletionContext_ObjCSelectorName = 1 << 19,
+
+  /**
+   * Completions for preprocessor macro names should be included in
+   * the results.
+   */
+  CXCompletionContext_MacroName = 1 << 20,
+
+  /**
+   * Natural language completions should be included in the results.
+   */
+  CXCompletionContext_NaturalLanguage = 1 << 21,
+
+  /**
+   * #include file completions should be included in the results.
+   */
+  CXCompletionContext_IncludedFile = 1 << 22,
+
+  /**
+   * The current context is unknown, so set all contexts.
+   */
+  CXCompletionContext_Unknown = ((1 << 23) - 1)
+};
+
+/**
+ * Returns a default set of code-completion options that can be
+ * passed to\c clang_codeCompleteAt().
+ */
+CINDEX_LINKAGE unsigned clang_defaultCodeCompleteOptions(void);
+
+/**
+ * Perform code completion at a given location in a translation unit.
+ *
+ * This function performs code completion at a particular file, line, and
+ * column within source code, providing results that suggest potential
+ * code snippets based on the context of the completion. The basic model
+ * for code completion is that Clang will parse a complete source file,
+ * performing syntax checking up to the location where code-completion has
+ * been requested. At that point, a special code-completion token is passed
+ * to the parser, which recognizes this token and determines, based on the
+ * current location in the C/Objective-C/C++ grammar and the state of
+ * semantic analysis, what completions to provide. These completions are
+ * returned via a new \c CXCodeCompleteResults structure.
+ *
+ * Code completion itself is meant to be triggered by the client when the
+ * user types punctuation characters or whitespace, at which point the
+ * code-completion location will coincide with the cursor. For example, if \c p
+ * is a pointer, code-completion might be triggered after the "-" and then
+ * after the ">" in \c p->. When the code-completion location is after the ">",
+ * the completion results will provide, e.g., the members of the struct that
+ * "p" points to. The client is responsible for placing the cursor at the
+ * beginning of the token currently being typed, then filtering the results
+ * based on the contents of the token. For example, when code-completing for
+ * the expression \c p->get, the client should provide the location just after
+ * the ">" (e.g., pointing at the "g") to this code-completion hook. Then, the
+ * client can filter the results based on the current token text ("get"), only
+ * showing those results that start with "get". The intent of this interface
+ * is to separate the relatively high-latency acquisition of code-completion
+ * results from the filtering of results on a per-character basis, which must
+ * have a lower latency.
+ *
+ * \param TU The translation unit in which code-completion should
+ * occur. The source files for this translation unit need not be
+ * completely up-to-date (and the contents of those source files may
+ * be overridden via \p unsaved_files). Cursors referring into the
+ * translation unit may be invalidated by this invocation.
+ *
+ * \param complete_filename The name of the source file where code
+ * completion should be performed. This filename may be any file
+ * included in the translation unit.
+ *
+ * \param complete_line The line at which code-completion should occur.
+ *
+ * \param complete_column The column at which code-completion should occur.
+ * Note that the column should point just after the syntactic construct that
+ * initiated code completion, and not in the middle of a lexical token.
+ *
+ * \param unsaved_files the Files that have not yet been saved to disk
+ * but may be required for parsing or code completion, including the
+ * contents of those files.  The contents and name of these files (as
+ * specified by CXUnsavedFile) are copied when necessary, so the
+ * client only needs to guarantee their validity until the call to
+ * this function returns.
+ *
+ * \param num_unsaved_files The number of unsaved file entries in \p
+ * unsaved_files.
+ *
+ * \param options Extra options that control the behavior of code
+ * completion, expressed as a bitwise OR of the enumerators of the
+ * CXCodeComplete_Flags enumeration. The
+ * \c clang_defaultCodeCompleteOptions() function returns a default set
+ * of code-completion options.
+ *
+ * \returns If successful, a new \c CXCodeCompleteResults structure
+ * containing code-completion results, which should eventually be
+ * freed with \c clang_disposeCodeCompleteResults(). If code
+ * completion fails, returns NULL.
+ */
+CINDEX_LINKAGE
+CXCodeCompleteResults *
+clang_codeCompleteAt(CXTranslationUnit TU, const char *complete_filename,
+                     unsigned complete_line, unsigned complete_column,
+                     struct CXUnsavedFile *unsaved_files,
+                     unsigned num_unsaved_files, unsigned options);
+
+/**
+ * Sort the code-completion results in case-insensitive alphabetical
+ * order.
+ *
+ * \param Results The set of results to sort.
+ * \param NumResults The number of results in \p Results.
+ */
+CINDEX_LINKAGE
+void clang_sortCodeCompletionResults(CXCompletionResult *Results,
+                                     unsigned NumResults);
+
+/**
+ * Free the given set of code-completion results.
+ */
+CINDEX_LINKAGE
+void clang_disposeCodeCompleteResults(CXCodeCompleteResults *Results);
+
+/**
+ * Determine the number of diagnostics produced prior to the
+ * location where code completion was performed.
+ */
+CINDEX_LINKAGE
+unsigned clang_codeCompleteGetNumDiagnostics(CXCodeCompleteResults *Results);
+
+/**
+ * Retrieve a diagnostic associated with the given code completion.
+ *
+ * \param Results the code completion results to query.
+ * \param Index the zero-based diagnostic number to retrieve.
+ *
+ * \returns the requested diagnostic. This diagnostic must be freed
+ * via a call to \c clang_disposeDiagnostic().
+ */
+CINDEX_LINKAGE
+CXDiagnostic clang_codeCompleteGetDiagnostic(CXCodeCompleteResults *Results,
+                                             unsigned Index);
+
+/**
+ * Determines what completions are appropriate for the context
+ * the given code completion.
+ *
+ * \param Results the code completion results to query
+ *
+ * \returns the kinds of completions that are appropriate for use
+ * along with the given code completion results.
+ */
+CINDEX_LINKAGE
+unsigned long long
+clang_codeCompleteGetContexts(CXCodeCompleteResults *Results);
+
+/**
+ * Returns the cursor kind for the container for the current code
+ * completion context. The container is only guaranteed to be set for
+ * contexts where a container exists (i.e. member accesses or Objective-C
+ * message sends); if there is not a container, this function will return
+ * CXCursor_InvalidCode.
+ *
+ * \param Results the code completion results to query
+ *
+ * \param IsIncomplete on return, this value will be false if Clang has complete
+ * information about the container. If Clang does not have complete
+ * information, this value will be true.
+ *
+ * \returns the container kind, or CXCursor_InvalidCode if there is not a
+ * container
+ */
+CINDEX_LINKAGE
+enum CXCursorKind
+clang_codeCompleteGetContainerKind(CXCodeCompleteResults *Results,
+                                   unsigned *IsIncomplete);
+
+/**
+ * Returns the USR for the container for the current code completion
+ * context. If there is not a container for the current context, this
+ * function will return the empty string.
+ *
+ * \param Results the code completion results to query
+ *
+ * \returns the USR for the container
+ */
+CINDEX_LINKAGE
+CXString clang_codeCompleteGetContainerUSR(CXCodeCompleteResults *Results);
+
+/**
+ * Returns the currently-entered selector for an Objective-C message
+ * send, formatted like "initWithFoo:bar:". Only guaranteed to return a
+ * non-empty string for CXCompletionContext_ObjCInstanceMessage and
+ * CXCompletionContext_ObjCClassMessage.
+ *
+ * \param Results the code completion results to query
+ *
+ * \returns the selector (or partial selector) that has been entered thus far
+ * for an Objective-C message send.
+ */
+CINDEX_LINKAGE
+CXString clang_codeCompleteGetObjCSelector(CXCodeCompleteResults *Results);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CINDEX_MISC Miscellaneous utility functions
+ *
+ * @{
+ */
+
+/**
+ * Return a version string, suitable for showing to a user, but not
+ *        intended to be parsed (the format is not guaranteed to be stable).
+ */
+CINDEX_LINKAGE CXString clang_getClangVersion(void);
+
+/**
+ * Enable/disable crash recovery.
+ *
+ * \param isEnabled Flag to indicate if crash recovery is enabled.  A non-zero
+ *        value enables crash recovery, while 0 disables it.
+ */
+CINDEX_LINKAGE void clang_toggleCrashRecovery(unsigned isEnabled);
+
+/**
+ * Visitor invoked for each file in a translation unit
+ *        (used with clang_getInclusions()).
+ *
+ * This visitor function will be invoked by clang_getInclusions() for each
+ * file included (either at the top-level or by \#include directives) within
+ * a translation unit.  The first argument is the file being included, and
+ * the second and third arguments provide the inclusion stack.  The
+ * array is sorted in order of immediate inclusion.  For example,
+ * the first element refers to the location that included 'included_file'.
+ */
+typedef void (*CXInclusionVisitor)(CXFile included_file,
+                                   CXSourceLocation *inclusion_stack,
+                                   unsigned include_len,
+                                   CXClientData client_data);
+
+/**
+ * Visit the set of preprocessor inclusions in a translation unit.
+ *   The visitor function is called with the provided data for every included
+ *   file.  This does not include headers included by the PCH file (unless one
+ *   is inspecting the inclusions in the PCH file itself).
+ */
+CINDEX_LINKAGE void clang_getInclusions(CXTranslationUnit tu,
+                                        CXInclusionVisitor visitor,
+                                        CXClientData client_data);
+
+typedef enum {
+  CXEval_Int = 1,
+  CXEval_Float = 2,
+  CXEval_ObjCStrLiteral = 3,
+  CXEval_StrLiteral = 4,
+  CXEval_CFStr = 5,
+  CXEval_Other = 6,
+
+  CXEval_UnExposed = 0
+
+} CXEvalResultKind;
+
+/**
+ * Evaluation result of a cursor
+ */
+typedef void *CXEvalResult;
+
+/**
+ * If cursor is a statement declaration tries to evaluate the
+ * statement and if its variable, tries to evaluate its initializer,
+ * into its corresponding type.
+ * If it's an expression, tries to evaluate the expression.
+ */
+CINDEX_LINKAGE CXEvalResult clang_Cursor_Evaluate(CXCursor C);
+
+/**
+ * Returns the kind of the evaluated result.
+ */
+CINDEX_LINKAGE CXEvalResultKind clang_EvalResult_getKind(CXEvalResult E);
+
+/**
+ * Returns the evaluation result as integer if the
+ * kind is Int.
+ */
+CINDEX_LINKAGE int clang_EvalResult_getAsInt(CXEvalResult E);
+
+/**
+ * Returns the evaluation result as a long long integer if the
+ * kind is Int. This prevents overflows that may happen if the result is
+ * returned with clang_EvalResult_getAsInt.
+ */
+CINDEX_LINKAGE long long clang_EvalResult_getAsLongLong(CXEvalResult E);
+
+/**
+ * Returns a non-zero value if the kind is Int and the evaluation
+ * result resulted in an unsigned integer.
+ */
+CINDEX_LINKAGE unsigned clang_EvalResult_isUnsignedInt(CXEvalResult E);
+
+/**
+ * Returns the evaluation result as an unsigned integer if
+ * the kind is Int and clang_EvalResult_isUnsignedInt is non-zero.
+ */
+CINDEX_LINKAGE unsigned long long
+clang_EvalResult_getAsUnsigned(CXEvalResult E);
+
+/**
+ * Returns the evaluation result as double if the
+ * kind is double.
+ */
+CINDEX_LINKAGE double clang_EvalResult_getAsDouble(CXEvalResult E);
+
+/**
+ * Returns the evaluation result as a constant string if the
+ * kind is other than Int or float. User must not free this pointer,
+ * instead call clang_EvalResult_dispose on the CXEvalResult returned
+ * by clang_Cursor_Evaluate.
+ */
+CINDEX_LINKAGE const char *clang_EvalResult_getAsStr(CXEvalResult E);
+
+/**
+ * Disposes the created Eval memory.
+ */
+CINDEX_LINKAGE void clang_EvalResult_dispose(CXEvalResult E);
+/**
+ * @}
+ */
+
+/** \defgroup CINDEX_HIGH Higher level API functions
+ *
+ * @{
+ */
+
+enum CXVisitorResult { CXVisit_Break, CXVisit_Continue };
+
+typedef struct CXCursorAndRangeVisitor {
+  void *context;
+  enum CXVisitorResult (*visit)(void *context, CXCursor, CXSourceRange);
+} CXCursorAndRangeVisitor;
+
+typedef enum {
+  /**
+   * Function returned successfully.
+   */
+  CXResult_Success = 0,
+  /**
+   * One of the parameters was invalid for the function.
+   */
+  CXResult_Invalid = 1,
+  /**
+   * The function was terminated by a callback (e.g. it returned
+   * CXVisit_Break)
+   */
+  CXResult_VisitBreak = 2
+
+} CXResult;
+
+/**
+ * Find references of a declaration in a specific file.
+ *
+ * \param cursor pointing to a declaration or a reference of one.
+ *
+ * \param file to search for references.
+ *
+ * \param visitor callback that will receive pairs of CXCursor/CXSourceRange for
+ * each reference found.
+ * The CXSourceRange will point inside the file; if the reference is inside
+ * a macro (and not a macro argument) the CXSourceRange will be invalid.
+ *
+ * \returns one of the CXResult enumerators.
+ */
+CINDEX_LINKAGE CXResult clang_findReferencesInFile(
+    CXCursor cursor, CXFile file, CXCursorAndRangeVisitor visitor);
+
+/**
+ * Find #import/#include directives in a specific file.
+ *
+ * \param TU translation unit containing the file to query.
+ *
+ * \param file to search for #import/#include directives.
+ *
+ * \param visitor callback that will receive pairs of CXCursor/CXSourceRange for
+ * each directive found.
+ *
+ * \returns one of the CXResult enumerators.
+ */
+CINDEX_LINKAGE CXResult clang_findIncludesInFile(
+    CXTranslationUnit TU, CXFile file, CXCursorAndRangeVisitor visitor);
+
+#if __has_feature(blocks)
+typedef enum CXVisitorResult (^CXCursorAndRangeVisitorBlock)(CXCursor,
+                                                             CXSourceRange);
+#else
+typedef struct _CXCursorAndRangeVisitorBlock *CXCursorAndRangeVisitorBlock;
+#endif
+
+CINDEX_LINKAGE
+CXResult clang_findReferencesInFileWithBlock(CXCursor, CXFile,
+                                             CXCursorAndRangeVisitorBlock);
+
+CINDEX_LINKAGE
+CXResult clang_findIncludesInFileWithBlock(CXTranslationUnit, CXFile,
+                                           CXCursorAndRangeVisitorBlock);
+
+/**
+ * The client's data object that is associated with a CXFile.
+ */
+typedef void *CXIdxClientFile;
+
+/**
+ * The client's data object that is associated with a semantic entity.
+ */
+typedef void *CXIdxClientEntity;
+
+/**
+ * The client's data object that is associated with a semantic container
+ * of entities.
+ */
+typedef void *CXIdxClientContainer;
+
+/**
+ * The client's data object that is associated with an AST file (PCH
+ * or module).
+ */
+typedef void *CXIdxClientASTFile;
+
+/**
+ * Source location passed to index callbacks.
+ */
+typedef struct {
+  void *ptr_data[2];
+  unsigned int_data;
+} CXIdxLoc;
+
+/**
+ * Data for ppIncludedFile callback.
+ */
+typedef struct {
+  /**
+   * Location of '#' in the \#include/\#import directive.
+   */
+  CXIdxLoc hashLoc;
+  /**
+   * Filename as written in the \#include/\#import directive.
+   */
+  const char *filename;
+  /**
+   * The actual file that the \#include/\#import directive resolved to.
+   */
+  CXFile file;
+  int isImport;
+  int isAngled;
+  /**
+   * Non-zero if the directive was automatically turned into a module
+   * import.
+   */
+  int isModuleImport;
+} CXIdxIncludedFileInfo;
+
+/**
+ * Data for IndexerCallbacks#importedASTFile.
+ */
+typedef struct {
+  /**
+   * Top level AST file containing the imported PCH, module or submodule.
+   */
+  CXFile file;
+  /**
+   * The imported module or NULL if the AST file is a PCH.
+   */
+  CXModule module;
+  /**
+   * Location where the file is imported. Applicable only for modules.
+   */
+  CXIdxLoc loc;
+  /**
+   * Non-zero if an inclusion directive was automatically turned into
+   * a module import. Applicable only for modules.
+   */
+  int isImplicit;
+
+} CXIdxImportedASTFileInfo;
+
+typedef enum {
+  CXIdxEntity_Unexposed = 0,
+  CXIdxEntity_Typedef = 1,
+  CXIdxEntity_Function = 2,
+  CXIdxEntity_Variable = 3,
+  CXIdxEntity_Field = 4,
+  CXIdxEntity_EnumConstant = 5,
+
+  CXIdxEntity_ObjCClass = 6,
+  CXIdxEntity_ObjCProtocol = 7,
+  CXIdxEntity_ObjCCategory = 8,
+
+  CXIdxEntity_ObjCInstanceMethod = 9,
+  CXIdxEntity_ObjCClassMethod = 10,
+  CXIdxEntity_ObjCProperty = 11,
+  CXIdxEntity_ObjCIvar = 12,
+
+  CXIdxEntity_Enum = 13,
+  CXIdxEntity_Struct = 14,
+  CXIdxEntity_Union = 15,
+
+  CXIdxEntity_CXXClass = 16,
+  CXIdxEntity_CXXNamespace = 17,
+  CXIdxEntity_CXXNamespaceAlias = 18,
+  CXIdxEntity_CXXStaticVariable = 19,
+  CXIdxEntity_CXXStaticMethod = 20,
+  CXIdxEntity_CXXInstanceMethod = 21,
+  CXIdxEntity_CXXConstructor = 22,
+  CXIdxEntity_CXXDestructor = 23,
+  CXIdxEntity_CXXConversionFunction = 24,
+  CXIdxEntity_CXXTypeAlias = 25,
+  CXIdxEntity_CXXInterface = 26,
+  CXIdxEntity_CXXConcept = 27
+
+} CXIdxEntityKind;
+
+typedef enum {
+  CXIdxEntityLang_None = 0,
+  CXIdxEntityLang_C = 1,
+  CXIdxEntityLang_ObjC = 2,
+  CXIdxEntityLang_CXX = 3,
+  CXIdxEntityLang_Swift = 4
+} CXIdxEntityLanguage;
+
+/**
+ * Extra C++ template information for an entity. This can apply to:
+ * CXIdxEntity_Function
+ * CXIdxEntity_CXXClass
+ * CXIdxEntity_CXXStaticMethod
+ * CXIdxEntity_CXXInstanceMethod
+ * CXIdxEntity_CXXConstructor
+ * CXIdxEntity_CXXConversionFunction
+ * CXIdxEntity_CXXTypeAlias
+ */
+typedef enum {
+  CXIdxEntity_NonTemplate = 0,
+  CXIdxEntity_Template = 1,
+  CXIdxEntity_TemplatePartialSpecialization = 2,
+  CXIdxEntity_TemplateSpecialization = 3
+} CXIdxEntityCXXTemplateKind;
+
+typedef enum {
+  CXIdxAttr_Unexposed = 0,
+  CXIdxAttr_IBAction = 1,
+  CXIdxAttr_IBOutlet = 2,
+  CXIdxAttr_IBOutletCollection = 3
+} CXIdxAttrKind;
+
+typedef struct {
+  CXIdxAttrKind kind;
+  CXCursor cursor;
+  CXIdxLoc loc;
+} CXIdxAttrInfo;
+
+typedef struct {
+  CXIdxEntityKind kind;
+  CXIdxEntityCXXTemplateKind templateKind;
+  CXIdxEntityLanguage lang;
+  const char *name;
+  const char *USR;
+  CXCursor cursor;
+  const CXIdxAttrInfo *const *attributes;
+  unsigned numAttributes;
+} CXIdxEntityInfo;
+
+typedef struct {
+  CXCursor cursor;
+} CXIdxContainerInfo;
+
+typedef struct {
+  const CXIdxAttrInfo *attrInfo;
+  const CXIdxEntityInfo *objcClass;
+  CXCursor classCursor;
+  CXIdxLoc classLoc;
+} CXIdxIBOutletCollectionAttrInfo;
+
+typedef enum { CXIdxDeclFlag_Skipped = 0x1 } CXIdxDeclInfoFlags;
+
+typedef struct {
+  const CXIdxEntityInfo *entityInfo;
+  CXCursor cursor;
+  CXIdxLoc loc;
+  const CXIdxContainerInfo *semanticContainer;
+  /**
+   * Generally same as #semanticContainer but can be different in
+   * cases like out-of-line C++ member functions.
+   */
+  const CXIdxContainerInfo *lexicalContainer;
+  int isRedeclaration;
+  int isDefinition;
+  int isContainer;
+  const CXIdxContainerInfo *declAsContainer;
+  /**
+   * Whether the declaration exists in code or was created implicitly
+   * by the compiler, e.g. implicit Objective-C methods for properties.
+   */
+  int isImplicit;
+  const CXIdxAttrInfo *const *attributes;
+  unsigned numAttributes;
+
+  unsigned flags;
+
+} CXIdxDeclInfo;
+
+typedef enum {
+  CXIdxObjCContainer_ForwardRef = 0,
+  CXIdxObjCContainer_Interface = 1,
+  CXIdxObjCContainer_Implementation = 2
+} CXIdxObjCContainerKind;
+
+typedef struct {
+  const CXIdxDeclInfo *declInfo;
+  CXIdxObjCContainerKind kind;
+} CXIdxObjCContainerDeclInfo;
+
+typedef struct {
+  const CXIdxEntityInfo *base;
+  CXCursor cursor;
+  CXIdxLoc loc;
+} CXIdxBaseClassInfo;
+
+typedef struct {
+  const CXIdxEntityInfo *protocol;
+  CXCursor cursor;
+  CXIdxLoc loc;
+} CXIdxObjCProtocolRefInfo;
+
+typedef struct {
+  const CXIdxObjCProtocolRefInfo *const *protocols;
+  unsigned numProtocols;
+} CXIdxObjCProtocolRefListInfo;
+
+typedef struct {
+  const CXIdxObjCContainerDeclInfo *containerInfo;
+  const CXIdxBaseClassInfo *superInfo;
+  const CXIdxObjCProtocolRefListInfo *protocols;
+} CXIdxObjCInterfaceDeclInfo;
+
+typedef struct {
+  const CXIdxObjCContainerDeclInfo *containerInfo;
+  const CXIdxEntityInfo *objcClass;
+  CXCursor classCursor;
+  CXIdxLoc classLoc;
+  const CXIdxObjCProtocolRefListInfo *protocols;
+} CXIdxObjCCategoryDeclInfo;
+
+typedef struct {
+  const CXIdxDeclInfo *declInfo;
+  const CXIdxEntityInfo *getter;
+  const CXIdxEntityInfo *setter;
+} CXIdxObjCPropertyDeclInfo;
+
+typedef struct {
+  const CXIdxDeclInfo *declInfo;
+  const CXIdxBaseClassInfo *const *bases;
+  unsigned numBases;
+} CXIdxCXXClassDeclInfo;
+
+/**
+ * Data for IndexerCallbacks#indexEntityReference.
+ *
+ * This may be deprecated in a future version as this duplicates
+ * the \c CXSymbolRole_Implicit bit in \c CXSymbolRole.
+ */
+typedef enum {
+  /**
+   * The entity is referenced directly in user's code.
+   */
+  CXIdxEntityRef_Direct = 1,
+  /**
+   * An implicit reference, e.g. a reference of an Objective-C method
+   * via the dot syntax.
+   */
+  CXIdxEntityRef_Implicit = 2
+} CXIdxEntityRefKind;
+
+/**
+ * Roles that are attributed to symbol occurrences.
+ *
+ * Internal: this currently mirrors low 9 bits of clang::index::SymbolRole with
+ * higher bits zeroed. These high bits may be exposed in the future.
+ */
+typedef enum {
+  CXSymbolRole_None = 0,
+  CXSymbolRole_Declaration = 1 << 0,
+  CXSymbolRole_Definition = 1 << 1,
+  CXSymbolRole_Reference = 1 << 2,
+  CXSymbolRole_Read = 1 << 3,
+  CXSymbolRole_Write = 1 << 4,
+  CXSymbolRole_Call = 1 << 5,
+  CXSymbolRole_Dynamic = 1 << 6,
+  CXSymbolRole_AddressOf = 1 << 7,
+  CXSymbolRole_Implicit = 1 << 8
+} CXSymbolRole;
+
+/**
+ * Data for IndexerCallbacks#indexEntityReference.
+ */
+typedef struct {
+  CXIdxEntityRefKind kind;
+  /**
+   * Reference cursor.
+   */
+  CXCursor cursor;
+  CXIdxLoc loc;
+  /**
+   * The entity that gets referenced.
+   */
+  const CXIdxEntityInfo *referencedEntity;
+  /**
+   * Immediate "parent" of the reference. For example:
+   *
+   * \code
+   * Foo *var;
+   * \endcode
+   *
+   * The parent of reference of type 'Foo' is the variable 'var'.
+   * For references inside statement bodies of functions/methods,
+   * the parentEntity will be the function/method.
+   */
+  const CXIdxEntityInfo *parentEntity;
+  /**
+   * Lexical container context of the reference.
+   */
+  const CXIdxContainerInfo *container;
+  /**
+   * Sets of symbol roles of the reference.
+   */
+  CXSymbolRole role;
+} CXIdxEntityRefInfo;
+
+/**
+ * A group of callbacks used by #clang_indexSourceFile and
+ * #clang_indexTranslationUnit.
+ */
+typedef struct {
+  /**
+   * Called periodically to check whether indexing should be aborted.
+   * Should return 0 to continue, and non-zero to abort.
+   */
+  int (*abortQuery)(CXClientData client_data, void *reserved);
+
+  /**
+   * Called at the end of indexing; passes the complete diagnostic set.
+   */
+  void (*diagnostic)(CXClientData client_data, CXDiagnosticSet, void *reserved);
+
+  CXIdxClientFile (*enteredMainFile)(CXClientData client_data, CXFile mainFile,
+                                     void *reserved);
+
+  /**
+   * Called when a file gets \#included/\#imported.
+   */
+  CXIdxClientFile (*ppIncludedFile)(CXClientData client_data,
+                                    const CXIdxIncludedFileInfo *);
+
+  /**
+   * Called when a AST file (PCH or module) gets imported.
+   *
+   * AST files will not get indexed (there will not be callbacks to index all
+   * the entities in an AST file). The recommended action is that, if the AST
+   * file is not already indexed, to initiate a new indexing job specific to
+   * the AST file.
+   */
+  CXIdxClientASTFile (*importedASTFile)(CXClientData client_data,
+                                        const CXIdxImportedASTFileInfo *);
+
+  /**
+   * Called at the beginning of indexing a translation unit.
+   */
+  CXIdxClientContainer (*startedTranslationUnit)(CXClientData client_data,
+                                                 void *reserved);
+
+  void (*indexDeclaration)(CXClientData client_data, const CXIdxDeclInfo *);
+
+  /**
+   * Called to index a reference of an entity.
+   */
+  void (*indexEntityReference)(CXClientData client_data,
+                               const CXIdxEntityRefInfo *);
+
+} IndexerCallbacks;
+
+CINDEX_LINKAGE int clang_index_isEntityObjCContainerKind(CXIdxEntityKind);
+CINDEX_LINKAGE const CXIdxObjCContainerDeclInfo *
+clang_index_getObjCContainerDeclInfo(const CXIdxDeclInfo *);
+
+CINDEX_LINKAGE const CXIdxObjCInterfaceDeclInfo *
+clang_index_getObjCInterfaceDeclInfo(const CXIdxDeclInfo *);
+
+CINDEX_LINKAGE
+const CXIdxObjCCategoryDeclInfo *
+clang_index_getObjCCategoryDeclInfo(const CXIdxDeclInfo *);
+
+CINDEX_LINKAGE const CXIdxObjCProtocolRefListInfo *
+clang_index_getObjCProtocolRefListInfo(const CXIdxDeclInfo *);
+
+CINDEX_LINKAGE const CXIdxObjCPropertyDeclInfo *
+clang_index_getObjCPropertyDeclInfo(const CXIdxDeclInfo *);
+
+CINDEX_LINKAGE const CXIdxIBOutletCollectionAttrInfo *
+clang_index_getIBOutletCollectionAttrInfo(const CXIdxAttrInfo *);
+
+CINDEX_LINKAGE const CXIdxCXXClassDeclInfo *
+clang_index_getCXXClassDeclInfo(const CXIdxDeclInfo *);
+
+/**
+ * For retrieving a custom CXIdxClientContainer attached to a
+ * container.
+ */
+CINDEX_LINKAGE CXIdxClientContainer
+clang_index_getClientContainer(const CXIdxContainerInfo *);
+
+/**
+ * For setting a custom CXIdxClientContainer attached to a
+ * container.
+ */
+CINDEX_LINKAGE void clang_index_setClientContainer(const CXIdxContainerInfo *,
+                                                   CXIdxClientContainer);
+
+/**
+ * For retrieving a custom CXIdxClientEntity attached to an entity.
+ */
+CINDEX_LINKAGE CXIdxClientEntity
+clang_index_getClientEntity(const CXIdxEntityInfo *);
+
+/**
+ * For setting a custom CXIdxClientEntity attached to an entity.
+ */
+CINDEX_LINKAGE void clang_index_setClientEntity(const CXIdxEntityInfo *,
+                                                CXIdxClientEntity);
+
+/**
+ * An indexing action/session, to be applied to one or multiple
+ * translation units.
+ */
+typedef void *CXIndexAction;
+
+/**
+ * An indexing action/session, to be applied to one or multiple
+ * translation units.
+ *
+ * \param CIdx The index object with which the index action will be associated.
+ */
+CINDEX_LINKAGE CXIndexAction clang_IndexAction_create(CXIndex CIdx);
+
+/**
+ * Destroy the given index action.
+ *
+ * The index action must not be destroyed until all of the translation units
+ * created within that index action have been destroyed.
+ */
+CINDEX_LINKAGE void clang_IndexAction_dispose(CXIndexAction);
+
+typedef enum {
+  /**
+   * Used to indicate that no special indexing options are needed.
+   */
+  CXIndexOpt_None = 0x0,
+
+  /**
+   * Used to indicate that IndexerCallbacks#indexEntityReference should
+   * be invoked for only one reference of an entity per source file that does
+   * not also include a declaration/definition of the entity.
+   */
+  CXIndexOpt_SuppressRedundantRefs = 0x1,
+
+  /**
+   * Function-local symbols should be indexed. If this is not set
+   * function-local symbols will be ignored.
+   */
+  CXIndexOpt_IndexFunctionLocalSymbols = 0x2,
+
+  /**
+   * Implicit function/class template instantiations should be indexed.
+   * If this is not set, implicit instantiations will be ignored.
+   */
+  CXIndexOpt_IndexImplicitTemplateInstantiations = 0x4,
+
+  /**
+   * Suppress all compiler warnings when parsing for indexing.
+   */
+  CXIndexOpt_SuppressWarnings = 0x8,
+
+  /**
+   * Skip a function/method body that was already parsed during an
+   * indexing session associated with a \c CXIndexAction object.
+   * Bodies in system headers are always skipped.
+   */
+  CXIndexOpt_SkipParsedBodiesInSession = 0x10
+
+} CXIndexOptFlags;
+
+/**
+ * Index the given source file and the translation unit corresponding
+ * to that file via callbacks implemented through #IndexerCallbacks.
+ *
+ * \param client_data pointer data supplied by the client, which will
+ * be passed to the invoked callbacks.
+ *
+ * \param index_callbacks Pointer to indexing callbacks that the client
+ * implements.
+ *
+ * \param index_callbacks_size Size of #IndexerCallbacks structure that gets
+ * passed in index_callbacks.
+ *
+ * \param index_options A bitmask of options that affects how indexing is
+ * performed. This should be a bitwise OR of the CXIndexOpt_XXX flags.
+ *
+ * \param[out] out_TU pointer to store a \c CXTranslationUnit that can be
+ * reused after indexing is finished. Set to \c NULL if you do not require it.
+ *
+ * \returns 0 on success or if there were errors from which the compiler could
+ * recover.  If there is a failure from which there is no recovery, returns
+ * a non-zero \c CXErrorCode.
+ *
+ * The rest of the parameters are the same as #clang_parseTranslationUnit.
+ */
+CINDEX_LINKAGE int clang_indexSourceFile(
+    CXIndexAction, CXClientData client_data, IndexerCallbacks *index_callbacks,
+    unsigned index_callbacks_size, unsigned index_options,
+    const char *source_filename, const char *const *command_line_args,
+    int num_command_line_args, struct CXUnsavedFile *unsaved_files,
+    unsigned num_unsaved_files, CXTranslationUnit *out_TU, unsigned TU_options);
+
+/**
+ * Same as clang_indexSourceFile but requires a full command line
+ * for \c command_line_args including argv[0]. This is useful if the standard
+ * library paths are relative to the binary.
+ */
+CINDEX_LINKAGE int clang_indexSourceFileFullArgv(
+    CXIndexAction, CXClientData client_data, IndexerCallbacks *index_callbacks,
+    unsigned index_callbacks_size, unsigned index_options,
+    const char *source_filename, const char *const *command_line_args,
+    int num_command_line_args, struct CXUnsavedFile *unsaved_files,
+    unsigned num_unsaved_files, CXTranslationUnit *out_TU, unsigned TU_options);
+
+/**
+ * Index the given translation unit via callbacks implemented through
+ * #IndexerCallbacks.
+ *
+ * The order of callback invocations is not guaranteed to be the same as
+ * when indexing a source file. The high level order will be:
+ *
+ *   -Preprocessor callbacks invocations
+ *   -Declaration/reference callbacks invocations
+ *   -Diagnostic callback invocations
+ *
+ * The parameters are the same as #clang_indexSourceFile.
+ *
+ * \returns If there is a failure from which there is no recovery, returns
+ * non-zero, otherwise returns 0.
+ */
+CINDEX_LINKAGE int clang_indexTranslationUnit(
+    CXIndexAction, CXClientData client_data, IndexerCallbacks *index_callbacks,
+    unsigned index_callbacks_size, unsigned index_options, CXTranslationUnit);
+
+/**
+ * Retrieve the CXIdxFile, file, line, column, and offset represented by
+ * the given CXIdxLoc.
+ *
+ * If the location refers into a macro expansion, retrieves the
+ * location of the macro expansion and if it refers into a macro argument
+ * retrieves the location of the argument.
+ */
+CINDEX_LINKAGE void clang_indexLoc_getFileLocation(CXIdxLoc loc,
+                                                   CXIdxClientFile *indexFile,
+                                                   CXFile *file, unsigned *line,
+                                                   unsigned *column,
+                                                   unsigned *offset);
+
+/**
+ * Retrieve the CXSourceLocation represented by the given CXIdxLoc.
+ */
+CINDEX_LINKAGE
+CXSourceLocation clang_indexLoc_getCXSourceLocation(CXIdxLoc loc);
+
+/**
+ * Visitor invoked for each field found by a traversal.
+ *
+ * This visitor function will be invoked for each field found by
+ * \c clang_Type_visitFields. Its first argument is the cursor being
+ * visited, its second argument is the client data provided to
+ * \c clang_Type_visitFields.
+ *
+ * The visitor should return one of the \c CXVisitorResult values
+ * to direct \c clang_Type_visitFields.
+ */
+typedef enum CXVisitorResult (*CXFieldVisitor)(CXCursor C,
+                                               CXClientData client_data);
+
+/**
+ * Visit the fields of a particular type.
+ *
+ * This function visits all the direct fields of the given cursor,
+ * invoking the given \p visitor function with the cursors of each
+ * visited field. The traversal may be ended prematurely, if
+ * the visitor returns \c CXFieldVisit_Break.
+ *
+ * \param T the record type whose field may be visited.
+ *
+ * \param visitor the visitor function that will be invoked for each
+ * field of \p T.
+ *
+ * \param client_data pointer data supplied by the client, which will
+ * be passed to the visitor each time it is invoked.
+ *
+ * \returns a non-zero value if the traversal was terminated
+ * prematurely by the visitor returning \c CXFieldVisit_Break.
+ */
+CINDEX_LINKAGE unsigned clang_Type_visitFields(CXType T, CXFieldVisitor visitor,
+                                               CXClientData client_data);
+
+/**
+ * Visit the base classes of a type.
+ *
+ * This function visits all the direct base classes of a the given cursor,
+ * invoking the given \p visitor function with the cursors of each
+ * visited base. The traversal may be ended prematurely, if
+ * the visitor returns \c CXFieldVisit_Break.
+ *
+ * \param T the record type whose field may be visited.
+ *
+ * \param visitor the visitor function that will be invoked for each
+ * field of \p T.
+ *
+ * \param client_data pointer data supplied by the client, which will
+ * be passed to the visitor each time it is invoked.
+ *
+ * \returns a non-zero value if the traversal was terminated
+ * prematurely by the visitor returning \c CXFieldVisit_Break.
+ */
+CINDEX_LINKAGE unsigned clang_visitCXXBaseClasses(CXType T,
+                                                  CXFieldVisitor visitor,
+                                                  CXClientData client_data);
+
+/**
+ * Visit the class methods of a type.
+ *
+ * This function visits all the methods of the given cursor,
+ * invoking the given \p visitor function with the cursors of each
+ * visited method. The traversal may be ended prematurely, if
+ * the visitor returns \c CXFieldVisit_Break.
+ *
+ * \param T The record type whose field may be visited.
+ *
+ * \param visitor The visitor function that will be invoked for each
+ * field of \p T.
+ *
+ * \param client_data Pointer data supplied by the client, which will
+ * be passed to the visitor each time it is invoked.
+ *
+ * \returns A non-zero value if the traversal was terminated
+ * prematurely by the visitor returning \c CXFieldVisit_Break.
+ */
+CINDEX_LINKAGE unsigned clang_visitCXXMethods(CXType T, CXFieldVisitor visitor,
+                                              CXClientData client_data);
+
+/**
+ * Describes the kind of binary operators.
+ */
+enum CXBinaryOperatorKind {
+  /** This value describes cursors which are not binary operators. */
+  CXBinaryOperator_Invalid = 0,
+  /** C++ Pointer - to - member operator. */
+  CXBinaryOperator_PtrMemD = 1,
+  /** C++ Pointer - to - member operator. */
+  CXBinaryOperator_PtrMemI = 2,
+  /** Multiplication operator. */
+  CXBinaryOperator_Mul = 3,
+  /** Division operator. */
+  CXBinaryOperator_Div = 4,
+  /** Remainder operator. */
+  CXBinaryOperator_Rem = 5,
+  /** Addition operator. */
+  CXBinaryOperator_Add = 6,
+  /** Subtraction operator. */
+  CXBinaryOperator_Sub = 7,
+  /** Bitwise shift left operator. */
+  CXBinaryOperator_Shl = 8,
+  /** Bitwise shift right operator. */
+  CXBinaryOperator_Shr = 9,
+  /** C++ three-way comparison (spaceship) operator. */
+  CXBinaryOperator_Cmp = 10,
+  /** Less than operator. */
+  CXBinaryOperator_LT = 11,
+  /** Greater than operator. */
+  CXBinaryOperator_GT = 12,
+  /** Less or equal operator. */
+  CXBinaryOperator_LE = 13,
+  /** Greater or equal operator. */
+  CXBinaryOperator_GE = 14,
+  /** Equal operator. */
+  CXBinaryOperator_EQ = 15,
+  /** Not equal operator. */
+  CXBinaryOperator_NE = 16,
+  /** Bitwise AND operator. */
+  CXBinaryOperator_And = 17,
+  /** Bitwise XOR operator. */
+  CXBinaryOperator_Xor = 18,
+  /** Bitwise OR operator. */
+  CXBinaryOperator_Or = 19,
+  /** Logical AND operator. */
+  CXBinaryOperator_LAnd = 20,
+  /** Logical OR operator. */
+  CXBinaryOperator_LOr = 21,
+  /** Assignment operator. */
+  CXBinaryOperator_Assign = 22,
+  /** Multiplication assignment operator. */
+  CXBinaryOperator_MulAssign = 23,
+  /** Division assignment operator. */
+  CXBinaryOperator_DivAssign = 24,
+  /** Remainder assignment operator. */
+  CXBinaryOperator_RemAssign = 25,
+  /** Addition assignment operator. */
+  CXBinaryOperator_AddAssign = 26,
+  /** Subtraction assignment operator. */
+  CXBinaryOperator_SubAssign = 27,
+  /** Bitwise shift left assignment operator. */
+  CXBinaryOperator_ShlAssign = 28,
+  /** Bitwise shift right assignment operator. */
+  CXBinaryOperator_ShrAssign = 29,
+  /** Bitwise AND assignment operator. */
+  CXBinaryOperator_AndAssign = 30,
+  /** Bitwise XOR assignment operator. */
+  CXBinaryOperator_XorAssign = 31,
+  /** Bitwise OR assignment operator. */
+  CXBinaryOperator_OrAssign = 32,
+  /** Comma operator. */
+  CXBinaryOperator_Comma = 33,
+  CXBinaryOperator_Last = CXBinaryOperator_Comma
+};
+
+/**
+ * Retrieve the spelling of a given CXBinaryOperatorKind.
+ */
+CINDEX_LINKAGE CXString
+clang_getBinaryOperatorKindSpelling(enum CXBinaryOperatorKind kind);
+
+/**
+ * Retrieve the binary operator kind of this cursor.
+ *
+ * If this cursor is not a binary operator then returns Invalid.
+ */
+CINDEX_LINKAGE enum CXBinaryOperatorKind
+clang_getCursorBinaryOperatorKind(CXCursor cursor);
+
+/**
+ * Describes the kind of unary operators.
+ */
+enum CXUnaryOperatorKind {
+  /** This value describes cursors which are not unary operators. */
+  CXUnaryOperator_Invalid,
+  /** Postfix increment operator. */
+  CXUnaryOperator_PostInc,
+  /** Postfix decrement operator. */
+  CXUnaryOperator_PostDec,
+  /** Prefix increment operator. */
+  CXUnaryOperator_PreInc,
+  /** Prefix decrement operator. */
+  CXUnaryOperator_PreDec,
+  /** Address of operator. */
+  CXUnaryOperator_AddrOf,
+  /** Dereference operator. */
+  CXUnaryOperator_Deref,
+  /** Plus operator. */
+  CXUnaryOperator_Plus,
+  /** Minus operator. */
+  CXUnaryOperator_Minus,
+  /** Not operator. */
+  CXUnaryOperator_Not,
+  /** LNot operator. */
+  CXUnaryOperator_LNot,
+  /** "__real expr" operator. */
+  CXUnaryOperator_Real,
+  /** "__imag expr" operator. */
+  CXUnaryOperator_Imag,
+  /** __extension__ marker operator. */
+  CXUnaryOperator_Extension,
+  /** C++ co_await operator. */
+  CXUnaryOperator_Coawait
+};
+
+/**
+ * Retrieve the spelling of a given CXUnaryOperatorKind.
+ */
+CINDEX_LINKAGE CXString
+clang_getUnaryOperatorKindSpelling(enum CXUnaryOperatorKind kind);
+
+/**
+ * Retrieve the unary operator kind of this cursor.
+ *
+ * If this cursor is not a unary operator then returns Invalid.
+ */
+CINDEX_LINKAGE enum CXUnaryOperatorKind
+clang_getCursorUnaryOperatorKind(CXCursor cursor);
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/* CINDEX_DEPRECATED - disabled to silence MSVC deprecation warnings */
+typedef void *CXRemapping;
+
+CINDEX_DEPRECATED CINDEX_LINKAGE CXRemapping clang_getRemappings(const char *);
+
+CINDEX_DEPRECATED CINDEX_LINKAGE CXRemapping
+clang_getRemappingsFromFileList(const char **, unsigned);
+
+CINDEX_DEPRECATED CINDEX_LINKAGE unsigned clang_remap_getNumFiles(CXRemapping);
+
+CINDEX_DEPRECATED CINDEX_LINKAGE void
+clang_remap_getFilenames(CXRemapping, unsigned, CXString *, CXString *);
+
+CINDEX_DEPRECATED CINDEX_LINKAGE void clang_remap_dispose(CXRemapping);
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif

--- a/examples/clang-c/LICENSE.TXT
+++ b/examples/clang-c/LICENSE.TXT
@@ -1,0 +1,278 @@
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2007-2019 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.

--- a/examples/clang-c/Platform.h
+++ b/examples/clang-c/Platform.h
@@ -1,0 +1,53 @@
+/*===-- clang-c/Platform.h - C Index platform decls   -------------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header provides platform specific macros (dllimport, deprecated, ...) *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_PLATFORM_H
+#define LLVM_CLANG_C_PLATFORM_H
+
+#include "clang-c/ExternC.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/* Windows DLL import/export. */
+#ifndef CINDEX_NO_EXPORTS
+  #define CINDEX_EXPORTS
+#endif
+#if defined(_WIN32) || defined(__CYGWIN__)
+  #ifdef CINDEX_EXPORTS
+    #ifdef _CINDEX_LIB_
+      #define CINDEX_LINKAGE __declspec(dllexport)
+    #else
+      #define CINDEX_LINKAGE __declspec(dllimport)
+    #endif
+  #endif
+#elif defined(CINDEX_EXPORTS) && defined(__GNUC__)
+  #define CINDEX_LINKAGE __attribute__((visibility("default")))
+#endif
+
+#ifndef CINDEX_LINKAGE
+  #define CINDEX_LINKAGE
+#endif
+
+#ifdef __GNUC__
+  #define CINDEX_DEPRECATED __attribute__((deprecated))
+#else
+  #ifdef _MSC_VER
+    #define CINDEX_DEPRECATED __declspec(deprecated)
+  #else
+    #define CINDEX_DEPRECATED
+  #endif
+#endif
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif

--- a/examples/clang-c/Rewrite.h
+++ b/examples/clang-c/Rewrite.h
@@ -1,0 +1,63 @@
+/*===-- clang-c/Rewrite.h - C CXRewriter   --------------------------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CLANG_C_REWRITE_H
+#define LLVM_CLANG_C_REWRITE_H
+
+#include "clang-c/CXString.h"
+#include "clang-c/ExternC.h"
+#include "clang-c/Index.h"
+#include "clang-c/Platform.h"
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+typedef void *CXRewriter;
+
+/**
+ * Create CXRewriter.
+ */
+CINDEX_LINKAGE CXRewriter clang_CXRewriter_create(CXTranslationUnit TU);
+
+/**
+ * Insert the specified string at the specified location in the original buffer.
+ */
+CINDEX_LINKAGE void clang_CXRewriter_insertTextBefore(CXRewriter Rew, CXSourceLocation Loc,
+                                           const char *Insert);
+
+/**
+ * Replace the specified range of characters in the input with the specified
+ * replacement.
+ */
+CINDEX_LINKAGE void clang_CXRewriter_replaceText(CXRewriter Rew, CXSourceRange ToBeReplaced,
+                                      const char *Replacement);
+
+/**
+ * Remove the specified range.
+ */
+CINDEX_LINKAGE void clang_CXRewriter_removeText(CXRewriter Rew, CXSourceRange ToBeRemoved);
+
+/**
+ * Save all changed files to disk.
+ * Returns 1 if any files were not saved successfully, returns 0 otherwise.
+ */
+CINDEX_LINKAGE int clang_CXRewriter_overwriteChangedFiles(CXRewriter Rew);
+
+/**
+ * Write out rewritten version of the main file to stdout.
+ */
+CINDEX_LINKAGE void clang_CXRewriter_writeMainFileToStdOut(CXRewriter Rew);
+
+/**
+ * Free the given CXRewriter.
+ */
+CINDEX_LINKAGE void clang_CXRewriter_dispose(CXRewriter Rew);
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif

--- a/examples/clang-c/clang.h
+++ b/examples/clang-c/clang.h
@@ -1,0 +1,15 @@
+#ifndef CLANG_INCLUDE
+#define CLANG_INCLUDE
+
+#include "clang-c/Index.h"
+#include "clang-c/CXDiagnostic.h"
+#include "clang-c/CXCompilationDatabase.h"
+#include "clang-c/BuildSystem.h"
+#include "clang-c/CXFile.h"
+#include "clang-c/CXSourceLocation.h"
+#include "clang-c/Documentation.h"
+#include "clang-c/FatalErrorHandler.h"
+#include "clang-c/Platform.h"
+#include "clang-c/Rewrite.h"
+
+#endif

--- a/examples/clang.c3
+++ b/examples/clang.c3
@@ -1,5 +1,5 @@
 import bindgen;
-import std::ascii, std::io;
+import std::core::ascii, std::io;
 
 fn void main(String[] args)
 {
@@ -19,10 +19,10 @@ fn void main(String[] args)
 		.type = &trans_type,
 		.variable = &trans_var,
 		.func = fn String(String str, Allocator alloc) =>
-			str.strip("clang_").pascal_to_camel(alloc),
+			str.strip_prefix("clang_").pascal_to_camel(alloc),
 		.constant = &trans_const,
 		.enum_field = fn String(String str, Allocator alloc) =>
-			str.strip("CX").camel_to_screaming(alloc),
+			str.strip_prefix("CX").pascal_to_screaming(alloc),
 		.func_macro = fn String(String str, Allocator alloc) => 
 			"".copy(alloc),
 	};

--- a/examples/clang.c3
+++ b/examples/clang.c3
@@ -11,6 +11,7 @@ fn void main(String[] args)
 		.module_name = "clang",
 		.imports = { "libc" },
 		.skip_errors = false,
+		.generate_docs = true,
 		.include_file = &include_file,
 	};
 
@@ -33,7 +34,7 @@ fn String trans_type(String str, Allocator alloc)
 {
 	switch (str)
 	{
-		case "time_t": return "Time_t".copy(alloc);
+		case "const char*": return "ZString".copy(alloc);
 	}
 
 	return str.copy(alloc);

--- a/examples/clang.c3
+++ b/examples/clang.c3
@@ -1,0 +1,64 @@
+import bindgen;
+import std::ascii, std::io;
+
+fn void main(String[] args)
+{
+	String out = args.len > 1 ? args[1] : "";
+
+	BGOptions opts = {
+		.out_name = out,
+		.clang_args = { "-I./examples" },
+		.module_name = "clang",
+		.imports = { "libc" },
+		.skip_errors = false,
+		.include_file = &include_file,
+	};
+
+	BGTransCallbacks trans_fns = {
+		.type = &trans_type,
+		.variable = &trans_var,
+		.func = fn String(String str, Allocator alloc) =>
+			str.strip("clang_").pascal_to_camel(alloc),
+		.constant = &trans_const,
+		.enum_field = fn String(String str, Allocator alloc) =>
+			str.strip("CX").camel_to_screaming(alloc),
+		.func_macro = fn String(String str, Allocator alloc) => 
+			"".copy(alloc),
+	};
+
+	bg::translate_header("./examples/clang-c/clang.h", opts, trans_fns)!!;
+}
+
+fn String trans_type(String str, Allocator alloc)
+{
+	switch (str)
+	{
+		case "time_t": return "Time_t".copy(alloc);
+	}
+
+	return str.copy(alloc);
+}
+
+fn String trans_var(String str, Allocator alloc) {
+
+	switch (str)
+	{
+		case "Module":
+		case "module": 
+			return "mod".copy(alloc);
+		case "fn": return "func".copy(alloc);
+		default: break;
+	}
+
+	return str.camel_to_snake(alloc);
+}
+
+// seems like there is no global constant needed
+fn String trans_const(String name, Allocator alloc) {
+	return "".copy(alloc);
+}
+
+fn bool include_file(String name)
+{
+	return name.contains("clang");
+}

--- a/project.json
+++ b/project.json
@@ -10,6 +10,11 @@
       "sources" : [ "examples/sandbox.c3" ],
     },
 
+    "clang": {
+      "type": "executable",
+      "sources": ["examples/clang.c3"]
+    },
+
     "dummy" : {
       "type" : "executable",
       "sources" : [ "examples/dummy.c3" ],

--- a/tests/bgtest_lib.c3
+++ b/tests/bgtest_lib.c3
@@ -3,7 +3,7 @@ module bgtest;
 import bgimpl,
        clang,
        std::io,
-       std::collections::elastic_array,
+       std::collections::fixedlist,
        std::collections::list;
 
 
@@ -39,7 +39,7 @@ fn CXCursor[]? parse(
   // Create temp header
   Path tmp = path::temp_directory(tmem)!!;
   tmp = tmp.tappend(HEADER_NAME)!!;
-  file::save(tmp.str_view(), code)!!;
+  file::save(tmp, code)!!;
 
   // Get args
   List{ZString} args_list;
@@ -53,7 +53,7 @@ fn CXCursor[]? parse(
   // Parse file
   CXIndex index = clang::createIndex(0, 0);
   defer clang::disposeIndex(index);
-  CXTranslationUnit tu = clang::parseTranslationUnit(index, (ZString)tmp.str_view(), args.ptr, args.len, null, 0, (CUInt)PARSE_FLAGS);
+  CXTranslationUnit tu = clang::parseTranslationUnit(index, (ZString)tmp, args.ptr, args.len, null, 0, (CUInt)PARSE_FLAGS);
   
   // Check the parse result
   if (tu == null) return PARSE_FAILURE~;
@@ -169,5 +169,5 @@ fn void cleanup() @local @finalizer
 }
 
 
-ElasticArray{CXTranslationUnit, TUS_CAPACITY} translation_units @local;
+FixedList{CXTranslationUnit, TUS_CAPACITY} translation_units @local;
 

--- a/tests/bgtest_lib.c3
+++ b/tests/bgtest_lib.c3
@@ -27,14 +27,14 @@ fn CXCursor[]? parse(
   Allocator alloc, 
   char[] code,
   ZString[] extra_args = {},
-  CXDiagnosticSeverity min_severity = clang::DIAGNOSTIC_ERROR,
+  CXDiagnosticSeverity min_severity = DIAGNOSTIC_ERROR,
   bool quiet = false)
   => @pool()
 {
   const PARSE_FLAGS = 
-    clang::TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD |
-    clang::TRANSLATION_UNIT_SKIP_FUNCTION_BODIES |
-    clang::TRANSLATION_UNIT_KEEP_GOING;
+    CXTranslationUnit_Flags.TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD |
+    CXTranslationUnit_Flags.TRANSLATION_UNIT_SKIP_FUNCTION_BODIES |
+    CXTranslationUnit_Flags.TRANSLATION_UNIT_KEEP_GOING;
 
   // Create temp header
   Path tmp = path::temp_directory(tmem)!!;
@@ -53,7 +53,7 @@ fn CXCursor[]? parse(
   // Parse file
   CXIndex index = clang::createIndex(0, 0);
   defer clang::disposeIndex(index);
-  CXTranslationUnit tu = clang::parseTranslationUnit(index, (ZString)tmp.str_view(), args.ptr, args.len, null, 0, PARSE_FLAGS);
+  CXTranslationUnit tu = clang::parseTranslationUnit(index, (ZString)tmp.str_view(), args.ptr, args.len, null, 0, (CUInt)PARSE_FLAGS);
   
   // Check the parse result
   if (tu == null) return PARSE_FAILURE~;
@@ -99,14 +99,14 @@ fn CXCursor[]? parse(
     // If cursor_file is null, it might be a macro included by a compiler
     CXFile cursor_file;
     clang::getExpansionLocation(clang::getCursorLocation(cursor), &cursor_file, null, null, null);
-    if (cursor_file == null) return clang::CHILD_VISIT_CONTINUE;
+    if (cursor_file == null) return CHILD_VISIT_CONTINUE;
 
     // Skip macro expansions
-    if (clang::getCursorKind(cursor) == clang::CURSOR_MACRO_EXPANSION) return clang::CHILD_VISIT_CONTINUE;
+    if (clang::getCursorKind(cursor) == CURSOR_MACRO_EXPANSION) return CHILD_VISIT_CONTINUE;
 
     List{CXCursor}* cursors = (List{CXCursor}*) client;
     cursors.push(cursor);
-    return clang::CHILD_VISIT_CONTINUE;
+    return CHILD_VISIT_CONTINUE;
   }, (CXClientData) &cursors);
 
   return cursors.to_array(alloc);
@@ -121,10 +121,10 @@ fn CXType[] get_types(
   CXCursor[] cursors) 
   @inline
 {
-  CXType[] res = allocator::alloc_array(alloc, CXType, cursors.len);
+  CXType[] res = alloc::alloc_array(alloc, CXType, cursors.len);
   foreach (i, c : cursors) {
     switch (clang::getCursorKind(c)) {
-      case clang::CURSOR_TYPEDEF_DECL:
+      case CURSOR_TYPEDEF_DECL:
         res[i] = clang::getTypedefDeclUnderlyingType(c);
 
       default:

--- a/tests/unit/data_methods.c3
+++ b/tests/unit/data_methods.c3
@@ -4,7 +4,7 @@ import std::io;
 
 
 <*
- @require WriteAttrs.membersof.len == 2 : "Test is out of date"
+ @require WriteAttrs::members.len == 2 : "Test is out of date"
 *>
 fn void test_WriteAttrs_to_format()
 {

--- a/tests/unit/misc.c3
+++ b/tests/unit/misc.c3
@@ -79,7 +79,7 @@ fn void test_is_type_incomplete()
   CXCursor[] cursors = bgtest::parse(tmem, SUITE_TRUE)!!;
   CXType[] types = bgtest::get_types(tmem, cursors);
   foreach (t : types) {
-    CXType base = t.kind == clang::TYPE_POINTER ? clang::getPointeeType(t) : t;
+    CXType base = t.kind == TYPE_POINTER ? clang::getPointeeType(t) : t;
     assert( isTypeIncomplete(base) );
   }
 
@@ -115,7 +115,7 @@ fn void test_get_true_cursor_extent()
 
   usz i;
   CXCursor[] cursors = bgtest::parse(tmem, SUITE)!!;
-  CXTranslationUnit tu = clang::getTranslationUnit_Cursor(cursors[0]);
+  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursors[0]);
   foreach (c : cursors) {
     CXToken* tokens_ptr; uint tokens_len;
     clang::tokenize(tu, getTrueCursorExtent(c), &tokens_ptr, &tokens_len);

--- a/tests/unit/writers.c3
+++ b/tests/unit/writers.c3
@@ -3,298 +3,298 @@ module bgimpl::wter @test;
 import std::io;
 
 macro @reset(
-  DString #out, 
-  WriteState #state) 
-  @local
+	DString #out, 
+	WriteState #state) 
+	@local
 {
-  #out.clear();
-  #state = {};
+	#out.clear();
+	#state = {};
 }
 
 
 fn void test_typedef_alias()
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nalias MyType = int;\n";
-    
-    typedefAlias(&out, &state, "MyType", "int");
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nalias MyType = int;\n";
+		
+		typedefAlias(&out, &state, "MyType", "int");
 
-    assert( state.kind == ALIAS );
-    assert( out.str_view() == EXPECTED );
-  }
-  
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nalias MyType @private = int;\n";
+		assert( state.kind == ALIAS );
+		assert( out.str_view() == EXPECTED );
+	}
+	
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nalias MyType @private = int;\n";
 
-    WriteAttrs attrs = { .private = true };
-    typedefAlias(&out, &state, "MyType", "int", attrs);
+		WriteAttrs attrs = { .private = true };
+		typedefAlias(&out, &state, "MyType", "int", attrs);
 
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 
 fn void test_typedef_distinct()
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\ntypedef MyType = int;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\ntypedef MyType = int;\n";
 
-    typedefDistinct(&out, &state, "MyType", "int");
+		typedefDistinct(&out, &state, "MyType", "int");
 
-    assert( state.kind == TYPEDEF );
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( state.kind == TYPEDEF );
+		assert( out.str_view() == EXPECTED );
+	}
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\ntypedef MyType @private = int;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\ntypedef MyType @private = int;\n";
 
-    WriteAttrs attrs = { .private = true };
-    typedefDistinct(&out, &state, "MyType", "int", attrs);
+		WriteAttrs attrs = { .private = true };
+		typedefDistinct(&out, &state, "MyType", "int", attrs);
 
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 
 fn void test_typedef_func()
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nalias FnType = fn int();\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nalias FnType = fn int();\n";
 
-    typedefFunc(&out, &state, "FnType", "int", {});
+		typedefFunc(&out, &state, "FnType", "int", {});
 
-    assert( state.kind == ALIAS );
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( state.kind == ALIAS );
+		assert( out.str_view() == EXPECTED );
+	}
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nalias FnType @private = fn int(\n  double,\n  float b);\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nalias FnType @private = fn int(\n\tdouble,\n\tfloat b);\n";
 
-    VarDecl[] params = { {"double", ""}, {"float", "b"} };
-    WriteAttrs attrs = { .private = true, };
-    typedefFunc(&out, &state, "FnType", "int", params, attrs);
+		VarDecl[] params = { {"double", ""}, {"float", "b"} };
+		WriteAttrs attrs = { .private = true, };
+		typedefFunc(&out, &state, "FnType", "int", params, attrs);
 
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 
 fn void test_const_decl()
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nconst int NAME = 2;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nconst int NAME = 2;\n";
 
-    constDecl(&out, &state, "int", "NAME", "2");
+		constDecl(&out, &state, "int", "NAME", "2");
 
-    assert( state.kind == CONST );
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( state.kind == CONST );
+		assert( out.str_view() == EXPECTED );
+	}
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "const int NAME @private = 0x123;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "const int NAME @private = 0x123;\n";
 
-    state.kind = ENUM;
-    WriteAttrs attrs = { .private = true };
-    constDecl(&out, &state, "int", "NAME", "0x123", attrs);
+		state.kind = ENUM;
+		WriteAttrs attrs = { .private = true };
+		constDecl(&out, &state, "int", "NAME", "0x123", attrs);
 
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( out.str_view() == EXPECTED );
+	}
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "const NAME @if(true) = 2.0f;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "const NAME @if(true) = 2.0f;\n";
 
-    state.kind = CONST;
-    WriteAttrs attrs = { .if_condition = "true" };
-    constDecl(&out, &state, "", "NAME", "2.0f", attrs);
+		state.kind = CONST;
+		WriteAttrs attrs = { .if_condition = "true" };
+		constDecl(&out, &state, "", "NAME", "2.0f", attrs);
 
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 
 fn void test_var_decl()
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nint name = 23;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nint name = 23;\n";
 
-    varDecl(&out, &state, "int", "name", "23");
+		varDecl(&out, &state, "int", "name", "23");
 
-    assert( state.kind == VAR );
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( state.kind == VAR );
+		assert( out.str_view() == EXPECTED );
+	}
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nint name @private;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nint name @private;\n";
 
-    state.kind = ENUM;
-    WriteAttrs attrs = { .private = true };
-    varDecl(&out, &state, "int", "name", "", attrs);
+		state.kind = ENUM;
+		WriteAttrs attrs = { .private = true };
+		varDecl(&out, &state, "int", "name", "", "", attrs);
 
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 
 fn void test_enum_decl()
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nconstdef En : int {\n\n}\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nconstdef En : int {\n\n}\n";
 
-    enumDecl(&out, &state, {}, "En", "int");
+		enumDecl(&out, &state, {}, "En", "int");
 
-    assert( state.kind == ENUM );
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( state.kind == ENUM );
+		assert( out.str_view() == EXPECTED );
+	}
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nconstdef En @private : int {\n\n}\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nconstdef En @private : int {\n\n}\n";
 
-    WriteAttrs attrs = { .private = true };
-    enumDecl(&out, &state, {}, "En", "int", attrs);
+		WriteAttrs attrs = { .private = true };
+		enumDecl(&out, &state, {}, "En", "int", "", attrs);
 
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 fn void test_func() 
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nextern fn char* f()\n@cname(\"F\");\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nextern fn char* f()\n@cname(\"F\");\n";
 
-    func(&out, &state, {}, "char*", "F", "f");
+		func(&out, &state, {}, "char*", "F", "f");
 
-    assert( state.kind == FUNC );
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( state.kind == FUNC );
+		assert( out.str_view() == EXPECTED );
+	}
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nextern fn char** some_func(\n  int b,\n  double)\n@cname(\"SomeFunc\") @private;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nextern fn char** some_func(\n\tint b,\n\tdouble)\n@cname(\"SomeFunc\") @private;\n";
 
-    VarDecl[] params = { {"int", "b"}, {"double", ""} };
-    WriteAttrs attrs = { .private = true };
-    func(&out, &state, params, "char**", "SomeFunc", "some_func", attrs);
+		VarDecl[] params = { {"int", "b"}, {"double", ""} };
+		WriteAttrs attrs = { .private = true };
+		func(&out, &state, params, "char**", "SomeFunc", "some_func", "", attrs);
 
-    io::printfn("<%s>", out);
-    assert( out.str_view() == EXPECTED );
-  }
+		io::printfn("<%s>", out);
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 
 fn void test_func_macro()
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nmacro @just_int() {}\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nmacro @just_int() {}\n";
 
-    funcMacro(&out, &state, {}, "just_int", "");
+		funcMacro(&out, &state, {}, "just_int", "");
 
-    assert( state.kind == MACRO );
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( state.kind == MACRO );
+		assert( out.str_view() == EXPECTED );
+	}
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nmacro @add(#one, #two) @private {\n  return #one + #two;\n}\n";
-      
-    String[] params = { "one", "two" };
-    WriteAttrs attrs = { .private = true };
-    funcMacro(&out, &state, params, "add", "return #one + #two;", attrs);
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nmacro @add(#one, #two) @private {\n\treturn #one + #two;\n}\n";
+		
+		String[] params = { "one", "two" };
+		WriteAttrs attrs = { .private = true };
+		funcMacro(&out, &state, params, "add", "return #one + #two;", attrs);
 
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 
 fn void test_module_head()
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nmodule hello;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nmodule hello;\n";
 
-    moduleHead(&out, &state, "hello");
+		moduleHead(&out, &state, "hello");
 
-    assert( state.kind == MODULE );
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( state.kind == MODULE );
+		assert( out.str_view() == EXPECTED );
+	}
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "\nmodule a @if(COND);\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "\nmodule a @if(COND);\n";
 
-    WriteAttrs attrs = { .if_condition = "COND" };
-    moduleHead(&out, &state, "a", attrs);
+		WriteAttrs attrs = { .if_condition = "COND" };
+		moduleHead(&out, &state, "a", attrs);
 
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 
 fn void test_import_module()
 {
-  WriteState state;
-  DString out;
-  out.tinit();
+	WriteState state;
+	DString out;
+	out.tinit();
 
-  {
-    defer @reset(out, state);
-    const EXPECTED = "import m::mm;\n";
+	{
+		defer @reset(out, state);
+		const EXPECTED = "import m::mm;\n";
 
-    importModule(&out, &state, "m::mm");
+		importModule(&out, &state, "m::mm");
 
-    assert( state.kind == IMPORT );
-    assert( out.str_view() == EXPECTED );
-  }
+		assert( state.kind == IMPORT );
+		assert( out.str_view() == EXPECTED );
+	}
 }
 
 fn void test_struct_decl()

--- a/tests/unit/writers.c3
+++ b/tests/unit/writers.c3
@@ -174,9 +174,9 @@ fn void test_enum_decl()
 
   {
     defer @reset(out, state);
-    const EXPECTED = "\ntypedef En = inline int;\n";
+    const EXPECTED = "\nconstdef En : int {\n\n}\n";
 
-    enumDecl(&out, &state, "En", "int");
+    enumDecl(&out, &state, {}, "En", "int");
 
     assert( state.kind == ENUM );
     assert( out.str_view() == EXPECTED );
@@ -184,10 +184,10 @@ fn void test_enum_decl()
 
   {
     defer @reset(out, state);
-    const EXPECTED = "\ntypedef En @private = inline int;\n";
+    const EXPECTED = "\nconstdef En @private : int {\n\n}\n";
 
     WriteAttrs attrs = { .private = true };
-    enumDecl(&out, &state, "En", "int", attrs);
+    enumDecl(&out, &state, {}, "En", "int", attrs);
 
     assert( out.str_view() == EXPECTED );
   }
@@ -201,7 +201,7 @@ fn void test_func()
 
   {
     defer @reset(out, state);
-    const EXPECTED = "\nfn char* f()\n@extern(\"F\");\n";
+    const EXPECTED = "\nextern fn char* f()\n@cname(\"F\");\n";
 
     func(&out, &state, {}, "char*", "F", "f");
 
@@ -211,7 +211,7 @@ fn void test_func()
 
   {
     defer @reset(out, state);
-    const EXPECTED = "\nfn char** some_func(\n  int b,\n  double)\n@extern(\"SomeFunc\") @private;\n";
+    const EXPECTED = "\nextern fn char** some_func(\n  int b,\n  double)\n@cname(\"SomeFunc\") @private;\n";
 
     VarDecl[] params = { {"int", "b"}, {"double", ""} };
     WriteAttrs attrs = { .private = true };


### PR DESCRIPTION
multiple fixes and refactors to support 0.8.0

its so many lines changed/added bacause of fixing indenting everywhere from spaces to tabs (\t)
aswell as from all comments in clang.c3i & libclang headers

- docs / comment support
- use '\t' instead of spaces
- use constdef instead of global constants
- replace usz -> sz
- replace @extern with @cname with extern
- libclang example target, to generate bindings