### PR TITLE
update to c3 0.8.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 
+.vscode/
+
 build/
 .direnv/
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ For better user experience there is additional API for string transformations, w
 
 There are several examples located in `examples` directory. To check them out, run the following command in root directory of the repository:
 
+- LibClang bindings: `c3c run clang -- ./build/clang.c3i`
 - Sandbox to try out library: `c3c run sandbox` - it will write to stdout
 - My dummy: `c3c run dummy -- ./build/dummy.c3i` or `c3c run dummy` - it will print output to stdout
 - Vulkan: `c3c run vulkan -- ./build/vulkan.c3i`
@@ -98,6 +99,7 @@ Join and contact me in [C3 discord channel](https://discord.com/channels/6503459
 
 ## TODO
 
+- Comments: convert attributes
 - Fix multiple definitions for macros
 - Inline definition of records and enums inside of function parameters
 - Allow user to write any attributes on an entity based on WriteAttrs

--- a/bindgen.c3l/bindgen.c3i
+++ b/bindgen.c3l/bindgen.c3i
@@ -29,7 +29,7 @@ extern fn void? translate_header(
   BGOptions         opts = {},
   BGTransCallbacks  trans_callbacks = {},
   BGGenCallbacks    gen_callbacks = {})
-@extern("bg_translate_header");
+@cname("bg_translate_header");
 
 
 <*
@@ -44,6 +44,7 @@ extern fn void? translate_header(
                 "This option is a function which returns true if we want to '#include' file passed to 'name' parameter." 
                 "Note that 'name' is either relative or absolute path to a file"
  skip_errors  : "Whether to skip clang's parse errors. Note, that '<...> file not found' errors are skipped always and not controlled with this flag"
+ generate_docs  : "Whether to retrive docs and translate to C3 docs"
 *>
 struct BGOptions
 {
@@ -58,6 +59,7 @@ struct BGOptions
   {
     bool skip_errors;
     bool no_verbose;
+    bool generate_docs;
   }
 }
 
@@ -77,7 +79,8 @@ struct BGTransCallbacks
 {
   BGTransFn func;
   BGTransFn type;
-  BGTransFn variable; 
+  BGTransFn variable;
+  BGTransFn enum_field;
   BGTransFn constant;
   BGTransFn func_macro;
 }
@@ -260,28 +263,28 @@ struct BGModuleWrap
 *>
 module bindgen::bgstr;
 
-fn bool is_between(String name, String bound_1, String bound_2) @extern("bgstr_is_between");
+fn bool is_between(String name, String bound_1, String bound_2) @cname("bgstr_is_between");
 
-fn String snake_to_camel(String str, Allocator alloc) @extern("bgstr_snake_to_camel");
-fn String snake_to_pascal(String str, Allocator alloc) @extern("bgstr_snake_to_pascal");
-fn String snake_to_screaming(String str, Allocator alloc) @extern("bgstr_snake_to_screaming");
+fn String snake_to_camel(String str, Allocator alloc) @cname("bgstr_snake_to_camel");
+fn String snake_to_pascal(String str, Allocator alloc) @cname("bgstr_snake_to_pascal");
+fn String snake_to_screaming(String str, Allocator alloc) @cname("bgstr_snake_to_screaming");
 
-fn String pascal_to_screaming(String str, Allocator alloc) @extern("bgstr_pascal_to_screaming");
-fn String pascal_to_snake(String str, Allocator alloc) @extern("bgstr_pascal_to_snake");
-fn String pascal_to_camel(String str, Allocator alloc) @extern("bgstr_pascal_to_camel");
+fn String pascal_to_screaming(String str, Allocator alloc) @cname("bgstr_pascal_to_screaming");
+fn String pascal_to_snake(String str, Allocator alloc) @cname("bgstr_pascal_to_snake");
+fn String pascal_to_camel(String str, Allocator alloc) @cname("bgstr_pascal_to_camel");
 
-fn String camel_to_screaming(String str, Allocator alloc) @extern("bgstr_camel_to_screaming");
-fn String camel_to_snake(String str, Allocator alloc) @extern("bgstr_camel_to_snake");
-fn String camel_to_pascal(String str, Allocator alloc) @extern("bgstr_camel_to_pascal");
+fn String camel_to_screaming(String str, Allocator alloc) @cname("bgstr_camel_to_screaming");
+fn String camel_to_snake(String str, Allocator alloc) @cname("bgstr_camel_to_snake");
+fn String camel_to_pascal(String str, Allocator alloc) @cname("bgstr_camel_to_pascal");
 
-fn String screaming_to_snake(String str, Allocator alloc) @extern("bgstr_screaming_to_snake");
-fn String screaming_to_camel(String str, Allocator alloc) @extern("bgstr_screaming_to_camel");
-fn String screaming_to_pascal(String str, Allocator alloc) @extern("bgstr_screaming_to_pascal");
+fn String screaming_to_snake(String str, Allocator alloc) @cname("bgstr_screaming_to_snake");
+fn String screaming_to_camel(String str, Allocator alloc) @cname("bgstr_screaming_to_camel");
+fn String screaming_to_pascal(String str, Allocator alloc) @cname("bgstr_screaming_to_pascal");
 
-fn String mixed_to_camel(String str, Allocator alloc) @extern("bgstr_mixed_to_camel");
-fn String mixed_to_screaming(String str, Allocator alloc) @extern("bgstr_mixed_to_screaming");
-fn String mixed_to_snake(String str, Allocator alloc) @extern("bgstr_mixed_to_snake");
-fn String mixed_to_pascal(String str, Allocator alloc) @extern("bgstr_mixed_to_pascal");
+fn String mixed_to_camel(String str, Allocator alloc) @cname("bgstr_mixed_to_camel");
+fn String mixed_to_screaming(String str, Allocator alloc) @cname("bgstr_mixed_to_screaming");
+fn String mixed_to_snake(String str, Allocator alloc) @cname("bgstr_mixed_to_snake");
+fn String mixed_to_pascal(String str, Allocator alloc) @cname("bgstr_mixed_to_pascal");
 
 macro bool String.is_between(String str, String a, String b) => is_between(str, a, b);
 

--- a/bindgen.c3l/src/bg.c3
+++ b/bindgen.c3l/src/bg.c3
@@ -39,10 +39,7 @@ fn void? translateHeader(
   if (opts.out_name != "") @pool() {
     err::warn(opts.no_verbose, "BGOptions.out_name is deprecated in favour of BGOptions.out_file");
 
-    Path out_path = { 
-      .path_string = opts.out_name,
-      .env = path::DEFAULT_ENV,
-    };
+    Path out_path = path::tnew(opts.out_name)!;
 
     if (path::is_dir(out_path)) {
       err::erro("The output name you've provided is an existing directory. Please provide a name of a file I should write to");
@@ -50,11 +47,7 @@ fn void? translateHeader(
     }
 
     // If there is no parent, we are in root
-    Path out_parent = out_path.parent() ?? {
-      .path_string = "/",
-      .env = path::DEFAULT_ENV,
-    };
-
+    Path out_parent = out_path.parent() ?? path::tnew(string::tformat("%s", path::PREFERRED_SEPARATOR))!;
     // Create missing directories on the path
     path::mkdir(out_parent, recursive: true)!!;
 
@@ -88,12 +81,12 @@ fn void? translateHeader(
   }
 
   CXTranslationUnit tu;
-  CXErrorCode code = clang::parseTranslationUnit2(index, (ZString) header_name, cargs.ptr, cargs.len, null, 0, bgimpl::TRANSLATION_UNIT_PARSE_FLAGS, &tu);
+  CXErrorCode code = clang::parseTranslationUnit2(index, (ZString)header_name, cargs.ptr, cargs.len, null, 0, (uint)bgimpl::TRANSLATION_UNIT_PARSE_FLAGS, &tu);
   checkCode(code)!;
   defer clang::disposeTranslationUnit(tu);
 
   // Print diagnostics
-  usz severe_count = runDiagnostics(tu, header_name, clang::DIAGNOSTIC_ERROR);
+  sz severe_count = runDiagnostics(tu, header_name, DIAGNOSTIC_ERROR);
   if (severe_count > 0 && !opts.skip_errors) return bg::CLANG_PARSE_ERROR~;
 
   GlobalVisitData visit_data = {
@@ -106,8 +99,9 @@ fn void? translateHeader(
     .cxfile = clang::getFile(tu, (ZString)header_name),
 
     .no_verbose = opts.no_verbose,
+    .use_docs = opts.generate_docs
   };
-  
+
   // TODO: also free Strings under types_table
   visit_data.types_table.init(mem);
   defer visit_data.types_table.free();
@@ -140,7 +134,7 @@ fn void? translateHeader(
  @param ignore_file_not_found : "Whether to ignore file not found error in diagnostics"
  @return                        "Number of severe diagnostics"
 *>
-fn usz runDiagnostics(
+fn sz runDiagnostics(
   CXTranslationUnit tu,
   String header_name,
   CXDiagnosticSeverity min_severity,
@@ -148,7 +142,7 @@ fn usz runDiagnostics(
   @inline
 {
   CUInt diagnostics_count = clang::getNumDiagnostics(tu);
-  usz severe_count;
+  sz severe_count;
   for (CUInt i; i < diagnostics_count; ++i) {
     CXDiagnostic diag = clang::getDiagnostic(tu, i); 
     defer clang::disposeDiagnostic(diag);
@@ -181,23 +175,23 @@ fn void? checkCode(
   CXErrorCode code)
 {
   switch (code) {
-    case clang::ERROR_SUCCESS: 
-      break;
-    case clang::ERROR_FAILURE:
-    case clang::ERROR_AST_READ_ERROR:
-      return bg::CLANG_PARSE_ERROR~;
-    case clang::ERROR_CRASHED:
-      return bg::CLANG_CRASH~;
-    case clang::ERROR_INVALID_ARGUMENTS:
-      return bg::INVALID_ARGUMENTS~;
+    case ERROR_SUCCESS: 
+    break;
+    case ERROR_FAILURE:
+    case ERROR_AST_READ_ERROR:
+    return bg::CLANG_PARSE_ERROR~;
+    case ERROR_CRASHED:
+    return bg::CLANG_CRASH~;
+    case ERROR_INVALID_ARGUMENTS:
+    return bg::INVALID_ARGUMENTS~;
   }
 }
 
 
-const TRANSLATION_UNIT_PARSE_FLAGS =
-    clang::TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD
-  | clang::TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES
-  | clang::TRANSLATION_UNIT_SKIP_FUNCTION_BODIES
-  | clang::TRANSLATION_UNIT_KEEP_GOING;
+const CXTranslationUnit_Flags TRANSLATION_UNIT_PARSE_FLAGS =
+  CXTranslationUnit_Flags.TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD
+| CXTranslationUnit_Flags.TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES
+| CXTranslationUnit_Flags.TRANSLATION_UNIT_SKIP_FUNCTION_BODIES
+| CXTranslationUnit_Flags.TRANSLATION_UNIT_KEEP_GOING;
 
 

--- a/bindgen.c3l/src/bgstr.c3
+++ b/bindgen.c3l/src/bgstr.c3
@@ -3,7 +3,7 @@ module bgimpl;
 import bgimpl::err;
 import std::collections::list;
 import std::collections::map;
-import std::ascii;
+import std::core::ascii;
 
 
 alias ListString = List{String};
@@ -153,7 +153,7 @@ fn String camelToPascal(
   @export("bgstr_camel_to_pascal")
 {
   String res = str.copy(alloc);
-  usz i;
+  sz i;
   while (i < str.len && str[i] == '_') ++i;
   if (i < str.len) res[i] = str[i].to_upper();
   return res;
@@ -193,7 +193,7 @@ fn String pascalToCamel(
   @export("bgstr_pascal_to_camel")
 {
   String res = str.copy(alloc);
-  usz i;
+  sz i;
   while (i < str.len && str[i] == '_') ++i;
   if (i < str.len) res[i] = str[i].to_lower();
   return res;
@@ -273,18 +273,18 @@ fn ListString parseSnakeCase(
   tokens.init(alloc, str.len / 2);
 
   // Treat possible beginning '_'
-  usz first = 0;
+  sz first = 0;
   while (first < str.len && str[first] == '_') ++first;
   if (first > 0) tokens.push(str[0..first-1]);
 
   // Treat possible closing '_' 
-  usz last = str.len - 1;
+  sz last = str.len - 1;
   while (last > 0 && str[last] == '_') --last;
 
   // Treat the rest [first..last]
-  for (usz i = first; i <= last;) {
+  for (sz i = first; i <= last;) {
     while (i <= last && str[i] == '_') ++i;
-    usz begin = i;
+    sz begin = i;
     while (i <= last && str[i] != '_') ++i;
     tokens.push(str[begin..i-1]);
   }
@@ -324,17 +324,17 @@ fn ListString parseCamelCase(
   tokens.init(alloc, str.len / 2);
 
   // Erase possible beginning '_'
-  isz first = 0;
+  sz first = 0;
   while (first < str.len && str[first] == '_') ++first;
   if (first > 0) tokens.push(str[0..first-1]);
 
   // Erase possible closing '_' 
-  isz last = str.len - 1;
+  sz last = str.len - 1;
   while (last >= 0 && str[last] == '_') --last;
 
   // Treat the rest [first..last]
-  for (usz i = first; i <= last;) {
-    usz begin = i++;
+  for (sz i = first; i <= last;) {
+    sz begin = i++;
 
     // Handle several upper cases and digits in a row
     bool is_prev_digit = false;
@@ -465,7 +465,7 @@ macro String convertToSnakeOrScreaming(
   ListString* tokens, 
   bool $to_snake) 
 {
-  usz size = 0;
+  sz size = 0;
   foreach (t : tokens) {
     size += t.len;
 
@@ -476,11 +476,11 @@ macro String convertToSnakeOrScreaming(
   --size;
 
   // If last token is '_', we do not insert '_' after prelast token
-  usz last_token_index = tokens.len() - ((*tokens)[^1][0] == '_' ? 2 : 1); 
+  sz last_token_index = tokens.len() - ((*tokens)[^1][0] == '_' ? 2 : 1); 
 
-  String res = (String) allocator::alloc_array(alloc, char, size);
+  String res = (String)alloc::alloc_array(alloc, char, size);
   
-  usz last = 0;
+  sz last = 0;
   foreach (i, t : tokens) {
     res[last:t.len] = t[..];
 
@@ -515,22 +515,22 @@ macro String convertToCamelOrPascal(
   ListString* tokens, 
   bool $to_camel) 
 {
-  usz size = 0;
+  sz size = 0;
   foreach (t : tokens) {
     size += t.len;
   }
 
-  String res = (String) allocator::alloc_array(alloc, char, size);
+  String res = (String)alloc::alloc_array(alloc, char, size);
   
   $if $to_camel:
     bool has_underscore = (*tokens)[0][0] == '_';
   $endif
 
-  usz last = 0;
+  sz last = 0;
   foreach (i, t : *tokens) {
     res[last:t.len] = t[..];
     
-    usz offset = 1;
+    sz offset = 1;
     $if $to_camel:
       if (i == (has_underscore ? 1 : 0)) offset = 0;
     $endif
@@ -545,7 +545,7 @@ macro String convertToCamelOrPascal(
       res[last] = res[last].to_upper();
     $endif
 
-    for (usz j = last + offset; j < last + t.len; ++j) {
+    for (sz j = last + offset; j < last + t.len; ++j) {
       res[j] = res[j].to_lower();
     }
 

--- a/bindgen.c3l/src/clang.c3i
+++ b/bindgen.c3l/src/clang.c3i
@@ -1,8224 +1,8126 @@
 
 module clang;
-import libc; // for Time_t
+import libc;
 
-/*-------------------------------*\
-|                                 |
-|       File CXErrorCode.h        |
-|                                 |
-\*-------------------------------*/
+<*
+  Error codes returned by libclang routines.
+  Zero (\c CXError_Success) is the only error code indicating success.  Other
+  error codes, including not yet assigned non-zero values, indicate errors.
+*>
+constdef CXErrorCode : CInt {
 
-/**
- * Error codes returned by libclang routines.
- *
- * Zero (\c CXError_Success) is the only error code indicating success.  Other
- * error codes, including not yet assigned non-zero values, indicate errors.
- */
-typedef CXErrorCode = inline CInt;
+  <*
+    No error.
+  *>
+  ERROR_SUCCESS = 0,
 
-/**
- * No error.
- */
-const CXErrorCode ERROR_SUCCESS = 0;
+  <*
+    A generic error code, no further details are available.
+    Errors of this kind can get their own specific error codes in future
+    libclang versions.
+  *>
+  ERROR_FAILURE = 1,
 
-/**
- * A generic error code, no further details are available.
- *
- * Errors of this kind can get their own specific error codes in future
- * libclang versions.
- */
-const CXErrorCode ERROR_FAILURE = 1;
+  <*
+    libclang crashed while performing the requested operation.
+  *>
+  ERROR_CRASHED = 2,
 
-/**
- * libclang crashed while performing the requested operation.
- */
-const CXErrorCode ERROR_CRASHED = 2;
+  <*
+    The function detected that the arguments violate the function
+    contract.
+  *>
+  ERROR_INVALID_ARGUMENTS = 3,
 
-/**
- * The function detected that the arguments violate the function
- * contract.
- */
-const CXErrorCode ERROR_INVALID_ARGUMENTS = 3;
+  <*
+    An AST deserialization error has occurred.
+  *>
+  ERROR_AST_READ_ERROR = 4
+}
 
-/**
- * An AST deserialization error has occurred.
- */
-const CXErrorCode ERROR_AST_READ_ERROR = 4;
-
-
-/*-------------------------------*\
-|                                 |
-|         File CXString.h         |
-|                                 |
-\*-------------------------------*/
-
-/**
- * A character string.
- *
- * The \c CXString type is used to return strings from the interface when
- * the ownership of that string might differ from one call to the next.
- * Use \c clang_getCString() to retrieve the string data and, once finished
- * with the string data, call \c clang_disposeString() to free the string.
- */
+<*
+  A character string.
+  The \c CXString type is used to return strings from the interface when
+  the ownership of that string might differ from one call to the next.
+  Use \c clang_getCString() to retrieve the string data and, once finished
+  with the string data, call \c clang_disposeString() to free the string.
+*>
 struct CXString {
   void* data;
   CUInt private_flags;
 }
+
 
 struct CXStringSet {
   CXString* strings;
   CUInt count;
 }
 
-/**
- * Retrieve the character data associated with the given string.
- */
-fn ZString getCString(
-  CXString string) 
-@extern("clang_getCString");
+<*
+  Retrieve the character data associated with the given string.
+  The returned data is a reference and not owned by the user. This data
+  is only valid while the `CXString` is valid. This function is similar
+  to `std::string::c_str()`.
+*>
+extern fn ZString getCString(
+  CXString string)
+@cname("clang_getCString");
 
-/**
- * Free the given string.
- */
-fn void disposeString(
-  CXString string) 
-@extern("clang_disposeString");
+<*
+  Free the given string.
+*>
+extern fn void disposeString(
+  CXString string)
+@cname("clang_disposeString");
 
-/**
- * Free the given string set.
- */
-fn void disposeStringSet(
-  CXStringSet* set) 
-@extern("clang_disposeStringSet");
+<*
+  Free the given string set.
+*>
+extern fn void disposeStringSet(
+  CXStringSet* set)
+@cname("clang_disposeStringSet");
 
+<*
+  Return the timestamp for use with Clang's
+  \c -fbuild-session-timestamp= option.
+*>
+extern fn CULongLong getBuildSessionTimestamp()
+@cname("clang_getBuildSessionTimestamp");
 
-/*-------------------------------*\
-|                                 |
-|          File CXFile.h          |
-|                                 |
-\*-------------------------------*/
+alias CXVirtualFileOverlay = void*;
 
-/**
- * A particular source file that is part of a translation unit.
- */
-typedef CXFile = inline void*;
+<*
+  Create a \c CXVirtualFileOverlay object.
+  Must be disposed with \c clang_VirtualFileOverlay_dispose().
+  \param options is reserved, always pass 0.
+*>
+extern fn CXVirtualFileOverlay virtualFileOverlay_create(
+  CUInt options)
+@cname("clang_VirtualFileOverlay_create");
 
-/**
- * Retrieve the complete file and path name of the given file.
- */
-fn CXString getFileName(
-  CXFile sfile) 
-@extern("clang_getFileName");
+<*
+  Map an absolute virtual file path to an absolute real one.
+  The virtual path must be canonicalized (not contain "."/"..").
+  \returns 0 for success, non-zero to indicate an error.
+*>
+extern fn CXErrorCode virtualFileOverlay_addFileMapping(
+  CXVirtualFileOverlay,
+  ZString virtual_path,
+  ZString real_path)
+@cname("clang_VirtualFileOverlay_addFileMapping");
 
-/**
- * Retrieve the last modification time of the given file.
- */
-fn Time_t getFileTime(
-  CXFile sfile) 
-@extern("clang_getFileTime");
+<*
+  Set the case sensitivity for the \c CXVirtualFileOverlay object.
+  The \c CXVirtualFileOverlay object is case-sensitive by default, this
+  option can be used to override the default.
+  \returns 0 for success, non-zero to indicate an error.
+*>
+extern fn CXErrorCode virtualFileOverlay_setCaseSensitivity(
+  CXVirtualFileOverlay,
+  CInt case_sensitive)
+@cname("clang_VirtualFileOverlay_setCaseSensitivity");
 
-/**
- * Uniquely identifies a CXFile, that refers to the same underlying file,
- * across an indexing session.
- */
+<*
+  Write out the \c CXVirtualFileOverlay object to a char buffer.
+  \param options is reserved, always pass 0.
+  \param out_buffer_ptr pointer to receive the buffer pointer, which should be
+  disposed using \c clang_free().
+  \param out_buffer_size pointer to receive the buffer size.
+  \returns 0 for success, non-zero to indicate an error.
+*>
+extern fn CXErrorCode virtualFileOverlay_writeToBuffer(
+  CXVirtualFileOverlay,
+  CUInt options,
+  ZString* out_buffer_ptr,
+  CUInt* out_buffer_size)
+@cname("clang_VirtualFileOverlay_writeToBuffer");
+
+<*
+  free memory allocated by libclang, such as the buffer returned by
+  \c CXVirtualFileOverlay() or \c clang_ModuleMapDescriptor_writeToBuffer().
+  \param buffer memory pointer to free.
+*>
+extern fn void free(
+  void* buffer)
+@cname("clang_free");
+
+<*
+  Dispose a \c CXVirtualFileOverlay object.
+*>
+extern fn void virtualFileOverlay_dispose(
+  CXVirtualFileOverlay)
+@cname("clang_VirtualFileOverlay_dispose");
+
+alias CXModuleMapDescriptor = void*;
+
+<*
+  Create a \c CXModuleMapDescriptor object.
+  Must be disposed with \c clang_ModuleMapDescriptor_dispose().
+  \param options is reserved, always pass 0.
+*>
+extern fn CXModuleMapDescriptor moduleMapDescriptor_create(
+  CUInt options)
+@cname("clang_ModuleMapDescriptor_create");
+
+<*
+  Sets the framework module name that the module.modulemap describes.
+  \returns 0 for success, non-zero to indicate an error.
+*>
+extern fn CXErrorCode moduleMapDescriptor_setFrameworkModuleName(
+  CXModuleMapDescriptor,
+  ZString name)
+@cname("clang_ModuleMapDescriptor_setFrameworkModuleName");
+
+<*
+  Sets the umbrella header name that the module.modulemap describes.
+  \returns 0 for success, non-zero to indicate an error.
+*>
+extern fn CXErrorCode moduleMapDescriptor_setUmbrellaHeader(
+  CXModuleMapDescriptor,
+  ZString name)
+@cname("clang_ModuleMapDescriptor_setUmbrellaHeader");
+
+<*
+  Write out the \c CXModuleMapDescriptor object to a char buffer.
+  \param options is reserved, always pass 0.
+  \param out_buffer_ptr pointer to receive the buffer pointer, which should be
+  disposed using \c clang_free().
+  \param out_buffer_size pointer to receive the buffer size.
+  \returns 0 for success, non-zero to indicate an error.
+*>
+extern fn CXErrorCode moduleMapDescriptor_writeToBuffer(
+  CXModuleMapDescriptor,
+  CUInt options,
+  ZString* out_buffer_ptr,
+  CUInt* out_buffer_size)
+@cname("clang_ModuleMapDescriptor_writeToBuffer");
+
+<*
+  Dispose a \c CXModuleMapDescriptor object.
+*>
+extern fn void moduleMapDescriptor_dispose(
+  CXModuleMapDescriptor)
+@cname("clang_ModuleMapDescriptor_dispose");
+
+alias CXFile = void*;
+
+<*
+  Retrieve the complete file and path name of the given file.
+*>
+extern fn CXString getFileName(
+  CXFile s_file)
+@cname("clang_getFileName");
+
+<*
+  Retrieve the last modification time of the given file.
+*>
+extern fn Time_t getFileTime(
+  CXFile s_file)
+@cname("clang_getFileTime");
+
+<*
+  Uniquely identifies a CXFile, that refers to the same underlying file,
+  across an indexing session.
+*>
 struct CXFileUniqueID {
-  CLongLong[3] data;
+  CULongLong[3] data;
 }
 
-/**
- * Retrieve the unique ID for the given \c file.
- *
- * \param file the file to get the ID for.
- * \param outID stores the returned CXFileUniqueID.
- * \returns If there was a failure getting the unique ID, returns non-zero,
- * otherwise returns 0.
- */
-fn CInt getFileUniqueID(
-  CXFile file, 
-  CXFileUniqueID* out_id) 
-@extern("clang_getFileUniqueID");
+<*
+  Retrieve the unique ID for the given \c file.
+  \param file the file to get the ID for.
+  \param outID stores the returned CXFileUniqueID.
+  \returns If there was a failure getting the unique ID, returns non-zero,
+  otherwise returns 0.
+*>
+extern fn CInt getFileUniqueID(
+  CXFile file,
+  CXFileUniqueID* out_id)
+@cname("clang_getFileUniqueID");
 
-/**
- * Returns non-zero if the \c file1 and \c file2 point to the same file,
- * or they are both NULL.
- */
-fn CInt isEqual_File(
-  CXFile file1, 
-  CXFile file2) 
-@extern("clang_File_isEqual");
+<*
+  Returns non-zero if the \c file1 and \c file2 point to the same file,
+  or they are both NULL.
+*>
+extern fn CInt file_isEqual(
+  CXFile file_1,
+  CXFile file_2)
+@cname("clang_File_isEqual");
 
-/**
- * Returns the real path name of \c file.
- *
- * An empty string may be returned. Use \c clang_getFileName() in that case.
- */
-fn CXString tryGetRealPathName_File(
-  CXFile file) 
-@extern("clang_File_tryGetRealPathName");
+<*
+  Returns the real path name of \c file.
+  An empty string may be returned. Use \c clang_getFileName() in that case.
+*>
+extern fn CXString file_tryGetRealPathName(
+  CXFile file)
+@cname("clang_File_tryGetRealPathName");
 
-
-/*-------------------------------*\
-|                                 |
-|     File CXSourceLocation.h     |
-|                                 |
-\*-------------------------------*/
-
-/**
- * Identifies a specific source location within a translation
- * unit.
- *
- * Use clang_getExpansionLocation() or clang_getSpellingLocation()
- * to map a source location to a particular file, line, and column.
- */
+<*
+  Identifies a specific source location within a translation
+  unit.
+  Use clang_getExpansionLocation() or clang_getSpellingLocation()
+  to map a source location to a particular file, line, and column.
+*>
 struct CXSourceLocation {
   void*[2] ptr_data;
   CUInt int_data;
 }
 
-/**
- * Identifies a half-open character range in the source code.
- *
- * Use clang_getRangeStart() and clang_getRangeEnd() to retrieve the
- * starting and end locations from a source range, respectively.
- */
+<*
+  Identifies a half-open character range in the source code.
+  Use clang_getRangeStart() and clang_getRangeEnd() to retrieve the
+  starting and end locations from a source range, respectively.
+*>
 struct CXSourceRange {
   void*[2] ptr_data;
   CUInt begin_int_data;
   CUInt end_int_data;
 }
 
-/**
- * Retrieve a NULL (invalid) source location.
- */
-fn CXSourceLocation getNullLocation() 
-@extern("clang_getNullLocation");
+<*
+  Retrieve a NULL (invalid) source location.
+*>
+extern fn CXSourceLocation getNullLocation()
+@cname("clang_getNullLocation");
 
-/**
- * Determine whether two source locations, which must refer into
- * the same translation unit, refer to exactly the same point in the source
- * code.
- *
- * \returns non-zero if the source locations refer to the same location, zero
- * if they refer to different locations.
- */
-fn CUInt equalLocations(
-  CXSourceLocation loc1, 
-  CXSourceLocation loc2) 
-@extern("clang_equalLocations");
+<*
+  Determine whether two source locations, which must refer into
+  the same translation unit, refer to exactly the same point in the source
+  code.
+  \returns non-zero if the source locations refer to the same location, zero
+  if they refer to different locations.
+*>
+extern fn CUInt equalLocations(
+  CXSourceLocation loc_1,
+  CXSourceLocation loc_2)
+@cname("clang_equalLocations");
 
-/**
- * Returns non-zero if the given source location is in a system header.
- */
-fn CInt isInSystemHeader_Location(
-  CXSourceLocation location) 
-@extern("clang_Location_isInSystemHeader");
+<*
+  Determine for two source locations if the first comes
+  strictly before the second one in the source code.
+  \returns non-zero if the first source location comes
+  strictly before the second one, zero otherwise.
+*>
+extern fn CUInt isBeforeInTranslationUnit(
+  CXSourceLocation loc_1,
+  CXSourceLocation loc_2)
+@cname("clang_isBeforeInTranslationUnit");
 
-/**
- * Returns non-zero if the given source location is in the main file of
- * the corresponding translation unit.
- */
-fn CInt isFromMainFile_Location(
-  CXSourceLocation location) 
-@extern("clang_Location_isFromMainFile");
+<*
+  Returns non-zero if the given source location is in a system header.
+*>
+extern fn CInt location_isInSystemHeader(
+  CXSourceLocation location)
+@cname("clang_Location_isInSystemHeader");
 
-/**
- * Retrieve a NULL (invalid) source range.
- */
-fn CXSourceRange getNullRange() 
-@extern("clang_getNullRange");
+<*
+  Returns non-zero if the given source location is in the main file of
+  the corresponding translation unit.
+*>
+extern fn CInt location_isFromMainFile(
+  CXSourceLocation location)
+@cname("clang_Location_isFromMainFile");
 
-/**
- * Retrieve a source range given the beginning and ending source
- * locations.
- */
-fn CXSourceRange getRange(
-  CXSourceLocation begin, 
-  CXSourceLocation end) 
-@extern("clang_getRange");
+<*
+  Retrieve a NULL (invalid) source range.
+*>
+extern fn CXSourceRange getNullRange()
+@cname("clang_getNullRange");
 
-/**
- * Determine whether two ranges are equivalent.
- *
- * \returns non-zero if the ranges are the same, zero if they differ.
- */
-fn CUInt equalRanges(
-  CXSourceRange range1, 
-  CXSourceRange range2) 
-@extern("clang_equalRanges");
+<*
+  Retrieve a source range given the beginning and ending source
+  locations.
+*>
+extern fn CXSourceRange getRange(
+  CXSourceLocation begin,
+  CXSourceLocation end)
+@cname("clang_getRange");
 
-/**
- * Returns non-zero if \p range is null.
- */
-fn CInt isNull_Range(
-  CXSourceRange range) 
-@extern("clang_Range_isNull");
+<*
+  Determine whether two ranges are equivalent.
+  \returns non-zero if the ranges are the same, zero if they differ.
+*>
+extern fn CUInt equalRanges(
+  CXSourceRange range_1,
+  CXSourceRange range_2)
+@cname("clang_equalRanges");
 
-/**
- * Retrieve the file, line, column, and offset represented by
- * the given source location.
- *
- * If the location refers into a macro expansion, retrieves the
- * location of the macro expansion.
- *
- * \param location the location within a source file that will be decomposed
- * into its parts.
- *
- * \param file [out] if non-NULL, will be set to the file to which the given
- * source location points.
- *
- * \param line [out] if non-NULL, will be set to the line to which the given
- * source location points.
- *
- * \param column [out] if non-NULL, will be set to the column to which the given
- * source location points.
- *
- * \param offset [out] if non-NULL, will be set to the offset into the
- * buffer to which the given source location points.
- */
-fn void getExpansionLocation(
-  CXSourceLocation location, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_getExpansionLocation");
+<*
+  Returns non-zero if \p range is null.
+*>
+extern fn CInt range_isNull(
+  CXSourceRange range)
+@cname("clang_Range_isNull");
 
-/**
- * Retrieve the file, line and column represented by the given source
- * location, as specified in a # line directive.
- *
- * Example: given the following source code in a file somefile.c
- *
- * \code
- * #123 "dummy.c" 1
- *
- * static CInt func(void)
- * {
- *     return 0;
- * }
- * \endcode
- *
- * the location information returned by this function would be
- *
- * File: dummy.c Line: 124 Column: 12
- *
- * whereas clang_getExpansionLocation would have returned
- *
- * File: somefile.c Line: 3 Column: 12
- *
- * \param location the location within a source file that will be decomposed
- * into its parts.
- *
- * \param filename [out] if non-NULL, will be set to the filename of the
- * source location. Note that filenames returned will be for "virtual" files,
- * which don't necessarily exist on the machine running clang - e.g. when
- * parsing preprocessed output obtained from a different environment. If
- * a non-NULL value is passed in, remember to dispose of the returned value
- * using \c clang_disposeString() once you've finished with it. For an invalid
- * source location, an empty string is returned.
- *
- * \param line [out] if non-NULL, will be set to the line number of the
- * source location. For an invalid source location, zero is returned.
- *
- * \param column [out] if non-NULL, will be set to the column number of the
- * source location. For an invalid source location, zero is returned.
- */
-fn void getPresumedLocation(
-  CXSourceLocation location, 
-  CXString* filename, 
-  CUInt* line, 
-  CUInt* column) 
-@extern("clang_getPresumedLocation");
+<*
+  Retrieve the file, line, column, and offset represented by
+  the given source location.
+  If the location refers into a macro expansion, retrieves the
+  location of the macro expansion.
+  \param location the location within a source file that will be decomposed
+  into its parts.
+  \param file [out] if non-NULL, will be set to the file to which the given
+  source location points.
+  \param line [out] if non-NULL, will be set to the line to which the given
+  source location points.
+  \param column [out] if non-NULL, will be set to the column to which the given
+  source location points.
+  \param offset [out] if non-NULL, will be set to the offset into the
+  buffer to which the given source location points.
+*>
+extern fn void getExpansionLocation(
+  CXSourceLocation location,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_getExpansionLocation");
 
-/**
- * Legacy API to retrieve the file, line, column, and offset represented
- * by the given source location.
- *
- * This interface has been replaced by the newer interface
- * #clang_getExpansionLocation(). See that interface's documentation for
- * details.
- */
-fn void getInstantiationLocation(
-  CXSourceLocation location, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_getInstantiationLocation");
+<*
+  Retrieve the file, line and column represented by the given source
+  location, as specified in a # line directive.
+  Example: given the following source code in a file somefile.c
+  \code
+  #123 "dummy.c" 1
+  static int func(void)
+  {
+  return 0;
+  }
+  \endcode
+  the location information returned by this function would be
+  File: dummy.c Line: 124 Column: 12
+  whereas clang_getExpansionLocation would have returned
+  File: somefile.c Line: 3 Column: 12
+  \param location the location within a source file that will be decomposed
+  into its parts.
+  \param filename [out] if non-NULL, will be set to the filename of the
+  source location. Note that filenames returned will be for "virtual" files,
+  which don't necessarily exist on the machine running clang - e.g. when
+  parsing preprocessed output obtained from a different environment. If
+  a non-NULL value is passed in, remember to dispose of the returned value
+  using \c clang_disposeString() once you've finished with it. For an invalid
+  source location, an empty string is returned.
+  \param line [out] if non-NULL, will be set to the line number of the
+  source location. For an invalid source location, zero is returned.
+  \param column [out] if non-NULL, will be set to the column number of the
+  source location. For an invalid source location, zero is returned.
+*>
+extern fn void getPresumedLocation(
+  CXSourceLocation location,
+  CXString* filename,
+  CUInt* line,
+  CUInt* column)
+@cname("clang_getPresumedLocation");
 
-/**
- * Retrieve the file, line, column, and offset represented by
- * the given source location.
- *
- * If the location refers into a macro instantiation, return where the
- * location was originally spelled in the source file.
- *
- * \param location the location within a source file that will be decomposed
- * into its parts.
- *
- * \param file [out] if non-NULL, will be set to the file to which the given
- * source location points.
- *
- * \param line [out] if non-NULL, will be set to the line to which the given
- * source location points.
- *
- * \param column [out] if non-NULL, will be set to the column to which the given
- * source location points.
- *
- * \param offset [out] if non-NULL, will be set to the offset into the
- * buffer to which the given source location points.
- */
-fn void getSpellingLocation(
-  CXSourceLocation location, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_getSpellingLocation");
+<*
+  Legacy API to retrieve the file, line, column, and offset represented
+  by the given source location.
+  This interface has been replaced by the newer interface
+  #clang_getExpansionLocation(). See that interface's documentation for
+  details.
+*>
+extern fn void getInstantiationLocation(
+  CXSourceLocation location,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_getInstantiationLocation");
 
-/**
- * Retrieve the file, line, column, and offset represented by
- * the given source location.
- *
- * If the location refers into a macro expansion, return where the macro was
- * expanded or where the macro argument was written, if the location points at
- * a macro argument.
- *
- * \param location the location within a source file that will be decomposed
- * into its parts.
- *
- * \param file [out] if non-NULL, will be set to the file to which the given
- * source location points.
- *
- * \param line [out] if non-NULL, will be set to the line to which the given
- * source location points.
- *
- * \param column [out] if non-NULL, will be set to the column to which the given
- * source location points.
- *
- * \param offset [out] if non-NULL, will be set to the offset into the
- * buffer to which the given source location points.
- */
-fn void getFileLocation(
-  CXSourceLocation location, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_getFileLocation");
+<*
+  Retrieve the file, line, column, and offset represented by
+  the given source location.
+  If the location refers into a macro instantiation, return where the
+  location was originally spelled in the source file.
+  \param location the location within a source file that will be decomposed
+  into its parts.
+  \param file [out] if non-NULL, will be set to the file to which the given
+  source location points.
+  \param line [out] if non-NULL, will be set to the line to which the given
+  source location points.
+  \param column [out] if non-NULL, will be set to the column to which the given
+  source location points.
+  \param offset [out] if non-NULL, will be set to the offset into the
+  buffer to which the given source location points.
+*>
+extern fn void getSpellingLocation(
+  CXSourceLocation location,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_getSpellingLocation");
 
-/**
- * Retrieve a source location representing the first character within a
- * source range.
- */
-fn CXSourceLocation getRangeStart(
-  CXSourceRange range) 
-@extern("clang_getRangeStart");
+<*
+  Retrieve the file, line, column, and offset represented by
+  the given source location.
+  If the location refers into a macro expansion, return where the macro was
+  expanded or where the macro argument was written, if the location points at
+  a macro argument.
+  \param location the location within a source file that will be decomposed
+  into its parts.
+  \param file [out] if non-NULL, will be set to the file to which the given
+  source location points.
+  \param line [out] if non-NULL, will be set to the line to which the given
+  source location points.
+  \param column [out] if non-NULL, will be set to the column to which the given
+  source location points.
+  \param offset [out] if non-NULL, will be set to the offset into the
+  buffer to which the given source location points.
+*>
+extern fn void getFileLocation(
+  CXSourceLocation location,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_getFileLocation");
 
-/**
- * Retrieve a source location representing the last character within a
- * source range.
- */
-fn CXSourceLocation getRangeEnd(
-  CXSourceRange range) 
-@extern("clang_getRangeEnd");
+<*
+  Retrieve a source location representing the first character within a
+  source range.
+*>
+extern fn CXSourceLocation getRangeStart(
+  CXSourceRange range)
+@cname("clang_getRangeStart");
 
-/**
- * Identifies an array of ranges.
- */
+<*
+  Retrieve a source location representing the last character within a
+  source range.
+*>
+extern fn CXSourceLocation getRangeEnd(
+  CXSourceRange range)
+@cname("clang_getRangeEnd");
+
+<*
+  Identifies an array of ranges.
+*>
 struct CXSourceRangeList {
-  /* The number of ranges in the \c ranges array. */
   CUInt count;
-  /*
-   * An array of \c CXSourceRanges.
-   */
   CXSourceRange* ranges;
 }
 
-/**
- * Destroy the given \c CXSourceRangeList.
- */
-fn void disposeSourceRangeList(
-  CXSourceRangeList* ranges) 
-@extern("clang_disposeSourceRangeList");
-
-
-/*-------------------------------*\
-|                                 |
-|       File CXDiagnostic.h       |
-|                                 |
-\*-------------------------------*/
-
-/**
- * Describes the severity of a particular diagnostic.
- */
-typedef CXDiagnosticSeverity = inline CInt;
-
-/**
- * A diagnostic that has been suppressed, e.g., by a command-line
- * option.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_IGNORED = 0;
-
-/**
- * This diagnostic is a note that should be attached to the
- * previous (non-note) diagnostic.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_NOTE = 1;
-
-/**
- * This diagnostic indicates suspicious code that may not be
- * wrong.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_WARNING = 2;
-
-/**
- * This diagnostic indicates that the code is ill-formed.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_ERROR = 3;
-
-/**
- * This diagnostic indicates that the code is ill-formed such
- * that future parser recovery is unlikely to produce useful
- * results.
- */
-const CXDiagnosticSeverity DIAGNOSTIC_FATAL = 4;
-
-
-/**
- * A single diagnostic, containing the diagnostic's severity,
- * location, text, source ranges, and fix-it hints.
- */
-typedef CXDiagnostic = inline void*;
-
-/**
- * A group of CXDiagnostics.
- */
-typedef CXDiagnosticSet = inline void*;
-
-/**
- * Determine the number of diagnostics in a CXDiagnosticSet.
- */
-fn CUInt getNumDiagnosticsInSet(
-  CXDiagnosticSet diags) 
-@extern("clang_getNumDiagnosticsInSet");
-
-/**
- * Retrieve a diagnostic associated with the given CXDiagnosticSet.
- *
- * \param Diags the CXDiagnosticSet to query.
- * \param Index the zero-based diagnostic number to retrieve.
- *
- * \returns the requested diagnostic. This diagnostic must be freed
- * via a call to \c clang_disposeDiagnostic().
- */
-fn CXDiagnostic getDiagnosticInSet(
-  CXDiagnosticSet diags, 
-  CUInt index) 
-@extern("clang_getDiagnosticInSet");
-
-/**
- * Describes the kind of error that occurred (if any) in a call to
- * \c clang_loadDiagnostics.
- */
-typedef CXLoadDiag_Error = inline CInt;
-/**
- * Indicates that no error occurred.
- */
-const CXLoadDiag_Error LOAD_DIAG_NONE = 0;
-
-/**
- * Indicates that an unknown error occurred while attempting to
- * deserialize diagnostics.
- */
-const CXLoadDiag_Error LOAD_DIAG_UNKNOWN = 1;
-
-/**
- * Indicates that the file containing the serialized diagnostics
- * could not be opened.
- */
-const CXLoadDiag_Error LOAD_DIAG_CANNOT_LOAD = 2;
-
-/**
- * Indicates that the serialized diagnostics file is invalid or
- * corrupt.
- */
-const CXLoadDiag_Error LOAD_DIAG_INVALID_FILE = 3;
-
-/**
- * Deserialize a set of diagnostics from a Clang diagnostics bitcode
- * file.
- *
- * \param file The name of the file to deserialize.
- * \param error A pointer to a enum value recording if there was a problem
- *        deserializing the diagnostics.
- * \param errorString A pointer to a CXString for recording the error string
- *        if the file was not successfully loaded.
- *
- * \returns A loaded CXDiagnosticSet if successful, and NULL otherwise.  These
- * diagnostics should be released using clang_disposeDiagnosticSet().
- */
-fn CXDiagnosticSet loadDiagnostics(
-  ZString file, 
-  CXLoadDiag_Error* error, 
-  CXString* errorString) 
-@extern("clang_loadDiagnostics");
-
-/**
- * Release a CXDiagnosticSet and all of its contained diagnostics.
- */
-fn void disposeDiagnosticSet(
-  CXDiagnosticSet diags) 
-@extern("clang_disposeDiagnosticSet");
-
-/**
- * Retrieve the child diagnostics of a CXDiagnostic.
- *
- * This CXDiagnosticSet does not need to be released by
- * clang_disposeDiagnosticSet.
- */
-fn CXDiagnosticSet getChildDiagnostics(
-  CXDiagnostic d) 
-@extern("clang_getChildDiagnostics");
-
-/**
- * Destroy a diagnostic.
- */
-fn void disposeDiagnostic(
-  CXDiagnostic diagnostic) 
-@extern("clang_disposeDiagnostic");
-
-/**
- * Options to control the display of diagnostics.
- *
- * The values in this enum are meant to be combined to customize the
- * behavior of \c clang_formatDiagnostic().
- */
-typedef CXDiagnosticDisplayOptions = inline CInt;
-
-/**
- * Display the source-location information where the
- * diagnostic was located.
- *
- * When set, diagnostics will be prefixed by the file, line, and
- * (optionally) column to which the diagnostic refers. For example,
- *
- * \code
- * test.c:28: warning: extra tokens at end of #endif directive
- * \endcode
- *
- * This option corresponds to the clang flag \c -fshow-source-location.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_SOURCE_LOCATION = 0x01;
-
-/**
- * If displaying the source-location information of the
- * diagnostic, also include the column number.
- *
- * This option corresponds to the clang flag \c -fshow-column.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_COLUMN = 0x02;
-
-/**
- * If displaying the source-location information of the
- * diagnostic, also include information about source ranges in a
- * machine-parsable format.
- *
- * This option corresponds to the clang flag
- * \c -fdiagnostics-print-source-range-info.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_SOURCE_RANGES = 0x04;
-
-/**
- * Display the option name associated with this diagnostic, if any.
- *
- * The option name displayed (e.g., -Wconversion) will be placed in brackets
- * after the diagnostic text. This option corresponds to the clang flag
- * \c -fdiagnostics-show-option.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_OPTION = 0x08;
-
-/**
- * Display the category number associated with this diagnostic, if any.
- *
- * The category number is displayed within brackets after the diagnostic text.
- * This option corresponds to the clang flag
- * \c -fdiagnostics-show-category=id.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_CATEGORY_ID = 0x10;
-
-/**
- * Display the category name associated with this diagnostic, if any.
- *
- * The category name is displayed within brackets after the diagnostic text.
- * This option corresponds to the clang flag
- * \c -fdiagnostics-show-category=name.
- */
-const CXDiagnosticDisplayOptions DIAGNOSTIC_DISPLAY_CATEGORY_NAME = 0x20;
-
-/**
- * Format the given diagnostic in a manner that is suitable for display.
- *
- * This routine will format the given diagnostic to a string, rendering
- * the diagnostic according to the various options given. The
- * \c clang_defaultDiagnosticDisplayOptions() function returns the set of
- * options that most closely mimics the behavior of the clang compiler.
- *
- * \param Diagnostic The diagnostic to print.
- *
- * \param Options A set of options that control the diagnostic display,
- * created by combining \c CXDiagnosticDisplayOptions values.
- *
- * \returns A new string containing for formatted diagnostic.
- */
-fn CXString formatDiagnostic(
-  CXDiagnostic diagnostic, 
-  CUInt options) 
-@extern("clang_formatDiagnostic");
-
-/**
- * Retrieve the set of display options most similar to the
- * default behavior of the clang compiler.
- *
- * \returns A set of display options suitable for use with \c
- * clang_formatDiagnostic().
- */
-fn CUInt defaultDiagnosticDisplayOptions() 
-@extern("clang_defaultDiagnosticDisplayOptions");
-
-/**
- * Determine the severity of the given diagnostic.
- */
-fn CXDiagnosticSeverity getDiagnosticSeverity(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticSeverity");
-
-/**
- * Retrieve the source location of the given diagnostic.
- *
- * This location is where Clang would print the caret ('^') when
- * displaying the diagnostic on the command line.
- */
-fn CXSourceLocation getDiagnosticLocation(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticLocation");
-
-/**
- * Retrieve the text of the given diagnostic.
- */
-fn CXString getDiagnosticSpelling(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticSpelling");
-
-/**
- * Retrieve the name of the command-line option that enabled this
- * diagnostic.
- *
- * \param Diag The diagnostic to be queried.
- *
- * \param Disable If non-NULL, will be set to the option that disables this
- * diagnostic (if any).
- *
- * \returns A string that contains the command-line option used to enable this
- * warning, such as "-Wconversion" or "-pedantic".
- */
-fn CXString getDiagnosticOption(
-  CXDiagnostic diag, 
-  CXString* disable) 
-@extern("clang_getDiagnosticOption");
-
-/**
- * Retrieve the category number for this diagnostic.
- *
- * Diagnostics can be categorized into groups along with other, related
- * diagnostics (e.g., diagnostics under the same warning flag). This routine
- * retrieves the category number for the given diagnostic.
- *
- * \returns The number of the category that contains this diagnostic, or zero
- * if this diagnostic is uncategorized.
- */
-fn CUInt getDiagnosticCategory(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticCategory");
-
-/**
- * Retrieve the name of a particular diagnostic category.  This
- *  is now deprecated.  Use clang_getDiagnosticCategoryText()
- *  instead.
- *
- * \param Category A diagnostic category number, as returned by
- * \c clang_getDiagnosticCategory().
- *
- * \returns The name of the given diagnostic category.
- */
-fn CXString getDiagnosticCategoryName(
-  CUInt category) 
-@extern("clang_getDiagnosticCategoryName") 
-@deprecated("Use clang_getDiagnosticCategoryText()");
-
-/**
- * Retrieve the diagnostic category text for a given diagnostic.
- *
- * \returns The text of the given diagnostic category.
- */
-fn CXString getDiagnosticCategoryText(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticCategoryText");
-
-/**
- * Determine the number of source ranges associated with the given
- * diagnostic.
- */
-fn CUInt getDiagnosticNumRanges(
-  CXDiagnostic d) 
-@extern("clang_getDiagnosticNumRanges");
-
-/**
- * Retrieve a source range associated with the diagnostic.
- *
- * A diagnostic's source ranges highlight important elements in the source
- * code. On the command line, Clang displays source ranges by
- * underlining them with '~' characters.
- *
- * \param Diagnostic the diagnostic whose range is being extracted.
- *
- * \param Range the zero-based index specifying which range to
- *
- * \returns the requested source range.
- */
-fn CXSourceRange getDiagnosticRange(
-  CXDiagnostic diagnostic, 
-  CUInt range) 
-@extern("clang_getDiagnosticRange");
-
-/**
- * Determine the number of fix-it hints associated with the
- * given diagnostic.
- */
-fn CUInt getDiagnosticNumFixIts(
-  CXDiagnostic diagnostic) 
-@extern("clang_getDiagnosticNumFixIts");
-
-/**
- * Retrieve the replacement information for a given fix-it.
- *
- * Fix-its are described in terms of a source range whose contents
- * should be replaced by a string. This approach generalizes over
- * three kinds of operations: removal of source code (the range covers
- * the code to be removed and the replacement string is empty),
- * replacement of source code (the range covers the code to be
- * replaced and the replacement string provides the new code), and
- * insertion (both the start and end of the range point at the
- * insertion location, and the replacement string provides the text to
- * insert).
- *
- * \param Diagnostic The diagnostic whose fix-its are being queried.
- *
- * \param FixIt The zero-based index of the fix-it.
- *
- * \param ReplacementRange The source range whose contents will be
- * replaced with the returned replacement string. Note that source
- * ranges are half-open ranges [a, b), so the source code should be
- * replaced from a and up to (but not including) b.
- *
- * \returns A string containing text that should be replace the source
- * code indicated by the \c ReplacementRange.
- */
-fn CXString getDiagnosticFixIt(
-  CXDiagnostic diagnostic, 
-  CUInt fix_it, 
-  CXSourceRange* replacement_range) 
-@extern("clang_getDiagnosticFixIt");
-
-
-/*-------------------------------*\
-|                                 |
-|  File CXCompilationDatabase.h   |
-|                                 |
-\*-------------------------------*/
-
-/**
- * A compilation database holds all information used to compile files in a
- * project. For each file in the database, it can be queried for the working
- * directory or the command line used for the compiler invocation.
- *
- * Must be freed by \c clang_CompilationDatabase_dispose
- */
-typedef CXCompilationDatabase = inline void*;
-
-/**
- * Contains the results of a search in the compilation database
- *
- * When searching for the compile command for a file, the compilation db can
- * return several commands, as the file may have been compiled with
- * different options in different places of the project. This choice of compile
- * commands is wrapped in this opaque data structure. It must be freed by
- * \c clang_CompileCommands_dispose.
- */
-typedef CXCompileCommands = inline void*;
-
-/**
- * Represents the command line invocation to compile a specific file.
- */
-typedef CXCompileCommand = inline void*;
-
-/**
- * Error codes for Compilation Database
- */
-typedef CXCompilationDatabase_Error = inline CInt;
-
-/*
- * No error occurred
- */
-const CXCompilationDatabase_Error COMPILATION_DATABASE_NO_ERROR = 0;
-/*
- * Database can not be loaded
- */
-const CXCompilationDatabase_Error COMPILATION_DATABASE_CAN_NOT_LOAD_DATA_BASE = 1;
-
-/**
- * Creates a compilation database from the database found in directory
- * buildDir. For example, CMake can output a compile_commands.json which can
- * be used to build the database.
- *
- * It must be freed by \c clang_CompilationDatabase_dispose.
- */
-fn CXCompilationDatabase fromDirectory_CompilationDatabase(
-  ZString build_dir, 
-  CXCompilationDatabase_Error* error_code) 
-@extern("clang_CompilationDatabase_fromDirectory");
-
-/**
- * Free the given compilation database
- */
-fn void dispose_CompilationDatabase(
-  CXCompilationDatabase database) 
-@extern("clang_CompilationDatabase_dispose");
-
-/**
- * Find the compile commands used for a file. The compile commands
- * must be freed by \c clang_CompileCommands_dispose.
- */
-fn CXCompileCommands getCompileCommands_CompilationDatabase(
-  CXCompilationDatabase database, 
-  ZString complete_fileName) 
-@extern("clang_CompilationDatabase_getCompileCommands");
-
-/**
- * Get all the compile commands in the given compilation database.
- */
-fn CXCompileCommands getAllCompileCommands_CompilationDatabase(
-  CXCompilationDatabase database) 
-@extern("clang_CompilationDatabase_getAllCompileCommands");
-
-/**
- * Free the given CompileCommands
- */
-fn void dispose_CompileCommands(
-  CXCompileCommands commands) 
-@extern("clang_CompileCommands_dispose");
-
-/**
- * Get the number of CompileCommand we have for a file
- */
-fn CUInt getSize_CompileCommands(
-  CXCompileCommands commands) 
-@extern("clang_CompileCommands_getSize");
-
-/**
- * Get the I'th CompileCommand for a file
- *
- * Note : 0 <= i < clang_CompileCommands_getSize(CXCompileCommands)
- */
-fn CXCompileCommand getCommand_CompileCommands(
-  CXCompileCommands commands, 
-  CUInt i) 
-@extern("clang_CompileCommands_getCommand");
-
-/**
- * Get the working directory where the CompileCommand was executed from
- */
-fn CXString getDirectory_CompileCommand(
-  CXCompileCommand command) 
-@extern("clang_CompileCommand_getDirectory");
-
-/**
- * Get the filename associated with the CompileCommand.
- */
-fn CXString getFilename_CompileCommand(
-  CXCompileCommand command) 
-@extern("clang_CompileCommand_getFilename");
-
-/**
- * Get the number of arguments in the compiler invocation.
- *
- */
-fn CUInt getNumArgs_CompileCommand(
-  CXCompileCommand command) 
-@extern("clang_CompileCommand_getNumArgs");
-
-/**
- * Get the I'th argument value in the compiler invocations
- *
- * Invariant :
- *  - argument 0 is the compiler executable
- */
-fn CXString getArg_CompileCommand(
-  CXCompileCommand command, 
-  CUInt i) 
-@extern("clang_CompileCommand_getArg");
-
-/**
- * Get the number of source mappings for the compiler invocation.
- */
-fn CUInt getNumMappedSources_CompileCommand(
-  CXCompileCommand command) 
-@extern("clang_CompileCommand_getNumMappedSources");
-
-/**
- * Get the I'th mapped source path for the compiler invocation.
- */
-fn CXString getMappedSourcePath_CompileCommand(
-  CXCompileCommand command, 
-  CUInt i) 
-@extern("clang_CompileCommand_getMappedSourcePath");
-
-/**
- * Get the I'th mapped source content for the compiler invocation.
- */
-fn CXString getMappedSourceContent_CompileCommand(
-  CXCompileCommand command, 
-  CUInt i) 
-@extern("clang_CompileCommand_getMappedSourceContent");
-
-
-/*-------------------------------*\
-|                                 |
-|       File BuildSystem.h        |
-|                                 |
-\*-------------------------------*/
-
-/**
- * Return the timestamp for use with Clang's
- * \c -fbuild-session-timestamp= option.
- */
-fn CULongLong getBuildSessionTimestamp() 
-@extern("clang_getBuildSessionTimestamp");
-
-/**
- * Object encapsulating information about overlaying virtual
- * file/directories over the real file system.
- */
-typedef CXVirtualFileOverlay = inline void*;
-
-/**
- * Create a \c CXVirtualFileOverlay object.
- * Must be disposed with \c clang_VirtualFileOverlay_dispose().
- *
- * \param options is reserved, always pass 0.
- */
-fn CXVirtualFileOverlay createVirtualFileOverlay(
-  CUInt options) 
-@extern("clang_VirtualFileOverlay_create");
-
-/**
- * Map an absolute virtual file path to an absolute real one.
- * The virtual path must be canonicalized (not contain "."/"..").
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode addFileMapping_VirtualFileOverlay(
-  CXVirtualFileOverlay file_overlay, 
-  ZString virtual_path, 
-  ZString real_path) 
-@extern("clang_VirtualFileOverlay_addFileMapping");
-
-/**
- * Set the case sensitivity for the \c CXVirtualFileOverlay object.
- * The \c CXVirtualFileOverlay object is case-sensitive by default, this
- * option can be used to override the default.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode setCaseSensitivity_VirtualFileOverlay(
-  CXVirtualFileOverlay file_overaly, 
-  CInt case_sensitive) 
-@extern("clang_VirtualFileOverlay_setCaseSensitivity");
-
-/**
- * Write out the \c CXVirtualFileOverlay object to a CChar buffer.
- *
- * \param options is reserved, always pass 0.
- * \param out_buffer_ptr pointer to receive the buffer pointer, which should be
- * disposed using \c clang_free().
- * \param out_buffer_size pointer to receive the buffer size.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode writeToBuffer_VirtualFileOverlay(
-  CXVirtualFileOverlay file_overaly, 
-  CUInt options, 
-  CChar** out_buffer_ptr, 
-  CUInt* out_buffer_size) 
-@extern("clang_VirtualFileOverlay_writeToBuffer");
-
-/**
- * free memory allocated by libclang, such as the buffer returned by
- * \c CXVirtualFileOverlay() or \c clang_ModuleMapDescriptor_writeToBuffer().
- *
- * \param buffer memory pointer to free.
- */
-fn void free(
-  void* buffer) 
-@extern("clang_free");
-
-/**
- * Dispose a \c CXVirtualFileOverlay object.
- */
-fn void dispose_VirtualFileOverlay(
-  CXVirtualFileOverlay file_overlay) 
-@extern("clang_VirtualFileOverlay_dispose");
-
-/**
- * Object encapsulating information about a module.modulemap file.
- */
-typedef CXModuleMapDescriptor = inline void*;
-
-/**
- * Create a \c CXModuleMapDescriptor object.
- * Must be disposed with \c clang_ModuleMapDescriptor_dispose().
- *
- * \param options is reserved, always pass 0.
- */
-fn CXModuleMapDescriptor createModuleMapDescriptor(
-  CUInt options) 
-@extern("clang_ModuleMapDescriptor_create");
-
-/**
- * Sets the framework module name that the module.modulemap describes.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode setFrameworkModuleName_ModuleMapDescriptor(
-  CXModuleMapDescriptor descriptor, 
-  ZString name) 
-@extern("clang_ModuleMapDescriptor_setFrameworkModuleName");
-
-/**
- * Sets the umbrella header name that the module.modulemap describes.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode setUmbrellaHeader_ModuleMapDescriptor(
-  CXModuleMapDescriptor descriptor, 
-  ZString name) 
-@extern("clang_ModuleMapDescriptor_setUmbrellaHeader");
-
-/**
- * Write out the \c CXModuleMapDescriptor object to a CChar buffer.
- *
- * \param options is reserved, always pass 0.
- * \param out_buffer_ptr pointer to receive the buffer pointer, which should be
- * disposed using \c clang_free().
- * \param out_buffer_size pointer to receive the buffer size.
- * \returns 0 for success, non-zero to indicate an error.
- */
-fn CXErrorCode writeToBuffer_ModuleMapDescriptor(
-  CXModuleMapDescriptor descriptor, 
-  CUInt options, 
-  CChar** out_buffer_ptr, 
-  CUInt* out_buffer_size) 
-@extern("clang_ModuleMapDescriptor_writeToBuffer");
-
-/**
- * Dispose a \c CXModuleMapDescriptor object.
- */
-fn void dispose_ModuleMapDescriptor(
-  CXModuleMapDescriptor descriptor) 
-@extern("clang_ModuleMapDescriptor_dispose");
-
-
-/*-------------------------------*\
-|                                 |
-|      File Documentation.h       |
-|                                 |
-\*-------------------------------*/
-
-/**
- * A parsed comment.
- */
-struct CXComment {
-  void* ast_node;
-  CXTranslationUnit translation_unit;
+<*
+  Destroy the given \c CXSourceRangeList.
+*>
+extern fn void disposeSourceRangeList(
+  CXSourceRangeList* ranges)
+@cname("clang_disposeSourceRangeList");
+
+<*
+  Describes the severity of a particular diagnostic.
+*>
+constdef CXDiagnosticSeverity : CInt {
+
+  <*
+    A diagnostic that has been suppressed, e.g., by a command-line
+    option.
+  *>
+  DIAGNOSTIC_IGNORED = 0,
+
+  <*
+    This diagnostic is a note that should be attached to the
+    previous (non-note) diagnostic.
+  *>
+  DIAGNOSTIC_NOTE = 1,
+
+  <*
+    This diagnostic indicates suspicious code that may not be
+    wrong.
+  *>
+  DIAGNOSTIC_WARNING = 2,
+
+  <*
+    This diagnostic indicates that the code is ill-formed.
+  *>
+  DIAGNOSTIC_ERROR = 3,
+
+  <*
+    This diagnostic indicates that the code is ill-formed such
+    that future parser recovery is unlikely to produce useful
+    results.
+  *>
+  DIAGNOSTIC_FATAL = 4
 }
 
-/**
- * Given a cursor that represents a documentable entity (e.g.,
- * declaration), return the associated parsed comment as a
- * \c CXComment_FullComment AST node.
- */
-fn CXComment getParsedComment_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getParsedComment");
-
-/**
- * Describes the type of the comment AST node (\c CXComment).  A comment
- * node can be considered block content (e. g., paragraph), inline content
- * (plain text) or neither (the root AST node).
- */
-typedef CXCommentKind = inline CInt;
-
-/**
- * Null comment.  No AST node is constructed at the requested location
- * because there is no text or a syntax error.
- */
-const CXCommentKind COMMENT_NULL = 0;
-
-/**
- * Plain text.  Inline content.
- */
-const CXCommentKind COMMENT_TEXT = 1;
-
-/**
- * A command with word-like arguments that is considered inline content.
- *
- * For example: \\c command.
- */
-const CXCommentKind COMMENT_INLINE_COMMAND = 2;
-
-/**
- * HTML start tag with attributes (name-value pairs).  Considered
- * inline content.
- *
- * For example:
- * \verbatim
- * <br> <br /> <a href="http://example.org/">
- * \endverbatim
- */
-const CXCommentKind COMMENT_HTML_START_TAG = 3;
-
-/**
- * HTML end tag.  Considered inline content.
- *
- * For example:
- * \verbatim
- * </a>
- * \endverbatim
- */
-const CXCommentKind COMMENT_HTML_END_TAG = 4;
-
-/**
- * A paragraph, contains inline comment.  The paragraph itself is
- * block content.
- */
-const CXCommentKind COMMENT_PARAGRAPH = 5;
-
-/**
- * A command that has zero or more word-like arguments (number of
- * word-like arguments depends on command name) and a paragraph as an
- * argument.  Block command is block content.
- *
- * Paragraph argument is also a child of the block command.
- *
- * For example: \has 0 word-like arguments and a paragraph argument.
- *
- * AST nodes of special kinds that parser knows about (e. g., \\param
- * command) have their own node kinds.
- */
-const CXCommentKind COMMENT_BLOCK_COMMAND = 6;
-
-/**
- * A \\param or \\arg command that describes the function parameter
- * (name, passing direction, description).
- *
- * For example: \\param [in] ParamName description.
- */
-const CXCommentKind COMMENT_PARAM_COMMAND = 7;
-
-/**
- * A \\tparam command that describes a template parameter (name and
- * description).
- *
- * For example: \\tparam T description.
- */
-const CXCommentKind COMMENT_TPARAM_COMMAND = 8;
-
-/**
- * A verbatim block command (e. g., preformatted code).  Verbatim
- * block has an opening and a closing command and contains multiple lines of
- * text (\c CXComment_VerbatimBlockLine child nodes).
- *
- * For example:
- * \\verbatim
- * aaa
- * \\endverbatim
- */
-const CXCommentKind COMMENT_VERBATIM_BLOCK_COMMAND = 9;
-
-/**
- * A line of text that is contained within a
- * CXComment_VerbatimBlockCommand node.
- */
-const CXCommentKind COMMENT_VERBATIM_BLOCK_LINE = 10;
-
-/**
- * A verbatim line command.  Verbatim line has an opening command,
- * a single line of text (up to the newline after the opening command) and
- * has no closing command.
- */
-const CXCommentKind COMMENT_VERBATIM_LINE = 11;
-
-/**
- * A full comment attached to a declaration, contains block content.
- */
-const CXCommentKind COMMENT_FULL_COMMENT = 12;
-
-/**
- * The most appropriate rendering mode for an inline command, chosen on
- * command semantics in Doxygen.
- */
-typedef CXCommentInlineCommandRenderKind = inline CInt;
-/**
- * Command argument should be rendered in a normal font.
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_NORMAL = 0;
-
-/**
- * Command argument should be rendered in a bold font.
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_BOLD = 1;
-
-/**
- * Command argument should be rendered in a monospaced font.
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_MONOSPACED = 2;
-
-/**
- * Command argument should be rendered emphasized (typically italic
- * font).
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_EMPHASIZED = 3;
-
-/**
- * Command argument should not be rendered (since it only defines an anchor).
- */
-const CXCommentInlineCommandRenderKind COMMENT_INLINE_COMMAND_RENDER_KIND_ANCHOR = 4;
-
-/**
- * Describes parameter passing direction for \\param or \\arg command.
- */
-typedef CXCommentParamPassDirection = inline CInt;
-
-/**
- * The parameter is an input parameter.
- */
-const CXCommentParamPassDirection COMMENT_PARAM_PASS_DIRECTION_IN = 0;
-
-/**
- * The parameter is an output parameter.
- */
-const CXCommentParamPassDirection COMMENT_PARAM_PASS_DIRECTION_OUT = 1;
-
-/**
- * The parameter is an input and output parameter.
- */
-const CXCommentParamPassDirection COMMENT_PARAM_PASS_DIRECTION_IN_OUT = 2;
-
-/**
- * \param Comment AST node of any kind.
- *
- * \returns the type of the AST node.
- */
-fn CXCommentKind getKind_Comment(
-  CXComment comment) 
-@extern("clang_Comment_getKind");
-
-/**
- * \param Comment AST node of any kind.
- *
- * \returns number of children of the AST node.
- */
-fn CUInt getNumChildren_Comment(
-  CXComment comment) 
-@extern("clang_Comment_getNumChildren");
-
-/**
- * \param Comment AST node of any kind.
- *
- * \param ChildIdx child index (zero-based).
- *
- * \returns the specified child of the AST node.
- */
-fn CXComment getChild_Comment(
-  CXComment comment, 
-  CUInt child_idx) 
-@extern("clang_Comment_getChild");
-
-/**
- * A \c CXComment_Paragraph node is considered whitespace if it contains
- * only \c CXComment_Text nodes that are empty or whitespace.
- *
- * Other AST nodes (except \c CXComment_Paragraph and \c CXComment_Text) are
- * never considered whitespace.
- *
- * \returns non-zero if \c Comment is whitespace.
- */
-fn CUInt isWhitespace_Comment(
-  CXComment comment) 
-@extern("clang_Comment_isWhitespace");
-
-/**
- * \returns non-zero if \c Comment is inline content and has a newline
- * immediately following it in the comment text.  Newlines between paragraphs
- * do not count.
- */
-fn CUInt hasTrailingNewlineInlineContentComment(
-  CXComment comment) 
-@extern("clang_InlineContentComment_hasTrailingNewline");
-
-/**
- * \param Comment a \c CXComment_Text AST node.
- *
- * \returns text contained in the AST node.
- */
-fn CXString getTextTextComment(
-  CXComment comment) 
-@extern("clang_TextComment_getText");
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns name of the inline command.
- */
-fn CXString getCommandNameInlineCommandComment(
-  CXComment comment) 
-@extern("clang_InlineCommandComment_getCommandName");
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns the most appropriate rendering mode, chosen on command
- * semantics in Doxygen.
- */
-fn CXCommentInlineCommandRenderKind getRenderKindInlineCommandComment(
-  CXComment comment) 
-@extern("clang_InlineCommandComment_getRenderKind");
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns number of command arguments.
- */
-fn CUInt getNumArgsInlineCommandComment(
-  CXComment comment) 
-@extern("clang_InlineCommandComment_getNumArgs");
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \param ArgIdx argument index (zero-based).
- *
- * \returns text of the specified argument.
- */
-fn CXString getArgTextInlineCommandComment(
-  CXComment comment, 
-  CUInt arg_idx) 
-@extern("clang_InlineCommandComment_getArgText");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
- * node.
- *
- * \returns HTML tag name.
- */
-fn CXString getTagNameHTMLTagComment(
-  CXComment comment) 
-@extern("clang_HTMLTagComment_getTagName");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \returns non-zero if tag is self-closing (for example, &lt;br /&gt;).
- */
-fn CUInt isSelfClosingHTMLStartTagComment(
-  CXComment comment) 
-@extern("clang_HTMLStartTagComment_isSelfClosing");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \returns number of attributes (name-value pairs) attached to the start tag.
- */
-fn CUInt getNumAttrsHTMLStartTag(
-  CXComment comment) 
-@extern("clang_HTMLStartTag_getNumAttrs");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \param AttrIdx attribute index (zero-based).
- *
- * \returns name of the specified attribute.
- */
-fn CXString getAttrNameHTMLStartTag(
-  CXComment comment, 
-  CUInt attr_idx) 
-@extern("clang_HTMLStartTag_getAttrName");
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \param AttrIdx attribute index (zero-based).
- *
- * \returns value of the specified attribute.
- */
-fn CXString getAttrValueHTMLStartTag(
-  CXComment comment, 
-  CUInt attr_idx) 
-@extern("clang_HTMLStartTag_getAttrValue");
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \returns name of the block command.
- */
-fn CXString getCommandNameCXBlockCommandComment(
-  CXComment comment) 
-@extern("clang_BlockCommandComment_getCommandName");
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \returns number of word-like arguments.
- */
-fn CUInt getNumArgsBlockCommandComment(
-  CXComment comment) 
-@extern("clang_BlockCommandComment_getNumArgs");
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \param ArgIdx argument index (zero-based).
- *
- * \returns text of the specified word-like argument.
- */
-fn CXString getArgTextBlockCommandComment(
-  CXComment comment, 
-  CUInt arg_idx) 
-@extern("clang_BlockCommandComment_getArgText");
-
-/**
- * \param Comment a \c CXComment_BlockCommand or
- * \c CXComment_VerbatimBlockCommand AST node.
- *
- * \returns paragraph argument of the block command.
- */
-fn CXComment getParagraphBlockCommandComment(
-  CXComment comment) 
-@extern("clang_BlockCommandComment_getParagraph");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns parameter name.
- */
-fn CXString getParamNameParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_getParamName");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns non-zero if the parameter that this AST node represents was found
- * in the function prototype and \c clang_ParamCommandComment_getParamIndex
- * function will return a meaningful value.
- */
-fn CUInt isParamIndexValidParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_isParamIndexValid");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns zero-based parameter index in function prototype.
- */
-fn CUInt getParamIndexParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_getParamIndex");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns non-zero if parameter passing direction was specified explicitly in
- * the comment.
- */
-fn CUInt isDirectionExplicitParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_isDirectionExplicit");
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns parameter passing direction.
- */
-fn CXCommentParamPassDirection getDirectionParamCommandComment(
-  CXComment comment) 
-@extern("clang_ParamCommandComment_getDirection");
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns template parameter name.
- */
-fn CXString getParamNameTParamCommandComment(
-  CXComment comment) 
-@extern("clang_TParamCommandComment_getParamName");
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns non-zero if the parameter that this AST node represents was found
- * in the template parameter list and
- * \c clang_TParamCommandComment_getDepth and
- * \c clang_TParamCommandComment_getIndex functions will return a meaningful
- * value.
- */
-fn CUInt isParamPositionValidTParamCommandComment(
-  CXComment comment) 
-@extern("clang_TParamCommandComment_isParamPositionValid");
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns zero-based nesting depth of this parameter in the template parameter list.
- *
- * For example,
- * \verbatim
- *     template<typename C, template<typename T> class TT>
- *     void test(TT<CInt> aaa);
- * \endverbatim
- * for C and TT nesting depth is 0,
- * for T nesting depth is 1.
- */
-fn CUInt getDepthTParamCommandComment(
-  CXComment comment) 
-@extern("clang_TParamCommandComment_getDepth");
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns zero-based parameter index in the template parameter list at a
- * given nesting depth.
- *
- * For example,
- * \verbatim
- *     template<typename C, template<typename T> class TT>
- *     void test(TT<CInt> aaa);
- * \endverbatim
- * for C and TT nesting depth is 0, so we can ask for index at depth 0:
- * at depth 0 C's index is 0, TT's index is 1.
- *
- * For T nesting depth is 1, so we can ask for index at depth 0 and 1:
- * at depth 0 T's index is 1 (same as TT's),
- * at depth 1 T's index is 0.
- */
-fn CUInt getIndexTParamCommandComment(
-  CXComment comment, 
-  CUInt depth) 
-@extern("clang_TParamCommandComment_getIndex");
-
-/**
- * \param Comment a \c CXComment_VerbatimBlockLine AST node.
- *
- * \returns text contained in the AST node.
- */
-fn CXString getTextVerbatimBlockLineComment(
-  CXComment comment) 
-@extern("clang_VerbatimBlockLineComment_getText");
-
-/**
- * \param Comment a \c CXComment_VerbatimLine AST node.
- *
- * \returns text contained in the AST node.
- */
-fn CXString getTextVerbatimLineComment(
-  CXComment comment) 
-@extern("clang_VerbatimLineComment_getText");
-
-/**
- * Convert an HTML tag AST node to string.
- *
- * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
- * node.
- *
- * \returns string containing an HTML tag.
- */
-fn CXString getAsStringHTMLTagComment(
-  CXComment comment) 
-@extern("clang_HTMLTagComment_getAsString");
-
-/**
- * Convert a given full parsed comment to an HTML fragment.
- *
- * Specific details of HTML layout are subject to change.  Don't try to parse
- * this HTML back into an AST, use other APIs instead.
- *
- * Currently the following CSS classes are used:
- * \li "para-brief" for \paragraph and equivalent commands;
- * \li "para-returns" for \\returns paragraph and equivalent commands;
- * \li "word-returns" for the "Returns" word in \\returns paragraph.
- *
- * Function argument documentation is rendered as a \<dl\> list with arguments
- * sorted in function prototype order.  CSS classes used:
- * \li "param-name-index-NUMBER" for parameter name (\<dt\>);
- * \li "param-descr-index-NUMBER" for parameter description (\<dd\>);
- * \li "param-name-index-invalid" and "param-descr-index-invalid" are used if
- * parameter index is invalid.
- *
- * Template parameter documentation is rendered as a \<dl\> list with
- * parameters sorted in template parameter list order.  CSS classes used:
- * \li "tparam-name-index-NUMBER" for parameter name (\<dt\>);
- * \li "tparam-descr-index-NUMBER" for parameter description (\<dd\>);
- * \li "tparam-name-index-other" and "tparam-descr-index-other" are used for
- * names inside template template parameters;
- * \li "tparam-name-index-invalid" and "tparam-descr-index-invalid" are used if
- * parameter position is invalid.
- *
- * \param Comment a \c CXComment_FullComment AST node.
- *
- * \returns string containing an HTML fragment.
- */
-fn CXString getAsHTMLFullComment(
-  CXComment comment) 
-@extern("clang_FullComment_getAsHTML");
-
-/**
- * Convert a given full parsed comment to an XML document.
- *
- * A Relax NG schema for the XML can be found in comment-xml-schema.rng file
- * inside clang source tree.
- *
- * \param Comment a \c CXComment_FullComment AST node.
- *
- * \returns string containing an XML document.
- */
-fn CXString getAsXMLFullComment(
-  CXComment comment) 
-@extern("clang_FullComment_getAsXML");
-
-/**
- * CXAPISet is an opaque type that represents a data structure containing all
- * the API information for a given translation unit. This can be used for a
- * single symbol symbol graph for a given symbol.
- */
-typedef CXAPISet = inline void*;
-
-/**
- * Traverses the translation unit to create a \c CXAPISet.
- *
- * \param tu is the \c CXTranslationUnit to build the \c CXAPISet for.
- *
- * \param out_api is a pointer to the output of this function. It is needs to be
- * disposed of by calling clang_disposeAPISet.
- *
- * \returns Error code indicating success or failure of the APISet creation.
- */
-fn CXErrorCode createAPISet(
-  CXTranslationUnit tu, 
-  CXAPISet* out_api) 
-@extern("clang_createAPISet");
-
-/**
- * Dispose of an APISet.
- *
- * The provided \c CXAPISet can not be used after this function is called.
- */
-fn void disposeAPISet(
-  CXAPISet api) 
-@extern("clang_disposeAPISet");
-
-/**
- * Generate a single symbol symbol graph for the given USR. Returns a null
- * string if the associated symbol can not be found in the provided \c CXAPISet.
- *
- * The output contains the symbol graph as well as some additional information
- * about related symbols.
- *
- * \param usr is a string containing the USR of the symbol to generate the
- * symbol graph for.
- *
- * \param api the \c CXAPISet to look for the symbol in.
- *
- * \returns a string containing the serialized symbol graph representation for
- * the symbol being queried or a null string if it can not be found in the
- * APISet.
- */
-fn CXString getSymbolGraphForUSR(
-  ZString usr, 
-  CXAPISet api) 
-@extern("clang_getSymbolGraphForUSR");
-
-/**
- * Generate a single symbol symbol graph for the declaration at the given
- * cursor. Returns a null string if the AST node for the cursor isn't a
- * declaration.
- *
- * The output contains the symbol graph as well as some additional information
- * about related symbols.
- *
- * \param cursor the declaration for which to generate the single symbol symbol
- * graph.
- *
- * \returns a string containing the serialized symbol graph representation for
- * the symbol being queried or a null string if it can not be found in the
- * APISet.
- */
-fn CXString getSymbolGraphForCursor(
-  CXCursor cursor) 
-@extern("clang_getSymbolGraphForCursor");
-
-
-/*-------------------------------*\
-|                                 |
-|     File FatalErrorHandler.h    |
-|                                 |
-\*-------------------------------*/
-
-/**
- * Installs error handler that prints error message to stderr and calls abort().
- * Replaces currently installed error handler (if any).
- */
-fn void installAbortingLLVMFatalErrorHandler() 
-@extern("clang_install_aborting_llvm_fatal_error_handler");
-
-/**
- * Removes currently installed error handler (if any).
- * If no error handler is intalled, the default strategy is to print error
- * message to stderr and call exit(1).
- */
-fn void uninstallLLVMFatalErrorHandler() 
-@extern("clang_uninstall_llvm_fatal_error_handler");
-
-
-/*-------------------------------*\
-|                                 |
-|         File Rewrite.h          |
-|                                 |
-\*-------------------------------*/
-
-typedef CXRewriter = void*;
-
-/**
- * Create CXRewriter.
- */
-fn CXRewriter create_Rewriter(
-  CXTranslationUnit tu) 
-@extern("clang_CXRewriter_create");
-
-/**
- * Insert the specified string at the specified location in the original buffer.
- */
-fn void insertTextBefore_Rewriter(
-  CXRewriter rew, 
-  CXSourceLocation loc, 
-  ZString insert) 
-@extern("clang_CXRewriter_insertTextBefore");
-
-/**
- * Replace the specified range of characters in the input with the specified
- * replacement.
- */
-fn void replaceText_Rewriter(
-  CXRewriter rew, 
-  CXSourceRange to_be_replaced, 
-  ZString replacement) 
-@extern("clang_CXRewriter_replaceText");
-
-/**
- * Remove the specified range.
- */
-fn void removeText_Rewriter(
-  CXRewriter rew, 
-  CXSourceRange to_be_removed) 
-@extern("clang_CXRewriter_removeText");
-
-/**
- * Save all changed files to disk.
- * Returns 1 if any files were not saved successfully, returns 0 otherwise.
- */
-fn CInt overwriteChangedFiles_Rewriter(
-  CXRewriter rew) 
-@extern("clang_CXRewriter_overwriteChangedFiles");
-
-/**
- * Write out rewritten version of the main file to stdout.
- */
-fn void writeMainFileToStdOut_Rewriter(
-  CXRewriter rew) 
-@extern("clang_CXRewriter_writeMainFileToStdOut");
-
-/**
- * Free the given CXRewriter.
- */
-fn void dispose_Rewriter(
-  CXRewriter rew) 
-@extern("clang_CXRewriter_dispose");
-
-
-/*-------------------------------*\
-|                                 |
-|          File Index.h           |
-|                                 |
-\*-------------------------------*/
-
-/**
- * An "index" that consists of a set of translation units that would
- * typically be linked together into an executable or library.
- */
-typedef CXIndex = inline void*;
-
-/**
- * An opaque type representing target information for a given translation
- * unit.
- */
-typedef CXTargetInfo = inline void*;
-
-/**
- * A single translation unit, which resides in an index.
- */
-typedef CXTranslationUnit = inline void*;
-
-/**
- * Opaque pointer representing client data that will be passed through
- * to various callbacks and visitors.
- */
-typedef CXClientData = inline void*;
-
-/**
- * Provides the contents of a file that has not yet been saved to disk.
- *
- * Each CXUnsavedFile instance provides the name of a file on the
- * system along with the current contents of that file that have not
- * yet been saved to disk.
- */
+alias CXDiagnostic = void*;
+
+alias CXDiagnosticSet = void*;
+
+<*
+  Determine the number of diagnostics in a CXDiagnosticSet.
+*>
+extern fn CUInt getNumDiagnosticsInSet(
+  CXDiagnosticSet diags)
+@cname("clang_getNumDiagnosticsInSet");
+
+<*
+  Retrieve a diagnostic associated with the given CXDiagnosticSet.
+  \param Diags the CXDiagnosticSet to query.
+  \param Index the zero-based diagnostic number to retrieve.
+  \returns the requested diagnostic. This diagnostic must be freed
+  via a call to \c clang_disposeDiagnostic().
+*>
+extern fn CXDiagnostic getDiagnosticInSet(
+  CXDiagnosticSet diags,
+  CUInt index)
+@cname("clang_getDiagnosticInSet");
+
+<*
+  Describes the kind of error that occurred (if any) in a call to
+  \c clang_loadDiagnostics.
+*>
+constdef CXLoadDiag_Error : CInt {
+
+  <*
+    Indicates that no error occurred.
+  *>
+  LOAD_DIAG_NONE = 0,
+
+  <*
+    Indicates that an unknown error occurred while attempting to
+    deserialize diagnostics.
+  *>
+  LOAD_DIAG_UNKNOWN = 1,
+
+  <*
+    Indicates that the file containing the serialized diagnostics
+    could not be opened.
+  *>
+  LOAD_DIAG_CANNOT_LOAD = 2,
+
+  <*
+    Indicates that the serialized diagnostics file is invalid or
+    corrupt.
+  *>
+  LOAD_DIAG_INVALID_FILE = 3
+}
+
+<*
+  Deserialize a set of diagnostics from a Clang diagnostics bitcode
+  file.
+  \param file The name of the file to deserialize.
+  \param error A pointer to a enum value recording if there was a problem
+  deserializing the diagnostics.
+  \param errorString A pointer to a CXString for recording the error string
+  if the file was not successfully loaded.
+  \returns A loaded CXDiagnosticSet if successful, and NULL otherwise.  These
+  diagnostics should be released using clang_disposeDiagnosticSet().
+*>
+extern fn CXDiagnosticSet loadDiagnostics(
+  ZString file,
+  CXLoadDiag_Error* error,
+  CXString* error_string)
+@cname("clang_loadDiagnostics");
+
+<*
+  Release a CXDiagnosticSet and all of its contained diagnostics.
+*>
+extern fn void disposeDiagnosticSet(
+  CXDiagnosticSet diags)
+@cname("clang_disposeDiagnosticSet");
+
+<*
+  Retrieve the child diagnostics of a CXDiagnostic.
+  This CXDiagnosticSet does not need to be released by
+  clang_disposeDiagnosticSet.
+*>
+extern fn CXDiagnosticSet getChildDiagnostics(
+  CXDiagnostic d)
+@cname("clang_getChildDiagnostics");
+
+<*
+  Destroy a diagnostic.
+*>
+extern fn void disposeDiagnostic(
+  CXDiagnostic diagnostic)
+@cname("clang_disposeDiagnostic");
+
+<*
+  Options to control the display of diagnostics.
+  The values in this enum are meant to be combined to customize the
+  behavior of \c clang_formatDiagnostic().
+*>
+constdef CXDiagnosticDisplayOptions : CInt {
+
+  <*
+    Display the source-location information where the
+    diagnostic was located.
+    When set, diagnostics will be prefixed by the file, line, and
+    (optionally) column to which the diagnostic refers. For example,
+    \code
+    test.c:28: warning: extra tokens at end of #endif directive
+    \endcode
+    This option corresponds to the clang flag \c -fshow-source-location.
+  *>
+  DIAGNOSTIC_DISPLAY_SOURCE_LOCATION = 1,
+
+  <*
+    If displaying the source-location information of the
+    diagnostic, also include the column number.
+    This option corresponds to the clang flag \c -fshow-column.
+  *>
+  DIAGNOSTIC_DISPLAY_COLUMN = 2,
+
+  <*
+    If displaying the source-location information of the
+    diagnostic, also include information about source ranges in a
+    machine-parsable format.
+    This option corresponds to the clang flag
+    \c -fdiagnostics-print-source-range-info.
+  *>
+  DIAGNOSTIC_DISPLAY_SOURCE_RANGES = 4,
+
+  <*
+    Display the option name associated with this diagnostic, if any.
+    The option name displayed (e.g., -Wconversion) will be placed in brackets
+    after the diagnostic text. This option corresponds to the clang flag
+    \c -fdiagnostics-show-option.
+  *>
+  DIAGNOSTIC_DISPLAY_OPTION = 8,
+
+  <*
+    Display the category number associated with this diagnostic, if any.
+    The category number is displayed within brackets after the diagnostic text.
+    This option corresponds to the clang flag
+    \c -fdiagnostics-show-category=id.
+  *>
+  DIAGNOSTIC_DISPLAY_CATEGORY_ID = 16,
+
+  <*
+    Display the category name associated with this diagnostic, if any.
+    The category name is displayed within brackets after the diagnostic text.
+    This option corresponds to the clang flag
+    \c -fdiagnostics-show-category=name.
+  *>
+  DIAGNOSTIC_DISPLAY_CATEGORY_NAME = 32
+}
+
+<*
+  Format the given diagnostic in a manner that is suitable for display.
+  This routine will format the given diagnostic to a string, rendering
+  the diagnostic according to the various options given. The
+  \c clang_defaultDiagnosticDisplayOptions() function returns the set of
+  options that most closely mimics the behavior of the clang compiler.
+  \param Diagnostic The diagnostic to print.
+  \param Options A set of options that control the diagnostic display,
+  created by combining \c CXDiagnosticDisplayOptions values.
+  \returns A new string containing for formatted diagnostic.
+*>
+extern fn CXString formatDiagnostic(
+  CXDiagnostic diagnostic,
+  CUInt options)
+@cname("clang_formatDiagnostic");
+
+<*
+  Retrieve the set of display options most similar to the
+  default behavior of the clang compiler.
+  \returns A set of display options suitable for use with \c
+  clang_formatDiagnostic().
+*>
+extern fn CUInt defaultDiagnosticDisplayOptions()
+@cname("clang_defaultDiagnosticDisplayOptions");
+
+<*
+  Determine the severity of the given diagnostic.
+*>
+extern fn CXDiagnosticSeverity getDiagnosticSeverity(
+  CXDiagnostic)
+@cname("clang_getDiagnosticSeverity");
+
+<*
+  Retrieve the source location of the given diagnostic.
+  This location is where Clang would print the caret ('^') when
+  displaying the diagnostic on the command line.
+*>
+extern fn CXSourceLocation getDiagnosticLocation(
+  CXDiagnostic)
+@cname("clang_getDiagnosticLocation");
+
+<*
+  Retrieve the text of the given diagnostic.
+*>
+extern fn CXString getDiagnosticSpelling(
+  CXDiagnostic)
+@cname("clang_getDiagnosticSpelling");
+
+<*
+  Retrieve the name of the command-line option that enabled this
+  diagnostic.
+  \param Diag The diagnostic to be queried.
+  \param Disable If non-NULL, will be set to the option that disables this
+  diagnostic (if any).
+  \returns A string that contains the command-line option used to enable this
+  warning, such as "-Wconversion" or "-pedantic".
+*>
+extern fn CXString getDiagnosticOption(
+  CXDiagnostic diag,
+  CXString* disable)
+@cname("clang_getDiagnosticOption");
+
+<*
+  Retrieve the category number for this diagnostic.
+  Diagnostics can be categorized into groups along with other, related
+  diagnostics (e.g., diagnostics under the same warning flag). This routine
+  retrieves the category number for the given diagnostic.
+  \returns The number of the category that contains this diagnostic, or zero
+  if this diagnostic is uncategorized.
+*>
+extern fn CUInt getDiagnosticCategory(
+  CXDiagnostic)
+@cname("clang_getDiagnosticCategory");
+
+<*
+  Retrieve the name of a particular diagnostic category.  This
+  is now deprecated.  Use clang_getDiagnosticCategoryText()
+  instead.
+  \param Category A diagnostic category number, as returned by
+  \c clang_getDiagnosticCategory().
+  \returns The name of the given diagnostic category.
+*>
+extern fn CXString getDiagnosticCategoryName(
+  CUInt category)
+@cname("clang_getDiagnosticCategoryName");
+
+<*
+  Retrieve the diagnostic category text for a given diagnostic.
+  \returns The text of the given diagnostic category.
+*>
+extern fn CXString getDiagnosticCategoryText(
+  CXDiagnostic)
+@cname("clang_getDiagnosticCategoryText");
+
+<*
+  Determine the number of source ranges associated with the given
+  diagnostic.
+*>
+extern fn CUInt getDiagnosticNumRanges(
+  CXDiagnostic)
+@cname("clang_getDiagnosticNumRanges");
+
+<*
+  Retrieve a source range associated with the diagnostic.
+  A diagnostic's source ranges highlight important elements in the source
+  code. On the command line, Clang displays source ranges by
+  underlining them with '~' characters.
+  \param Diagnostic the diagnostic whose range is being extracted.
+  \param Range the zero-based index specifying which range to
+  \returns the requested source range.
+*>
+extern fn CXSourceRange getDiagnosticRange(
+  CXDiagnostic diagnostic,
+  CUInt range)
+@cname("clang_getDiagnosticRange");
+
+<*
+  Determine the number of fix-it hints associated with the
+  given diagnostic.
+*>
+extern fn CUInt getDiagnosticNumFixIts(
+  CXDiagnostic diagnostic)
+@cname("clang_getDiagnosticNumFixIts");
+
+<*
+  Retrieve the replacement information for a given fix-it.
+  Fix-its are described in terms of a source range whose contents
+  should be replaced by a string. This approach generalizes over
+  three kinds of operations: removal of source code (the range covers
+  the code to be removed and the replacement string is empty),
+  replacement of source code (the range covers the code to be
+  replaced and the replacement string provides the new code), and
+  insertion (both the start and end of the range point at the
+  insertion location, and the replacement string provides the text to
+  insert).
+  \param Diagnostic The diagnostic whose fix-its are being queried.
+  \param FixIt The zero-based index of the fix-it.
+  \param ReplacementRange The source range whose contents will be
+  replaced with the returned replacement string. Note that source
+  ranges are half-open ranges [a, b), so the source code should be
+  replaced from a and up to (but not including) b.
+  \returns A string containing text that should be replace the source
+  code indicated by the \c ReplacementRange.
+*>
+extern fn CXString getDiagnosticFixIt(
+  CXDiagnostic diagnostic,
+  CUInt fix_it,
+  CXSourceRange* replacement_range)
+@cname("clang_getDiagnosticFixIt");
+
+alias CXIndex = void*;
+
+alias CXTargetInfo = void*;
+
+alias CXTranslationUnit = void*;
+
+alias CXClientData = void*;
+
+<*
+  Provides the contents of a file that has not yet been saved to disk.
+  Each CXUnsavedFile instance provides the name of a file on the
+  system along with the current contents of that file that have not
+  yet been saved to disk.
+*>
 struct CXUnsavedFile {
-  /*
-   * The file whose contents have not yet been saved.
-   *
-   * This file must already exist in the file system.
-   */
   ZString filename;
-
-  /*
-   * A buffer containing the unsaved contents of this file.
-   */
   ZString contents;
-
-  /* 
-   * The length of the unsaved contents of this buffer.
-   */
-  ulong length;
+  CULong length;
 }
 
-/**
- * Describes the availability of a particular entity, which indicates
- * whether the use of this entity will result in a warning or error due to
- * it being deprecated or unavailable.
- */
-typedef CXAvailabilityKind = inline CInt;
+<*
+  Describes the availability of a particular entity, which indicates
+  whether the use of this entity will result in a warning or error due to
+  it being deprecated or unavailable.
+*>
+constdef CXAvailabilityKind : CInt {
 
-/**
- * The entity is available.
- */
-const CXAvailabilityKind AVAILABILITY_AVAILABLE = 0;
-/*
- * The entity is available, but has been deprecated (and its use is
- * not recommended).
- */
-const CXAvailabilityKind AVAILABILITY_DEPRECATED = 1;
-/*
- * The entity is not available; any use of it will be an error.
- */
-const CXAvailabilityKind AVAILABILITY_NOT_AVAILABLE = 2;
-/*
- * The entity is available, but not accessible; any use of it will be
- * an error.
- */
-const CXAvailabilityKind AVAILABILITY_NOT_ACCESSIBLE = 3;
+  <*
+    The entity is available.
+  *>
+  AVAILABILITY_AVAILABLE = 0,
 
-/**
- * Describes a version number of the form major.minor.subminor.
- */
+  <*
+    The entity is available, but has been deprecated (and its use is
+    not recommended).
+  *>
+  AVAILABILITY_DEPRECATED = 1,
+
+  <*
+    The entity is not available; any use of it will be an error.
+  *>
+  AVAILABILITY_NOT_AVAILABLE = 2,
+
+  <*
+    The entity is available, but not accessible; any use of it will be
+    an error.
+  *>
+  AVAILABILITY_NOT_ACCESSIBLE = 3
+}
+
+<*
+  Describes a version number of the form major.minor.subminor.
+*>
 struct CXVersion {
-  /*
-   * The major version number, e.g., the '10' in '10.7.3'. A negative
-   * value indicates that there is no version number at all.
-   */
   CInt major;
-
-  /*
-   * The minor version number, e.g., the '7' in '10.7.3'. This value
-   * will be negative if no minor version number was provided, e.g., for
-   * version '10'.
-   */
   CInt minor;
-
-  /*
-   * The subminor version number, e.g., the '3' in '10.7.3'. This value
-   * will be negative if no minor or subminor version number was provided,
-   * e.g., in version '10' or '10.7'.
-   */
   CInt subminor;
 }
 
-/**
- * Describes the exception specification of a cursor.
- *
- * A negative value indicates that the cursor is not a function declaration.
- */
-typedef CXCursor_ExceptionSpecificationKind = inline CInt;
+<*
+  Describes the exception specification of a cursor.
+  A negative value indicates that the cursor is not a function declaration.
+*>
+constdef CXCursor_ExceptionSpecificationKind : CInt {
 
-/**
- * The cursor has no exception specification.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_NONE = 0;
-/**
- * The cursor has exception specification throw()
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC_NONE = 1;
-/**
- * The cursor has exception specification throw(T1, T2)
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC = 2;
-/**
- * The cursor has exception specification throw(...).
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_MS_ANY = 3;
-/**
- * The cursor has exception specification basic noexcept.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_BASIC_NOEXCEPT = 4;
-/**
- * The cursor has exception specification computed noexcept.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_COMPUTED_NOEXCEPT = 5;
-/**
- * The exception specification has not yet been evaluated.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_UNEVALUATED = 6;
-/**
- * The exception specification has not yet been instantiated.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_UNINSTANTIATED = 7;
-/**
- * The exception specification has not been parsed yet.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_UNPARSED = 8;
-/**
- * The cursor has a __declspec(nothrow) exception specification.
- */
-const CXCursor_ExceptionSpecificationKind CURSOR_EXCEPTION_SPECIFICATION_KIND_NO_THROW = 9;
+  <*
+    The cursor has no exception specification.
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_NONE = 0,
 
+  <*
+    The cursor has exception specification throw()
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC_NONE = 1,
 
-/**
- * Provides a shared context for creating translation units.
- *
- * It provides two options:
- *
- * - excludeDeclarationsFromPCH: When non-zero, allows enumeration of "local"
- * declarations (when loading any new translation units). A "local" declaration
- * is one that belongs in the translation unit itself and not in a precompiled
- * header that was used by the translation unit. If zero, all declarations
- * will be enumerated.
- *
- * Here is an example:
- *
- * \code
- *   // excludeDeclsFromPCH = 1, displayDiagnostics=1
- *   Idx = clang_createIndex(1, 1);
- *
- *   // IndexTest.pch was produced with the following command:
- *   // "clang -x c IndexTest.h -emit-ast -o IndexTest.pch"
- *   TU = clang_createTranslationUnit(Idx, "IndexTest.pch");
- *
- *   // This will load all the symbols from 'IndexTest.pch'
- *   clang_visitChildren(clang_getTranslationUnitCursor(TU),
- *                       TranslationUnitVisitor, 0);
- *   clang_disposeTranslationUnit(TU);
- *
- *   // This will load all the symbols from 'IndexTest.c', excluding symbols
- *   // from 'IndexTest.pch'.
- *   CChar *args[] = { "-Xclang", "-include-pch=IndexTest.pch" };
- *   TU = clang_createTranslationUnitFromSourceFile(Idx, "IndexTest.c", 2, args,
- *                                                  0, 0);
- *   clang_visitChildren(clang_getTranslationUnitCursor(TU),
- *                       TranslationUnitVisitor, 0);
- *   clang_disposeTranslationUnit(TU);
- * \endcode
- *
- * This process of creating the 'pch', loading it separately, and using it (via
- * -include-pch) allows 'excludeDeclsFromPCH' to remove redundant callbacks
- * (which gives the indexer the same performance benefit as the compiler).
- */
-fn CXIndex createIndex(
-  CInt excludeDeclarationsFromPCH, 
-  CInt displayDiagnostics) 
-@extern("clang_createIndex");
+  <*
+    The cursor has exception specification throw(T1, T2)
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_DYNAMIC = 2,
 
-/**
- * Destroy the given index.
- *
- * The index must not be destroyed until all of the translation units created
- * within that index have been destroyed.
- */
-fn void disposeIndex(
-  CXIndex index) 
-@extern("clang_disposeIndex");
+  <*
+    The cursor has exception specification throw(...).
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_MS_ANY = 3,
 
-typedef CXChoice = inline CInt;
+  <*
+    The cursor has exception specification basic noexcept.
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_BASIC_NOEXCEPT = 4,
 
-/*
- * Use the default value of an option that may depend on the process
- * environment.
- */
-const CXChoice CHOICE_DEFAULT = 0;
-/*
- * Enable the option.
- */
-const CXChoice CHOICE_ENABLED = 1;
-/*
- * Disable the option.
- */
-const CXChoice CHOICE_DISABLED = 2;
+  <*
+    The cursor has exception specification computed noexcept.
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_COMPUTED_NOEXCEPT = 5,
 
-typedef CXGlobalOptFlags = inline CInt;
-/*
- * Used to indicate that no special CXIndex options are needed.
- */
+  <*
+    The exception specification has not yet been evaluated.
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_UNEVALUATED = 6,
 
-const CXGlobalOptFlags GLOBAL_OPT_FLAGS_NONE = 0x0;
+  <*
+    The exception specification has not yet been instantiated.
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_UNINSTANTIATED = 7,
 
-/*
- * Used to indicate that threads that libclang creates for indexing
- * purposes should use background priority.
- *
- * Affects #clang_indexSourceFile, #clang_indexTranslationUnit,
- * #clang_parseTranslationUnit, #clang_saveTranslationUnit.
- */
-const CXGlobalOptFlags GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_INDEXING = 0x1;
-/*
- * Used to indicate that threads that libclang creates for editing
- * purposes should use background priority.
- *
- * Affects #clang_reparseTranslationUnit, #clang_codeCompleteAt,
- * #clang_annotateTokens
- */
-const CXGlobalOptFlags GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_EDITING = 0x2;
-/*
- * Used to indicate that all threads that libclang creates should use
- * background priority.
- */
-const CXGlobalOptFlags GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_ALL = GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_INDEXING | GLOBAL_OPT_FLAGS_THREAD_BACKGROUND_PRIORITY_FOR_EDITING;
+  <*
+    The exception specification has not been parsed yet.
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_UNPARSED = 8,
 
+  <*
+    The cursor has a __declspec(nothrow) exception specification.
+  *>
+  CURSOR_EXCEPTION_SPECIFICATION_KIND_NO_THROW = 9
+}
 
-/**
- * Index initialization options.
- *
- * 0 is the default value of each member of this struct except for Size.
- * Initialize the struct in one of the following three ways to avoid adapting
- * code each time a new member is added to it:
- * \code
- * CXIndexOptions Opts;
- * memset(&Opts, 0, sizeof(Opts));
- * Opts.Size = sizeof(CXIndexOptions);
- * \endcode
- * or explicitly initialize the first data member and zero-initialize the rest:
- * \code
- * CXIndexOptions Opts = { sizeof(CXIndexOptions) };
- * \endcode
- * or to prevent the -Wmissing-field-initializers warning for the above version:
- * \code
- * CXIndexOptions Opts{};
- * Opts.Size = sizeof(CXIndexOptions);
- * \endcode
- */
+<*
+  Provides a shared context for creating translation units.
+  It provides two options:
+  - excludeDeclarationsFromPCH: When non-zero, allows enumeration of "local"
+  declarations (when loading any new translation units). A "local" declaration
+  is one that belongs in the translation unit itself and not in a precompiled
+  header that was used by the translation unit. If zero, all declarations
+  will be enumerated.
+  Here is an example:
+  \code
+  // excludeDeclsFromPCH = 1, displayDiagnostics=1
+  Idx = clang_createIndex(1, 1);
+  // IndexTest.pch was produced with the following command:
+  // "clang -x c IndexTest.h -emit-ast -o IndexTest.pch"
+  TU = clang_createTranslationUnit(Idx, "IndexTest.pch");
+  // This will load all the symbols from 'IndexTest.pch'
+  clang_visitChildren(clang_getTranslationUnitCursor(TU),
+  TranslationUnitVisitor, 0);
+  clang_disposeTranslationUnit(TU);
+  // This will load all the symbols from 'IndexTest.c', excluding symbols
+  // from 'IndexTest.pch'.
+  char *args[] = { "-Xclang", "-include-pch=IndexTest.pch" };
+  TU = clang_createTranslationUnitFromSourceFile(Idx, "IndexTest.c", 2, args,
+  0, 0);
+  clang_visitChildren(clang_getTranslationUnitCursor(TU),
+  TranslationUnitVisitor, 0);
+  clang_disposeTranslationUnit(TU);
+  \endcode
+  This process of creating the 'pch', loading it separately, and using it (via
+  -include-pch) allows 'excludeDeclsFromPCH' to remove redundant callbacks
+  (which gives the indexer the same performance benefit as the compiler).
+*>
+extern fn CXIndex createIndex(
+  CInt exclude_declarations_from_pch,
+  CInt display_diagnostics)
+@cname("clang_createIndex");
+
+<*
+  Destroy the given index.
+  The index must not be destroyed until all of the translation units created
+  within that index have been destroyed.
+*>
+extern fn void disposeIndex(
+  CXIndex index)
+@cname("clang_disposeIndex");
+
+constdef CXChoice : CInt {
+
+  <*
+    Use the default value of an option that may depend on the process
+    environment.
+  *>
+  CHOICE_DEFAULT = 0,
+
+  <*
+    Enable the option.
+  *>
+  CHOICE_ENABLED = 1,
+
+  <*
+    Disable the option.
+  *>
+  CHOICE_DISABLED = 2
+}
+
+constdef CXGlobalOptFlags : CInt {
+
+  <*
+    Used to indicate that no special CXIndex options are needed.
+  *>
+  GLOBAL_OPT_NONE = 0,
+
+  <*
+    Used to indicate that threads that libclang creates for indexing
+    purposes should use background priority.
+    Affects #clang_indexSourceFile, #clang_indexTranslationUnit,
+    #clang_parseTranslationUnit, #clang_saveTranslationUnit.
+  *>
+  GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_INDEXING = 1,
+
+  <*
+    Used to indicate that threads that libclang creates for editing
+    purposes should use background priority.
+    Affects #clang_reparseTranslationUnit, #clang_codeCompleteAt,
+    #clang_annotateTokens
+  *>
+  GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_EDITING = 2,
+
+  <*
+    Used to indicate that all threads that libclang creates should use
+    background priority.
+  *>
+  GLOBAL_OPT_THREAD_BACKGROUND_PRIORITY_FOR_ALL = 3
+}
+
+<*
+  Index initialization options.
+  0 is the default value of each member of this struct except for Size.
+  Initialize the struct in one of the following three ways to avoid adapting
+  code each time a new member is added to it:
+  \code
+  CXIndexOptions Opts;
+  memset(&Opts, 0, sizeof(Opts));
+  Opts.Size = sizeof(CXIndexOptions);
+  \endcode
+  or explicitly initialize the first data member and zero-initialize the rest:
+  \code
+  CXIndexOptions Opts = { sizeof(CXIndexOptions) };
+  \endcode
+  or to prevent the -Wmissing-field-initializers warning for the above version:
+  \code
+  CXIndexOptions Opts{};
+  Opts.Size = sizeof(CXIndexOptions);
+  \endcode
+*>
 struct CXIndexOptions {
-  /*
-   * The size of struct CXIndexOptions used for option versioning.
-   *
-   * Always initialize this member to sizeof(CXIndexOptions), or assign
-   * sizeof(CXIndexOptions) to it right after creating a CXIndexOptions object.
-   */
   CUInt size;
-
-  /*
-   * A CXChoice enumerator that specifies the indexing priority policy.
-   * \sa CXGlobalOpt_ThreadBackgroundPriorityForIndexing
-   */
-  CChar thread_background_priority_for_indexing;
-
-  /*
-   * A CXChoice enumerator that specifies the editing priority policy.
-   * \sa CXGlobalOpt_ThreadBackgroundPriorityForEditing
-   */
-  CChar thread_background_priority_for_editing;
-
+  char thread_background_priority_for_indexing;
+  char thread_background_priority_for_editing;
   bitstruct : ushort {
-    /*
-     * \see clang_createIndex()
-     */
-    bool exclude_declarations_from_pch;
-
-    /*
-     * \see clang_createIndex()
-     */
-    bool display_diagnostics;
-
-    /*
-     * Store PCH in memory. If zero, PCH are stored in temporary files.
-     */
-    bool store_preambles_in_memory;
+    CUInt exclude_declarations_from_pch : 0..0;
+    CUInt display_diagnostics : 1..1;
+    CUInt store_preambles_in_memory : 2..2;
+    CUInt x : 3..15;
   }
-
-  /*
-   * The path to a directory, in which to store temporary PCH files. If null or
-   * empty, the default system temporary directory is used. These PCH files are
-   * deleted on clean exit but stay on disk if the program crashes or is killed.
-   *
-   * This option is ignored if \a StorePreamblesInMemory is non-zero.
-   *
-   * Libclang does not create the directory at the specified path in the file
-   * system. Therefore it must exist, or storing PCH files will fail.
-   */
   ZString preamble_storage_path;
-
-  /*
-   * Specifies a path which will contain log files for certain libclang
-   * invocations. A null value implies that libclang invocations are not logged.
-   */
   ZString invocation_emission_path;
 }
 
-/**
- * Provides a shared context for creating translation units.
- *
- * Call this function instead of clang_createIndex() if you need to configure
- * the additional options in CXIndexOptions.
- *
- * \returns The created index or null in case of error, such as an unsupported
- * value of options->Size.
- *
- * For example:
- * \code
- * CXIndex createIndex(ZString ApplicationTemporaryPath) {
- *   const CInt ExcludeDeclarationsFromPCH = 1;
- *   const CInt DisplayDiagnostics = 1;
- *   CXIndex Idx;
- * #if CINDEX_VERSION_MINOR >= 64
- *   CXIndexOptions Opts;
- *   memset(&Opts, 0, sizeof(Opts));
- *   Opts.Size = sizeof(CXIndexOptions);
- *   Opts.ThreadBackgroundPriorityForIndexing = 1;
- *   Opts.ExcludeDeclarationsFromPCH = ExcludeDeclarationsFromPCH;
- *   Opts.DisplayDiagnostics = DisplayDiagnostics;
- *   Opts.PreambleStoragePath = ApplicationTemporaryPath;
- *   Idx = clang_createIndexWithOptions(&Opts);
- *   if (Idx)
- *     return Idx;
- *   fprintf(stderr,
- *           "clang_createIndexWithOptions() failed. "
- *           "CINDEX_VERSION_MINOR = %d, sizeof(CXIndexOptions) = %u\n",
- *           CINDEX_VERSION_MINOR, Opts.Size);
- * #else
- *   (void)ApplicationTemporaryPath;
- * #endif
- *   Idx = clang_createIndex(ExcludeDeclarationsFromPCH, DisplayDiagnostics);
- *   clang_CXIndex_setGlobalOptions(
- *       Idx, clang_CXIndex_getGlobalOptions(Idx) |
- *                CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
- *   return Idx;
- * }
- * \endcode
- *
- * \sa clang_createIndex()
- */
-fn CXIndex createIndexWithOptions(
-  CXIndexOptions *options) 
-@extern("clang_createIndexWithOptions");
+<*
+  Provides a shared context for creating translation units.
+  Call this function instead of clang_createIndex() if you need to configure
+  the additional options in CXIndexOptions.
+  \returns The created index or null in case of error, such as an unsupported
+  value of options->Size.
+  For example:
+  \code
+  CXIndex createIndex(const char *ApplicationTemporaryPath) {
+  const int ExcludeDeclarationsFromPCH = 1;
+  const int DisplayDiagnostics = 1;
+  CXIndex Idx;
+  #if CINDEX_VERSION_MINOR >= 64
+  CXIndexOptions Opts;
+  memset(&Opts, 0, sizeof(Opts));
+  Opts.Size = sizeof(CXIndexOptions);
+  Opts.ThreadBackgroundPriorityForIndexing = 1;
+  Opts.ExcludeDeclarationsFromPCH = ExcludeDeclarationsFromPCH;
+  Opts.DisplayDiagnostics = DisplayDiagnostics;
+  Opts.PreambleStoragePath = ApplicationTemporaryPath;
+  Idx = clang_createIndexWithOptions(&Opts);
+  if (Idx)
+  return Idx;
+  fprintf(stderr,
+  "clang_createIndexWithOptions() failed. "
+  "CINDEX_VERSION_MINOR = %d, sizeof(CXIndexOptions) = %u\n",
+  CINDEX_VERSION_MINOR, Opts.Size);
+  #else
+  (void)ApplicationTemporaryPath;
+  #endif
+  Idx = clang_createIndex(ExcludeDeclarationsFromPCH, DisplayDiagnostics);
+  clang_CXIndex_setGlobalOptions(
+  Idx, clang_CXIndex_getGlobalOptions(Idx) |
+  CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
+  return Idx;
+  }
+  \endcode
+  \sa clang_createIndex()
+*>
+extern fn CXIndex createIndexWithOptions(
+  CXIndexOptions* options)
+@cname("clang_createIndexWithOptions");
 
-/**
- * Sets general options associated with a CXIndex.
- *
- * This function is DEPRECATED. Set
- * CXIndexOptions::ThreadBackgroundPriorityForIndexing and/or
- * CXIndexOptions::ThreadBackgroundPriorityForEditing and call
- * clang_createIndexWithOptions() instead.
- *
- * For example:
- * \code
- * CXIndex idx = ...;
- * clang_CXIndex_setGlobalOptions(idx,
- *     clang_CXIndex_getGlobalOptions(idx) |
- *     CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
- * \endcode
- *
- * \param options A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags.
- */
-fn void setGlobalOptions_Index(
-  CXIndex index,
-  CUInt options) 
-@extern("clang_CXIndex_setGlobalOptions")
-@deprecated("Set CXIndexOptions::ThreadBackgroundPriorityForIndexing and/or CXIndexOptions::ThreadBackgroundPriorityForEditing and call clang_createIndexWithOptions() instead.");
+<*
+  Sets general options associated with a CXIndex.
+  This function is DEPRECATED. Set
+  CXIndexOptions::ThreadBackgroundPriorityForIndexing and/or
+  CXIndexOptions::ThreadBackgroundPriorityForEditing and call
+  clang_createIndexWithOptions() instead.
+  For example:
+  \code
+  CXIndex idx = ...;
+  clang_CXIndex_setGlobalOptions(idx,
+  clang_CXIndex_getGlobalOptions(idx) |
+  CXGlobalOpt_ThreadBackgroundPriorityForIndexing);
+  \endcode
+  \param options A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags.
+*>
+extern fn void cXIndex_setGlobalOptions(
+  CXIndex,
+  CUInt options)
+@cname("clang_CXIndex_setGlobalOptions");
 
-/**
- * Gets the general options associated with a CXIndex.
- *
- * This function allows to obtain the final option values used by libclang after
- * specifying the option policies via CXChoice enumerators.
- *
- * \returns A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags that
- * are associated with the given CXIndex object.
- */
-fn CUInt getGlobalOptions_Index(
-  CXIndex index)
-@extern("clang_CXIndex_getGlobalOptions");
+<*
+  Gets the general options associated with a CXIndex.
+  This function allows to obtain the final option values used by libclang after
+  specifying the option policies via CXChoice enumerators.
+  \returns A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags that
+  are associated with the given CXIndex object.
+*>
+extern fn CUInt cXIndex_getGlobalOptions(
+  CXIndex)
+@cname("clang_CXIndex_getGlobalOptions");
 
-/**
- * Sets the invocation emission path option in a CXIndex.
- *
- * This function is DEPRECATED. Set CXIndexOptions::InvocationEmissionPath and
- * call clang_createIndexWithOptions() instead.
- *
- * The invocation emission path specifies a path which will contain log
- * files for certain libclang invocations. A null value (default) implies that
- * libclang invocations are not logged..
- */
-fn void setInvocationEmissionPathOption_Index(
-  CXIndex self, 
-  ZString path) 
-@extern("clang_CXIndex_setInvocationEmissionPathOption")
-@deprecated("Set CXIndexOptions::InvocationEmissionPath and call clang_createIndexWithOptions() instead.");
+<*
+  Sets the invocation emission path option in a CXIndex.
+  This function is DEPRECATED. Set CXIndexOptions::InvocationEmissionPath and
+  call clang_createIndexWithOptions() instead.
+  The invocation emission path specifies a path which will contain log
+  files for certain libclang invocations. A null value (default) implies that
+  libclang invocations are not logged..
+*>
+extern fn void cXIndex_setInvocationEmissionPathOption(
+  CXIndex,
+  ZString path)
+@cname("clang_CXIndex_setInvocationEmissionPathOption");
 
-/**
- * Determine whether the given header is guarded against
- * multiple inclusions, either with the conventional
- * \#ifndef/\#define/\#endif macro guards or with \#pragma once.
- */
-fn CUInt isFileMultipleIncludeGuarded(
-  CXTranslationUnit tu, 
-  CXFile file) 
-@extern("clang_isFileMultipleIncludeGuarded");
+<*
+  Determine whether the given header is guarded against
+  multiple inclusions, either with the conventional
+  \#ifndef/\#define/\#endif macro guards or with \#pragma once.
+*>
+extern fn CUInt isFileMultipleIncludeGuarded(
+  CXTranslationUnit tu,
+  CXFile file)
+@cname("clang_isFileMultipleIncludeGuarded");
 
-/**
- * Retrieve a file handle within the given translation unit.
- *
- * \param tu the translation unit
- *
- * \param file_name the name of the file.
- *
- * \returns the file handle for the named file in the translation unit \p tu,
- * or a NULL file handle if the file was not a part of this translation unit.
- */
-fn CXFile getFile(
-  CXTranslationUnit tu, 
-  ZString file_name) 
-@extern("clang_getFile");
+<*
+  Retrieve a file handle within the given translation unit.
+  \param tu the translation unit
+  \param file_name the name of the file.
+  \returns the file handle for the named file in the translation unit \p tu,
+  or a NULL file handle if the file was not a part of this translation unit.
+*>
+extern fn CXFile getFile(
+  CXTranslationUnit tu,
+  ZString file_name)
+@cname("clang_getFile");
 
-/**
- * Retrieve the buffer associated with the given file.
- *
- * \param tu the translation unit
- *
- * \param file the file for which to retrieve the buffer.
- *
- * \param size [out] if non-NULL, will be set to the size of the buffer.
- *
- * \returns a pointer to the buffer in memory that holds the contents of
- * \p file, or a NULL pointer when the file is not loaded.
- */
-fn ZString getFileContents(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  usz *size) 
-@extern("clang_getFileContents");
+<*
+  Retrieve the buffer associated with the given file.
+  \param tu the translation unit
+  \param file the file for which to retrieve the buffer.
+  \param size [out] if non-NULL, will be set to the size of the buffer.
+  \returns a pointer to the buffer in memory that holds the contents of
+  \p file, or a NULL pointer when the file is not loaded.
+*>
+extern fn ZString getFileContents(
+  CXTranslationUnit tu,
+  CXFile file,
+  sz* size)
+@cname("clang_getFileContents");
 
-/**
- * Retrieves the source location associated with a given file/line/column
- * in a particular translation unit.
- */
-fn CXSourceLocation getLocation(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  CUInt line, 
-  CUInt column) 
-@extern("clang_getLocation");
+<*
+  Retrieves the source location associated with a given file/line/column
+  in a particular translation unit.
+*>
+extern fn CXSourceLocation getLocation(
+  CXTranslationUnit tu,
+  CXFile file,
+  CUInt line,
+  CUInt column)
+@cname("clang_getLocation");
 
-/**
- * Retrieves the source location associated with a given character offset
- * in a particular translation unit.
- */
-fn CXSourceLocation getLocationForOffset(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  CUInt offset) 
-@extern("clang_getLocationForOffset");
+<*
+  Retrieves the source location associated with a given character offset
+  in a particular translation unit.
+*>
+extern fn CXSourceLocation getLocationForOffset(
+  CXTranslationUnit tu,
+  CXFile file,
+  CUInt offset)
+@cname("clang_getLocationForOffset");
 
-/**
- * Retrieve all ranges that were skipped by the preprocessor.
- *
- * The preprocessor will skip lines when they are surrounded by an
- * if/ifdef/ifndef directive whose condition does not evaluate to true.
- */
-fn CXSourceRangeList* getSkippedRanges(
-  CXTranslationUnit tu, 
-  CXFile file) 
-@extern("clang_getSkippedRanges");
+<*
+  Retrieve all ranges that were skipped by the preprocessor.
+  The preprocessor will skip lines when they are surrounded by an
+  if/ifdef/ifndef directive whose condition does not evaluate to true.
+*>
+extern fn CXSourceRangeList* getSkippedRanges(
+  CXTranslationUnit tu,
+  CXFile file)
+@cname("clang_getSkippedRanges");
 
-/**
- * Retrieve all ranges from all files that were skipped by the
- * preprocessor.
- *
- * The preprocessor will skip lines when they are surrounded by an
- * if/ifdef/ifndef directive whose condition does not evaluate to true.
- */
-fn CXSourceRangeList* getAllSkippedRanges(
-  CXTranslationUnit tu) 
-@extern("clang_getAllSkippedRanges");
-
-/**
- * Determine the number of diagnostics produced for the given
- * translation unit.
- */
-fn CUInt getNumDiagnostics(
-  CXTranslationUnit unit) 
-@extern("clang_getNumDiagnostics");
-
-/**
- * Retrieve a diagnostic associated with the given translation unit.
- *
- * \param Unit the translation unit to query.
- * \param Index the zero-based diagnostic number to retrieve.
- *
- * \returns the requested diagnostic. This diagnostic must be freed
- * via a call to \c clang_disposeDiagnostic().
- */
-fn CXDiagnostic getDiagnostic(
-  CXTranslationUnit unit, 
-  CUInt index) 
-@extern("clang_getDiagnostic");
-
-/**
- * Retrieve the complete set of diagnostics associated with a
- *        translation unit.
- *
- * \param Unit the translation unit to query.
- */
-fn CXDiagnosticSet getDiagnosticSetFromTU(
-  CXTranslationUnit unit) 
-@extern("clang_getDiagnosticSetFromTU");
-
-/**
- * Get the original translation unit source file name.
- */
-fn CXString getTranslationUnitSpelling(
-  CXTranslationUnit ct_unit) 
-@extern("clang_getTranslationUnitSpelling");
-
-/**
- * Return the CXTranslationUnit for a given source file and the provided
- * command line arguments one would pass to the compiler.
- *
- * Note: The 'source_filename' argument is optional.  If the caller provides a
- * NULL pointer, the name of the source file is expected to reside in the
- * specified command line arguments.
- *
- * Note: When encountered in 'clang_command_line_args', the following options
- * are ignored:
- *
- *   '-c'
- *   '-emit-ast'
- *   '-fsyntax-only'
- *   '-o \<output file>'  (both '-o' and '\<output file>' are ignored)
- *
- * \param CIdx The index object with which the translation unit will be
- * associated.
- *
- * \param source_filename The name of the source file to load, or NULL if the
- * source file is included in \p clang_command_line_args.
- *
- * \param num_clang_command_line_args The number of command-line arguments in
- * \p clang_command_line_args.
- *
- * \param clang_command_line_args The command-line arguments that would be
- * passed to the \c clang executable if it were being invoked out-of-process.
- * These command-line options will be parsed and will affect how the translation
- * unit is parsed. Note that the following options are ignored: '-c',
- * '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
- *
- * \param num_unsaved_files the number of unsaved file entries in \p
- * unsaved_files.
- *
- * \param unsaved_files the files that have not yet been saved to disk
- * but may be required for code completion, including the contents of
- * those files.  The contents and name of these files (as specified by
- * CXUnsavedFile) are copied when necessary, so the client only needs to
- * guarantee their validity until the call to this function returns.
- */
-fn CXTranslationUnit createTranslationUnitFromSourceFile(
-  CXIndex c_idx, 
-  ZString source_filename, 
-  CInt num_clang_command_line_args, 
-  ZString* clang_command_line_args, 
-  CUInt num_unsaved_files, 
-  CXUnsavedFile* unsaved_files) 
-@extern("clang_createTranslationUnitFromSourceFile");
-
-/**
- * Same as \c clang_createTranslationUnit2, but returns
- * the \c CXTranslationUnit instead of an error code.  In case of an error this
- * routine returns a \c NULL \c CXTranslationUnit, without further detailed
- * error codes.
- */
-fn CXTranslationUnit createTranslationUnit(
-  CXIndex c_idx, 
-  ZString ast_filename) 
-@extern("clang_createTranslationUnit");
-
-/**
- * Create a translation unit from an AST file (\c -emit-ast).
- *
- * \param[out] out_TU A non-NULL pointer to store the created
- * \c CXTranslationUnit.
- *
- * \returns Zero on success, otherwise returns an error code.
- */
-fn CXErrorCode createTranslationUnit2(
-  CXIndex c_idx, 
-  ZString ast_filename, 
-  CXTranslationUnit* out_tu) 
-@extern("clang_createTranslationUnit2");
-
-/**
- * Flags that control the creation of translation units.
- *
- * The enumerators in this enumeration type are meant to be bitwise
- * ORed together to specify which options should be used when
- * constructing the translation unit.
- */
-typedef CXTranslationUnit_Flags = inline CInt;
-
-/*
- * Used to indicate that no special translation-unit options are
- * needed.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_NONE = 0x0;
-/*
- * Used to indicate that the parser should construct a "detailed"
- * preprocessing record, including all macro definitions and instantiations.
- *
- * Constructing a detailed preprocessing record requires more memory
- * and time to parse, since the information contained in the record
- * is usually not retained. However, it can be useful for
- * applications that require more detailed information about the
- * behavior of the preprocessor.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD = 0x01;
-/*
- * Used to indicate that the translation unit is incomplete.
- *
- * When a translation unit is considered "incomplete", semantic
- * analysis that is typically performed at the end of the
- * translation unit will be suppressed. For example, this suppresses
- * the completion of tentative declarations in C and of
- * instantiation of implicitly-instantiation function templates in
- * C++. This option is typically used when parsing a header with the
- * intent of producing a precompiled header.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_INCOMPLETE = 0x02;
-/*
- * Used to indicate that the translation unit should be built with an
- * implicit precompiled header for the preamble.
- *
- * An implicit precompiled header is used as an optimization when a
- * particular translation unit is likely to be reparsed many times
- * when the sources aren't changing that often. In this case, an
- * implicit precompiled header will be built containing all of the
- * initial includes at the top of the main file (what we refer to as
- * the "preamble" of the file). In subsequent parses, if the
- * preamble or the files in it have not changed, \c
- * clang_reparseTranslationUnit() will re-use the implicit
- * precompiled header to improve parsing performance.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_PRECOMPILED_PREAMBLE = 0x04;
-/*
- * Used to indicate that the translation unit should cache some
- * code-completion results with each reparse of the source file.
- *
- * Caching of code-completion results is a performance optimization that
- * introduces some overhead to reparsing but improves the performance of
- * code-completion operations.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_CACHE_COMPLETION_RESULTS = 0x08;
-/*
- * Used to indicate that the translation unit will be serialized with
- * \c clang_saveTranslationUnit.
- *
- * This option is typically used when parsing a header with the intent of
- * producing a precompiled header.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_FOR_SERIALIZATION = 0x10;
-/*
- * DEPRECATED: Enabled chained precompiled preambles in C++.
- *
- * Note: this is a *temporary* option that is available only while
- * we are testing C++ precompiled preamble support. It is deprecated.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_CXX_CHAINED_PCH = 0x20;
-/*
- * Used to indicate that function/method bodies should be skipped while
- * parsing.
- *
- * This option can be used to search for declarations/definitions while
- * ignoring the usages.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_SKIP_FUNCTION_BODIES = 0x40;
-/*
- * Used to indicate that brief documentation comments should be
- * included into the set of code completions returned from this translation
- * unit.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_INCLUDE_BRIEF_COMMENTS_IN_CODE_COMPLETION = 0x80;
-/*
- * Used to indicate that the precompiled preamble should be created on
- * the first parse. Otherwise it will be created on the first reparse. This
- * trades runtime on the first parse (serializing the preamble takes time) for
- * reduced runtime on the second parse (can now reuse the preamble).
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_CREATE_PREAMBLE_ON_FIRST_PARSE = 0x100;
-/*
- * Do not stop processing when fatal errors are encountered.
- *
- * When fatal errors are encountered while parsing a translation unit,
- * semantic analysis is typically stopped early when compiling code. A common
- * source for fatal errors are unresolvable include files. For the
- * purposes of an IDE, this is undesirable behavior and as much information
- * as possible should be reported. Use this flag to enable this behavior.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_KEEP_GOING = 0x200;
-/*
- * Sets the preprocessor in a mode for parsing a single file only.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_SINGLE_FILE_PARSE = 0x400;
-/*
- * Used in combination with CXTranslationUnit_SkipFunctionBodies to
- * constrain the skipping of function bodies to the preamble.
- *
- * The function bodies of the main file are not skipped.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_LIMIT_SKIP_FUNCTION_BODIES_TO_PREAMBLE = 0x800;
-/*
- * Used to indicate that attributed types should be included in CXType.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_INCLUDE_ATTRIBUTED_TYPES = 0x1000;
-/*
- * Used to indicate that implicit attributes should be visited.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_VISIT_IMPLICIT_ATTRIBUTES = 0x2000;
-/*
- * Used to indicate that non-errors from included files should be ignored.
- *
- * If set, clang_getDiagnosticSetFromTU() will not report e.g. warnings from
- * included files anymore. This speeds up clang_getDiagnosticSetFromTU() for
- * the case where these warnings are not of interest, as for an IDE for
- * example, which typically shows only the diagnostics in the main file.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES = 0x4000;
-/*
- * Tells the preprocessor not to skip excluded conditional blocks.
- */
-const CXTranslationUnit_Flags TRANSLATION_UNIT_RETAIN_EXCLUDED_CONDITIONAL_BLOCKS = 0x8000;
-
-/**
- * Returns the set of flags that is suitable for parsing a translation
- * unit that is being edited.
- *
- * The set of flags returned provide options for \c clang_parseTranslationUnit()
- * to indicate that the translation unit is likely to be reparsed many times,
- * either explicitly (via \c clang_reparseTranslationUnit()) or implicitly
- * (e.g., by code completion (\c clang_codeCompletionAt())). The returned flag
- * set contains an unspecified set of optimizations (e.g., the precompiled
- * preamble) geared toward improving the performance of these routines. The
- * set of optimizations enabled may change from one version to the next.
- */
-fn CUInt defaultEditingTranslationUnitOptions() 
-@extern("clang_defaultEditingTranslationUnitOptions");
-
-/**
- * Same as \c clang_parseTranslationUnit2, but returns
- * the \c CXTranslationUnit instead of an error code.  In case of an error this
- * routine returns a \c NULL \c CXTranslationUnit, without further detailed
- * error codes.
- */
-fn CXTranslationUnit parseTranslationUnit(
-  CXIndex cidx, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CUInt options) 
-@extern("clang_parseTranslationUnit");
-
-/**
- * Parse the given source file and the translation unit corresponding
- * to that file.
- *
- * This routine is the main entry poCInt for the Clang C API, providing the
- * ability to parse a source file into a translation unit that can then be
- * queried by other functions in the API. This routine accepts a set of
- * command-line arguments so that the compilation can be configured in the same
- * way that the compiler is configured on the command line.
- *
- * \param CIdx The index object with which the translation unit will be
- * associated.
- *
- * \param source_filename The name of the source file to load, or NULL if the
- * source file is included in \c command_line_args.
- *
- * \param command_line_args The command-line arguments that would be
- * passed to the \c clang executable if it were being invoked out-of-process.
- * These command-line options will be parsed and will affect how the translation
- * unit is parsed. Note that the following options are ignored: '-c',
- * '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
- *
- * \param num_command_line_args The number of command-line arguments in
- * \c command_line_args.
- *
- * \param unsaved_files the files that have not yet been saved to disk
- * but may be required for parsing, including the contents of
- * those files.  The contents and name of these files (as specified by
- * CXUnsavedFile) are copied when necessary, so the client only needs to
- * guarantee their validity until the call to this function returns.
- *
- * \param num_unsaved_files the number of unsaved file entries in \p
- * unsaved_files.
- *
- * \param options A bitmask of options that affects how the translation unit
- * is managed but not its compilation. This should be a bitwise OR of the
- * CXTranslationUnit_XXX flags.
- *
- * \param[out] out_TU A non-NULL pointer to store the created
- * \c CXTranslationUnit, describing the parsed code and containing any
- * diagnostics produced by the compiler.
- *
- * \returns Zero on success, otherwise returns an error code.
- */
-fn CXErrorCode parseTranslationUnit2(
-  CXIndex c_idx, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CUInt options, 
-  CXTranslationUnit* out_TU)
-@extern("clang_parseTranslationUnit2");
-
-/**
- * Same as clang_parseTranslationUnit2 but requires a full command line
- * for \c command_line_args including argv[0]. This is useful if the standard
- * library paths are relative to the binary.
- */
-fn CXErrorCode parseTranslationUnit2FullArgv(
-  CXIndex c_idx, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CUInt options, 
-  CXTranslationUnit* out_TU) 
-@extern("clang_parseTranslationUnit2FullArgv");
-
-/**
- * Flags that control how translation units are saved.
- *
- * The enumerators in this enumeration type are meant to be bitwise
- * ORed together to specify which options should be used when
- * saving the translation unit.
- */
-typedef CXSaveTranslationUnit_Flags = inline CInt;
-
-/*
- * Used to indicate that no special saving options are needed.
- */
-const CXSaveTranslationUnit_Flags SAVE_TRANSLATION_UNIT_NONE = 0x0;
-
-/**
- * Returns the set of flags that is suitable for saving a translation
- * unit.
- *
- * The set of flags returned provide options for
- * \c clang_saveTranslationUnit() by default. The returned flag
- * set contains an unspecified set of options that save translation units with
- * the most commonly-requested data.
- */
-fn CUInt defaultSaveOptions(
-  CXTranslationUnit tu) 
-@extern("clang_defaultSaveOptions");
-
-/**
- * Describes the kind of error that occurred (if any) in a call to
- * \c clang_saveTranslationUnit().
- */
-typedef CXSaveError = inline CInt; 
-
-/*
- * Indicates that no error occurred while saving a translation unit.
- */
-const CXSaveError SAVE_ERROR_NONE = 0;
-/*
- * Indicates that an unknown error occurred while attempting to save
- * the file.
- *
- * This error typically indicates that file I/O failed when attempting to
- * write the file.
- */
-const CXSaveError SAVE_ERROR_UNKNOWN = 1;
-/*
- * Indicates that errors during translation prevented this attempt
- * to save the translation unit.
- *
- * Errors that prevent the translation unit from being saved can be
- * extracted using \c clang_getNumDiagnostics() and \c clang_getDiagnostic().
- */
-const CXSaveError SAVE_ERROR_TRANSLATION_ERRORS = 2;
-/*
- * Indicates that the translation unit to be saved was somehow
- * invalid (e.g., NULL).
- */
-const CXSaveError SAVE_ERROR_INVALID_TU = 3;
-
-/**
- * Saves a translation unit into a serialized representation of
- * that translation unit on disk.
- *
- * Any translation unit that was parsed without error can be saved
- * into a file. The translation unit can then be deserialized into a
- * new \c CXTranslationUnit with \c clang_createTranslationUnit() or,
- * if it is an incomplete translation unit that corresponds to a
- * header, used as a precompiled header when parsing other translation
- * units.
- *
- * \param TU The translation unit to save.
- *
- * \param FileName The file to which the translation unit will be saved.
- *
- * \param options A bitmask of options that affects how the translation unit
- * is saved. This should be a bitwise OR of the
- * CXSaveTranslationUnit_XXX flags.
- *
- * \returns A value that will match one of the enumerators of the CXSaveError
- * enumeration. Zero (CXSaveError_None) indicates that the translation unit was
- * saved successfully, while a non-zero value indicates that a problem occurred.
- */
-fn CInt saveTranslationUnit(
-  CXTranslationUnit tu, 
-  ZString file_name, 
-  CUInt options) 
-@extern("clang_saveTranslationUnit");
-
-/**
- * Suspend a translation unit in order to free memory associated with it.
- *
- * A suspended translation unit uses significantly less memory but on the other
- * side does not support any other calls than \c clang_reparseTranslationUnit
- * to resume it or \c clang_disposeTranslationUnit to dispose it completely.
- */
-fn CUInt suspendTranslationUnit(
+<*
+  Retrieve all ranges from all files that were skipped by the
+  preprocessor.
+  The preprocessor will skip lines when they are surrounded by an
+  if/ifdef/ifndef directive whose condition does not evaluate to true.
+*>
+extern fn CXSourceRangeList* getAllSkippedRanges(
   CXTranslationUnit tu)
-@extern("clang_suspendTranslationUnit");
+@cname("clang_getAllSkippedRanges");
 
-/**
- * Destroy the specified CXTranslationUnit object.
- */
-fn void disposeTranslationUnit(
-  CXTranslationUnit tu) 
-@extern("clang_disposeTranslationUnit");
+<*
+  Determine the number of diagnostics produced for the given
+  translation unit.
+*>
+extern fn CUInt getNumDiagnostics(
+  CXTranslationUnit unit)
+@cname("clang_getNumDiagnostics");
 
-/**
- * Flags that control the reparsing of translation units.
- *
- * The enumerators in this enumeration type are meant to be bitwise
- * ORed together to specify which options should be used when
- * reparsing the translation unit.
- */
-typedef CXReparse_Flags = inline CInt;
+<*
+  Retrieve a diagnostic associated with the given translation unit.
+  \param Unit the translation unit to query.
+  \param Index the zero-based diagnostic number to retrieve.
+  \returns the requested diagnostic. This diagnostic must be freed
+  via a call to \c clang_disposeDiagnostic().
+*>
+extern fn CXDiagnostic getDiagnostic(
+  CXTranslationUnit unit,
+  CUInt index)
+@cname("clang_getDiagnostic");
 
-const CXReparse_Flags REPARSE_FLAGS_NONE = 0x0;
+<*
+  Retrieve the complete set of diagnostics associated with a
+  translation unit.
+  \param Unit the translation unit to query.
+*>
+extern fn CXDiagnosticSet getDiagnosticSetFromTU(
+  CXTranslationUnit unit)
+@cname("clang_getDiagnosticSetFromTU");
 
-/**
- * Returns the set of flags that is suitable for reparsing a translation
- * unit.
- *
- * The set of flags returned provide options for
- * \c clang_reparseTranslationUnit() by default. The returned flag
- * set contains an unspecified set of optimizations geared toward common uses
- * of reparsing. The set of optimizations enabled may change from one version
- * to the next.
- */
-fn CUInt defaultReparseOptions(
-  CXTranslationUnit tu) 
-@extern("clang_defaultReparseOptions");
+<*
+  Get the original translation unit source file name.
+*>
+extern fn CXString getTranslationUnitSpelling(
+  CXTranslationUnit ct_unit)
+@cname("clang_getTranslationUnitSpelling");
 
-/**
- * Reparse the source files that produced this translation unit.
- *
- * This routine can be used to re-parse the source files that originally
- * created the given translation unit, for example because those source files
- * have changed (either on disk or as passed via \p unsaved_files). The
- * source code will be reparsed with the same command-line options as it
- * was originally parsed.
- *
- * Reparsing a translation unit invalidates all cursors and source locations
- * that refer into that translation unit. This makes reparsing a translation
- * unit semantically equivalent to destroying the translation unit and then
- * creating a new translation unit with the same command-line arguments.
- * However, it may be more efficient to reparse a translation
- * unit using this routine.
- *
- * \param TU The translation unit whose contents will be re-parsed. The
- * translation unit must originally have been built with
- * \c clang_createTranslationUnitFromSourceFile().
- *
- * \param num_unsaved_files The number of unsaved file entries in \p
- * unsaved_files.
- *
- * \param unsaved_files The files that have not yet been saved to disk
- * but may be required for parsing, including the contents of
- * those files.  The contents and name of these files (as specified by
- * CXUnsavedFile) are copied when necessary, so the client only needs to
- * guarantee their validity until the call to this function returns.
- *
- * \param options A bitset of options composed of the flags in CXReparse_Flags.
- * The function \c clang_defaultReparseOptions() produces a default set of
- * options recommended for most uses, based on the translation unit.
- *
- * \returns 0 if the sources could be reparsed.  A non-zero error code will be
- * returned if reparsing was impossible, such that the translation unit is
- * invalid. In such cases, the only valid call for \c TU is
- * \c clang_disposeTranslationUnit(TU).  The error codes returned by this
- * routine are described by the \c CXErrorCode enum.
- */
-fn CInt reparseTranslationUnit(
-  CXTranslationUnit tu, 
-  CUInt num_unsaved_files,  
-  CXUnsavedFile *unsaved_files, 
-  CUInt options) 
-@extern("clang_reparseTranslationUnit");
+<*
+  Return the CXTranslationUnit for a given source file and the provided
+  command line arguments one would pass to the compiler.
+  Note: The 'source_filename' argument is optional.  If the caller provides a
+  NULL pointer, the name of the source file is expected to reside in the
+  specified command line arguments.
+  Note: When encountered in 'clang_command_line_args', the following options
+  are ignored:
+  '-c'
+  '-emit-ast'
+  '-fsyntax-only'
+  '-o \<output file>'  (both '-o' and '\<output file>' are ignored)
+  \param CIdx The index object with which the translation unit will be
+  associated.
+  \param source_filename The name of the source file to load, or NULL if the
+  source file is included in \p clang_command_line_args.
+  \param num_clang_command_line_args The number of command-line arguments in
+  \p clang_command_line_args.
+  \param clang_command_line_args The command-line arguments that would be
+  passed to the \c clang executable if it were being invoked out-of-process.
+  These command-line options will be parsed and will affect how the translation
+  unit is parsed. Note that the following options are ignored: '-c',
+  '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
+  \param num_unsaved_files the number of unsaved file entries in \p
+  unsaved_files.
+  \param unsaved_files the files that have not yet been saved to disk
+  but may be required for code completion, including the contents of
+  those files.  The contents and name of these files (as specified by
+  CXUnsavedFile) are copied when necessary, so the client only needs to
+  guarantee their validity until the call to this function returns.
+*>
+extern fn CXTranslationUnit createTranslationUnitFromSourceFile(
+  CXIndex c_idx,
+  ZString source_filename,
+  CInt num_clang_command_line_args,
+  ZString* clang_command_line_args,
+  CUInt num_unsaved_files,
+  CXUnsavedFile* unsaved_files)
+@cname("clang_createTranslationUnitFromSourceFile");
 
-/**
- * Categorizes how memory is being used by a translation unit.
- */
-typedef CXTUResourceUsageKind = inline CInt; 
+<*
+  Same as \c clang_createTranslationUnit2, but returns
+  the \c CXTranslationUnit instead of an error code.  In case of an error this
+  routine returns a \c NULL \c CXTranslationUnit, without further detailed
+  error codes.
+*>
+extern fn CXTranslationUnit createTranslationUnit(
+  CXIndex c_idx,
+  ZString ast_filename)
+@cname("clang_createTranslationUnit");
 
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_AST = 1;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_IDENTIFIERS = 2;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SELECTORS = 3;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_GLOBAL_COMPLETION_RESULTS = 4;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SOURCE_MANAGER_CONTENT_CACHE = 5;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_AST_SIDE_TABLES = 6;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_MALLOC = 7;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_MMAP = 8;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_MALLOC = 9;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_MMAP = 10;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_PREPROCESSOR = 11;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_PREPROCESSING_RECORD = 12;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_SOURCE_MANAGER_DATA_STRUCTURES = 13;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH = 14;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_MEMORY_IN_BYTES_BEGIN = TU_RESOURCE_USAGE_AST;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_MEMORY_IN_BYTES_END = TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_FIRST = TU_RESOURCE_USAGE_AST;
-const CXTUResourceUsageKind TU_RESOURCE_USAGE_LAST = TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH;
+<*
+  Create a translation unit from an AST file (\c -emit-ast).
+  \param[out] out_TU A non-NULL pointer to store the created
+  \c CXTranslationUnit.
+  \returns Zero on success, otherwise returns an error code.
+*>
+extern fn CXErrorCode createTranslationUnit2(
+  CXIndex c_idx,
+  ZString ast_filename,
+  CXTranslationUnit* out_tu)
+@cname("clang_createTranslationUnit2");
 
-/**
- * Returns the human-readable null-terminated C string that represents
- *  the name of the memory category.  This string should never be freed.
- */
-fn
-ZString getTUResourceUsageName(
-  CXTUResourceUsageKind kind) 
-@extern("clang_getTUResourceUsageName");
+<*
+  Flags that control the creation of translation units.
+  The enumerators in this enumeration type are meant to be bitwise
+  ORed together to specify which options should be used when
+  constructing the translation unit.
+*>
+constdef CXTranslationUnit_Flags : CInt {
+
+  <*
+    Used to indicate that no special translation-unit options are
+    needed.
+  *>
+  TRANSLATION_UNIT_NONE = 0,
+
+  <*
+    Used to indicate that the parser should construct a "detailed"
+    preprocessing record, including all macro definitions and instantiations.
+    Constructing a detailed preprocessing record requires more memory
+    and time to parse, since the information contained in the record
+    is usually not retained. However, it can be useful for
+    applications that require more detailed information about the
+    behavior of the preprocessor.
+  *>
+  TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD = 1,
+
+  <*
+    Used to indicate that the translation unit is incomplete.
+    When a translation unit is considered "incomplete", semantic
+    analysis that is typically performed at the end of the
+    translation unit will be suppressed. For example, this suppresses
+    the completion of tentative declarations in C and of
+    instantiation of implicitly-instantiation function templates in
+    C++. This option is typically used when parsing a header with the
+    intent of producing a precompiled header.
+  *>
+  TRANSLATION_UNIT_INCOMPLETE = 2,
+
+  <*
+    Used to indicate that the translation unit should be built with an
+    implicit precompiled header for the preamble.
+    An implicit precompiled header is used as an optimization when a
+    particular translation unit is likely to be reparsed many times
+    when the sources aren't changing that often. In this case, an
+    implicit precompiled header will be built containing all of the
+    initial includes at the top of the main file (what we refer to as
+    the "preamble" of the file). In subsequent parses, if the
+    preamble or the files in it have not changed, \c
+    clang_reparseTranslationUnit() will re-use the implicit
+    precompiled header to improve parsing performance.
+  *>
+  TRANSLATION_UNIT_PRECOMPILED_PREAMBLE = 4,
+
+  <*
+    Used to indicate that the translation unit should cache some
+    code-completion results with each reparse of the source file.
+    Caching of code-completion results is a performance optimization that
+    introduces some overhead to reparsing but improves the performance of
+    code-completion operations.
+  *>
+  TRANSLATION_UNIT_CACHE_COMPLETION_RESULTS = 8,
+
+  <*
+    Used to indicate that the translation unit will be serialized with
+    \c clang_saveTranslationUnit.
+    This option is typically used when parsing a header with the intent of
+    producing a precompiled header.
+  *>
+  TRANSLATION_UNIT_FOR_SERIALIZATION = 16,
+
+  <*
+    DEPRECATED: Enabled chained precompiled preambles in C++.
+    Note: this is a *temporary* option that is available only while
+    we are testing C++ precompiled preamble support. It is deprecated.
+  *>
+  TRANSLATION_UNIT_CXX_CHAINED_PCH = 32,
+
+  <*
+    Used to indicate that function/method bodies should be skipped while
+    parsing.
+    This option can be used to search for declarations/definitions while
+    ignoring the usages.
+  *>
+  TRANSLATION_UNIT_SKIP_FUNCTION_BODIES = 64,
+
+  <*
+    Used to indicate that brief documentation comments should be
+    included into the set of code completions returned from this translation
+    unit.
+  *>
+  TRANSLATION_UNIT_INCLUDE_BRIEF_COMMENTS_IN_CODE_COMPLETION = 128,
+
+  <*
+    Used to indicate that the precompiled preamble should be created on
+    the first parse. Otherwise it will be created on the first reparse. This
+    trades runtime on the first parse (serializing the preamble takes time) for
+    reduced runtime on the second parse (can now reuse the preamble).
+  *>
+  TRANSLATION_UNIT_CREATE_PREAMBLE_ON_FIRST_PARSE = 256,
+
+  <*
+    Do not stop processing when fatal errors are encountered.
+    When fatal errors are encountered while parsing a translation unit,
+    semantic analysis is typically stopped early when compiling code. A common
+    source for fatal errors are unresolvable include files. For the
+    purposes of an IDE, this is undesirable behavior and as much information
+    as possible should be reported. Use this flag to enable this behavior.
+  *>
+  TRANSLATION_UNIT_KEEP_GOING = 512,
+
+  <*
+    Sets the preprocessor in a mode for parsing a single file only.
+  *>
+  TRANSLATION_UNIT_SINGLE_FILE_PARSE = 1024,
+
+  <*
+    Used in combination with CXTranslationUnit_SkipFunctionBodies to
+    constrain the skipping of function bodies to the preamble.
+    The function bodies of the main file are not skipped.
+  *>
+  TRANSLATION_UNIT_LIMIT_SKIP_FUNCTION_BODIES_TO_PREAMBLE = 2048,
+
+  <*
+    Used to indicate that attributed types should be included in CXType.
+  *>
+  TRANSLATION_UNIT_INCLUDE_ATTRIBUTED_TYPES = 4096,
+
+  <*
+    Used to indicate that implicit attributes should be visited.
+  *>
+  TRANSLATION_UNIT_VISIT_IMPLICIT_ATTRIBUTES = 8192,
+
+  <*
+    Used to indicate that non-errors from included files should be ignored.
+    If set, clang_getDiagnosticSetFromTU() will not report e.g. warnings from
+    included files anymore. This speeds up clang_getDiagnosticSetFromTU() for
+    the case where these warnings are not of interest, as for an IDE for
+    example, which typically shows only the diagnostics in the main file.
+  *>
+  TRANSLATION_UNIT_IGNORE_NON_ERRORS_FROM_INCLUDED_FILES = 16384,
+
+  <*
+    Tells the preprocessor not to skip excluded conditional blocks.
+  *>
+  TRANSLATION_UNIT_RETAIN_EXCLUDED_CONDITIONAL_BLOCKS = 32768
+}
+
+<*
+  Returns the set of flags that is suitable for parsing a translation
+  unit that is being edited.
+  The set of flags returned provide options for \c clang_parseTranslationUnit()
+  to indicate that the translation unit is likely to be reparsed many times,
+  either explicitly (via \c clang_reparseTranslationUnit()) or implicitly
+  (e.g., by code completion (\c clang_codeCompletionAt())). The returned flag
+  set contains an unspecified set of optimizations (e.g., the precompiled
+  preamble) geared toward improving the performance of these routines. The
+  set of optimizations enabled may change from one version to the next.
+*>
+extern fn CUInt defaultEditingTranslationUnitOptions()
+@cname("clang_defaultEditingTranslationUnitOptions");
+
+<*
+  Same as \c clang_parseTranslationUnit2, but returns
+  the \c CXTranslationUnit instead of an error code.  In case of an error this
+  routine returns a \c NULL \c CXTranslationUnit, without further detailed
+  error codes.
+*>
+extern fn CXTranslationUnit parseTranslationUnit(
+  CXIndex c_idx,
+  ZString source_filename,
+  ZString* command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CUInt options)
+@cname("clang_parseTranslationUnit");
+
+<*
+  Parse the given source file and the translation unit corresponding
+  to that file.
+  This routine is the main entry point for the Clang C API, providing the
+  ability to parse a source file into a translation unit that can then be
+  queried by other functions in the API. This routine accepts a set of
+  command-line arguments so that the compilation can be configured in the same
+  way that the compiler is configured on the command line.
+  \param CIdx The index object with which the translation unit will be
+  associated.
+  \param source_filename The name of the source file to load, or NULL if the
+  source file is included in \c command_line_args.
+  \param command_line_args The command-line arguments that would be
+  passed to the \c clang executable if it were being invoked out-of-process.
+  These command-line options will be parsed and will affect how the translation
+  unit is parsed. Note that the following options are ignored: '-c',
+  '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
+  \param num_command_line_args The number of command-line arguments in
+  \c command_line_args.
+  \param unsaved_files the files that have not yet been saved to disk
+  but may be required for parsing, including the contents of
+  those files.  The contents and name of these files (as specified by
+  CXUnsavedFile) are copied when necessary, so the client only needs to
+  guarantee their validity until the call to this function returns.
+  \param num_unsaved_files the number of unsaved file entries in \p
+  unsaved_files.
+  \param options A bitmask of options that affects how the translation unit
+  is managed but not its compilation. This should be a bitwise OR of the
+  CXTranslationUnit_XXX flags.
+  \param[out] out_TU A non-NULL pointer to store the created
+  \c CXTranslationUnit, describing the parsed code and containing any
+  diagnostics produced by the compiler.
+  \returns Zero on success, otherwise returns an error code.
+*>
+extern fn CXErrorCode parseTranslationUnit2(
+  CXIndex c_idx,
+  ZString source_filename,
+  ZString* command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CUInt options,
+  CXTranslationUnit* out_tu)
+@cname("clang_parseTranslationUnit2");
+
+<*
+  Same as clang_parseTranslationUnit2 but requires a full command line
+  for \c command_line_args including argv[0]. This is useful if the standard
+  library paths are relative to the binary.
+*>
+extern fn CXErrorCode parseTranslationUnit2FullArgv(
+  CXIndex c_idx,
+  ZString source_filename,
+  ZString* command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CUInt options,
+  CXTranslationUnit* out_tu)
+@cname("clang_parseTranslationUnit2FullArgv");
+
+<*
+  Flags that control how translation units are saved.
+  The enumerators in this enumeration type are meant to be bitwise
+  ORed together to specify which options should be used when
+  saving the translation unit.
+*>
+constdef CXSaveTranslationUnit_Flags : CInt {
+
+  <*
+    Used to indicate that no special saving options are needed.
+  *>
+  SAVE_TRANSLATION_UNIT_NONE = 0
+}
+
+<*
+  Returns the set of flags that is suitable for saving a translation
+  unit.
+  The set of flags returned provide options for
+  \c clang_saveTranslationUnit() by default. The returned flag
+  set contains an unspecified set of options that save translation units with
+  the most commonly-requested data.
+*>
+extern fn CUInt defaultSaveOptions(
+  CXTranslationUnit tu)
+@cname("clang_defaultSaveOptions");
+
+<*
+  Describes the kind of error that occurred (if any) in a call to
+  \c clang_saveTranslationUnit().
+*>
+constdef CXSaveError : CInt {
+
+  <*
+    Indicates that no error occurred while saving a translation unit.
+  *>
+  SAVE_ERROR_NONE = 0,
+
+  <*
+    Indicates that an unknown error occurred while attempting to save
+    the file.
+    This error typically indicates that file I/O failed when attempting to
+    write the file.
+  *>
+  SAVE_ERROR_UNKNOWN = 1,
+
+  <*
+    Indicates that errors during translation prevented this attempt
+    to save the translation unit.
+    Errors that prevent the translation unit from being saved can be
+    extracted using \c clang_getNumDiagnostics() and \c clang_getDiagnostic().
+  *>
+  SAVE_ERROR_TRANSLATION_ERRORS = 2,
+
+  <*
+    Indicates that the translation unit to be saved was somehow
+    invalid (e.g., NULL).
+  *>
+  SAVE_ERROR_INVALID_TU = 3
+}
+
+<*
+  Saves a translation unit into a serialized representation of
+  that translation unit on disk.
+  Any translation unit that was parsed without error can be saved
+  into a file. The translation unit can then be deserialized into a
+  new \c CXTranslationUnit with \c clang_createTranslationUnit() or,
+  if it is an incomplete translation unit that corresponds to a
+  header, used as a precompiled header when parsing other translation
+  units.
+  \param TU The translation unit to save.
+  \param FileName The file to which the translation unit will be saved.
+  \param options A bitmask of options that affects how the translation unit
+  is saved. This should be a bitwise OR of the
+  CXSaveTranslationUnit_XXX flags.
+  \returns A value that will match one of the enumerators of the CXSaveError
+  enumeration. Zero (CXSaveError_None) indicates that the translation unit was
+  saved successfully, while a non-zero value indicates that a problem occurred.
+*>
+extern fn CInt saveTranslationUnit(
+  CXTranslationUnit tu,
+  ZString file_name,
+  CUInt options)
+@cname("clang_saveTranslationUnit");
+
+<*
+  Suspend a translation unit in order to free memory associated with it.
+  A suspended translation unit uses significantly less memory but on the other
+  side does not support any other calls than \c clang_reparseTranslationUnit
+  to resume it or \c clang_disposeTranslationUnit to dispose it completely.
+*>
+extern fn CUInt suspendTranslationUnit(
+  CXTranslationUnit)
+@cname("clang_suspendTranslationUnit");
+
+<*
+  Destroy the specified CXTranslationUnit object.
+*>
+extern fn void disposeTranslationUnit(
+  CXTranslationUnit)
+@cname("clang_disposeTranslationUnit");
+
+<*
+  Flags that control the reparsing of translation units.
+  The enumerators in this enumeration type are meant to be bitwise
+  ORed together to specify which options should be used when
+  reparsing the translation unit.
+*>
+constdef CXReparse_Flags : CInt {
+
+  <*
+    Used to indicate that no special reparsing options are needed.
+  *>
+  REPARSE_NONE = 0
+}
+
+<*
+  Returns the set of flags that is suitable for reparsing a translation
+  unit.
+  The set of flags returned provide options for
+  \c clang_reparseTranslationUnit() by default. The returned flag
+  set contains an unspecified set of optimizations geared toward common uses
+  of reparsing. The set of optimizations enabled may change from one version
+  to the next.
+*>
+extern fn CUInt defaultReparseOptions(
+  CXTranslationUnit tu)
+@cname("clang_defaultReparseOptions");
+
+<*
+  Reparse the source files that produced this translation unit.
+  This routine can be used to re-parse the source files that originally
+  created the given translation unit, for example because those source files
+  have changed (either on disk or as passed via \p unsaved_files). The
+  source code will be reparsed with the same command-line options as it
+  was originally parsed.
+  Reparsing a translation unit invalidates all cursors and source locations
+  that refer into that translation unit. This makes reparsing a translation
+  unit semantically equivalent to destroying the translation unit and then
+  creating a new translation unit with the same command-line arguments.
+  However, it may be more efficient to reparse a translation
+  unit using this routine.
+  \param TU The translation unit whose contents will be re-parsed. The
+  translation unit must originally have been built with
+  \c clang_createTranslationUnitFromSourceFile().
+  \param num_unsaved_files The number of unsaved file entries in \p
+  unsaved_files.
+  \param unsaved_files The files that have not yet been saved to disk
+  but may be required for parsing, including the contents of
+  those files.  The contents and name of these files (as specified by
+  CXUnsavedFile) are copied when necessary, so the client only needs to
+  guarantee their validity until the call to this function returns.
+  \param options A bitset of options composed of the flags in CXReparse_Flags.
+  The function \c clang_defaultReparseOptions() produces a default set of
+  options recommended for most uses, based on the translation unit.
+  \returns 0 if the sources could be reparsed.  A non-zero error code will be
+  returned if reparsing was impossible, such that the translation unit is
+  invalid. In such cases, the only valid call for \c TU is
+  \c clang_disposeTranslationUnit(TU).  The error codes returned by this
+  routine are described by the \c CXErrorCode enum.
+*>
+extern fn CInt reparseTranslationUnit(
+  CXTranslationUnit tu,
+  CUInt num_unsaved_files,
+  CXUnsavedFile* unsaved_files,
+  CUInt options)
+@cname("clang_reparseTranslationUnit");
+
+<*
+  Categorizes how memory is being used by a translation unit.
+*>
+constdef CXTUResourceUsageKind : CInt {
+  TU_RESOURCE_USAGE_AST = 1,
+  TU_RESOURCE_USAGE_IDENTIFIERS = 2,
+  TU_RESOURCE_USAGE_SELECTORS = 3,
+  TU_RESOURCE_USAGE_GLOBAL_COMPLETION_RESULTS = 4,
+  TU_RESOURCE_USAGE_SOURCE_MANAGER_CONTENT_CACHE = 5,
+  TU_RESOURCE_USAGE_AST_SIDE_TABLES = 6,
+  TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_MALLOC = 7,
+  TU_RESOURCE_USAGE_SOURCE_MANAGER_MEMBUFFER_M_MAP = 8,
+  TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_MALLOC = 9,
+  TU_RESOURCE_USAGE_EXTERNAL_AST_SOURCE_MEMBUFFER_M_MAP = 10,
+  TU_RESOURCE_USAGE_PREPROCESSOR = 11,
+  TU_RESOURCE_USAGE_PREPROCESSING_RECORD = 12,
+  TU_RESOURCE_USAGE_SOURCE_MANAGER_DATA_STRUCTURES = 13,
+  TU_RESOURCE_USAGE_PREPROCESSOR_HEADER_SEARCH = 14,
+  TU_RESOURCE_USAGE_MEMORY_IN_BYTES_BEGIN = 1,
+  TU_RESOURCE_USAGE_MEMORY_IN_BYTES_END = 14,
+  TU_RESOURCE_USAGE_FIRST = 1,
+  TU_RESOURCE_USAGE_LAST = 14
+}
+
+<*
+  Returns the human-readable null-terminated C string that represents
+  the name of the memory category.  This string should never be freed.
+*>
+extern fn ZString getTUResourceUsageName(
+  CXTUResourceUsageKind kind)
+@cname("clang_getTUResourceUsageName");
+
 
 struct CXTUResourceUsageEntry {
-  /* The memory usage category. */
   CXTUResourceUsageKind kind;
-
-  /* Amount of resources used.
-     The units will depend on the resource kind. */
   CULong amount;
 }
 
-/**
- * The memory usage of a CXTranslationUnit, broken into categories.
- */
+<*
+  The memory usage of a CXTranslationUnit, broken into categories.
+*>
 struct CXTUResourceUsage {
-  /* Private data member, used for queries. */
   void* data;
-
-  /* The number of entries in the 'entries' array. */
-  CUInt numEntries;
-
-  /* An array of key-value pairs, representing the breakdown of memory
-            usage. */
+  CUInt num_entries;
   CXTUResourceUsageEntry* entries;
 }
 
-/**
- * Return the memory usage of a translation unit.  This object
- *  should be released with clang_disposeCXTUResourceUsage().
- */
-fn CXTUResourceUsage getCXTUResourceUsage(
-  CXTranslationUnit tu) 
-@extern("clang_getCXTUResourceUsage");
-
-fn void disposeCXTUResourceUsage(
-  CXTUResourceUsage usage) 
-@extern("clang_disposeCXTUResourceUsage");
-
-/**
- * Get target information for this translation unit.
- *
- * The CXTargetInfo object cannot outlive the CXTranslationUnit object.
- */
-fn CXTargetInfo getTranslationUnitTargetInfo(
-  CXTranslationUnit ct_unit) 
-@extern("clang_getTranslationUnitTargetInfo");
-
-/**
- * Destroy the CXTargetInfo object.
- */
-fn void dispose_TargetInfo(
-  CXTargetInfo info) 
-@extern("clang_TargetInfo_dispose");
-
-/**
- * Get the normalized target triple as a string.
- *
- * Returns the empty string in case of any error.
- */
-fn CXString getTriple_TargetInfo(
-  CXTargetInfo info) 
-@extern("clang_TargetInfo_getTriple");
-
-/**
- * Get the pointer width of the target in bits.
- *
- * Returns -1 in case of error.
- */
-fn CInt getPointerWidth_TargetInfo(
-  CXTargetInfo info) 
-@extern("clang_TargetInfo_getPointerWidth");
-
-/**
- * Describes the kind of entity that a cursor refers to.
- */
-typedef CXCursorKind = inline CInt;
-
-/* Declarations */
-/**
- * A declaration whose specific kind is not exposed via this
- * interface.
- *
- * Unexposed declarations have the same operations as any other kind
- * of declaration; one can extract their location information,
- * spelling, find their definitions, etc. However, the specific kind
- * of the declaration is not reported.
- */
-const CXCursorKind CURSOR_UNEXPOSED_DECL = 1;
-/** A C or C++ struct.
-  */
-const CXCursorKind CURSOR_STRUCT_DECL = 2;
-/** A C or C++ union. 
-  */
-const CXCursorKind CURSOR_UNION_DECL = 3;
-/** A C++ class. 
-  */
-const CXCursorKind CURSOR_CLASS_DECL = 4;
-/** An enumeration. 
-  */
-const CXCursorKind CURSOR_ENUM_DECL = 5;
-/**
- * A field (in C) or non-static data member (in C++) in a
- * struct, union, or C++ class.
- */
-const CXCursorKind CURSOR_FIELD_DECL = 6;
-/** An enumerator constant.
-  */
-const CXCursorKind CURSOR_ENUM_CONSTANT_DECL = 7;
-/** A function. 
-  */
-const CXCursorKind CURSOR_FUNCTION_DECL = 8;
-/** A variable. 
-  */
-const CXCursorKind CURSOR_VAR_DECL = 9;
-/** A function or method parameter. 
-  */
-const CXCursorKind CURSOR_PARM_DECL = 10;
-/** An Objective-C \@interface. 
-  */
-const CXCursorKind CURSOR_OBJC_INTERFACE_DECL = 11;
-/** An Objective-C \@interface for a category. 
-  */
-const CXCursorKind CURSOR_OBJC_CATEGORY_DECL = 12;
-/** An Objective-C \@protocol declaration. 
-  */
-const CXCursorKind CURSOR_OBJC_PROTOCOL_DECL = 13;
-/** An Objective-C \@property declaration. 
-  */
-const CXCursorKind CURSOR_OBJC_PROPERTY_DECL = 14;
-/** An Objective-C instance variable. 
-  */
-const CXCursorKind CURSOR_OBJC_IVAR_DECL = 15;
-/** An Objective-C instance method. 
-  */
-const CXCursorKind CURSOR_OBJC_INSTANCE_METHOD_DECL = 16;
-/** An Objective-C class method. 
-  */
-const CXCursorKind CURSOR_OBJC_CLASS_METHOD_DECL = 17;
-/** An Objective-C \@implementation. 
-  */
-const CXCursorKind CURSOR_OBJC_IMPLEMENTATION_DECL = 18;
-/** An Objective-C \@implementation for a category. 
-  */
-const CXCursorKind CURSOR_OBJC_CATEGORY_IMPL_DECL = 19;
-/** A typedef. 
-  */
-const CXCursorKind CURSOR_TYPEDEF_DECL = 20;
-/** A C++ class method. 
-  */
-const CXCursorKind CURSOR_CXX_METHOD = 21;
-/** A C++ namespace. 
-  */
-const CXCursorKind CURSOR_NAMESPACE = 22;
-/** A linkage specification, e.g. 'extern "C"'. 
-  */
-const CXCursorKind CURSOR_LINKAGE_SPEC = 23;
-/** A C++ constructor. 
-  */
-const CXCursorKind CURSOR_CONSTRUCTOR = 24;
-/** A C++ destructor. 
-  */
-const CXCursorKind CURSOR_DESTRUCTOR = 25;
-/** A C++ conversion function. 
-  */
-const CXCursorKind CURSOR_CONVERSION_FUNCTION = 26;
-/** A C++ template type parameter. 
-  */
-const CXCursorKind CURSOR_TEMPLATE_TYPE_PARAMETER = 27;
-/** A C++ non-type template parameter. 
-  */
-const CXCursorKind CURSOR_NON_TYPE_TEMPLATE_PARAMETER = 28;
-/** A C++ template template parameter. 
-  */
-const CXCursorKind CURSOR_TEMPLATE_TEMPLATE_PARAMETER = 29;
-/** A C++ function template. 
-  */
-const CXCursorKind CURSOR_FUNCTION_TEMPLATE = 30;
-/** A C++ class template. 
-  */
-const CXCursorKind CURSOR_CLASS_TEMPLATE = 31;
-/** A C++ class template partial specialization. 
-  */
-const CXCursorKind CURSOR_CLASS_TEMPLATE_PARTIAL_SPECIALIZATION = 32;
-/** A C++ namespace alias declaration. 
-  */
-const CXCursorKind CURSOR_NAMESPACEALIAS = 33;
-/** A C++ using directive. 
-  */
-const CXCursorKind CURSOR_USING_DIRECTIVE = 34;
-/** A C++ using declaration. 
-  */
-const CXCursorKind CURSOR_USING_DECLARATION = 35;
-/** A C++ alias declaration 
-  */
-const CXCursorKind CURSOR_TYPE_ALIAS_DECL = 36;
-/** An Objective-C \@synthesize definition. 
-  */
-const CXCursorKind CURSOR_OBJC_SYNTHESIZE_DECL = 37;
-/** An Objective-C \@dynamic definition. 
-  */
-const CXCursorKind CURSOR_OBJC_DYNAMIC_DECL = 38;
-/** An access specifier. 
-  */
-const CXCursorKind CURSOR_CXX_ACCESS_SPECIFIER = 39;
-
-const CXCursorKind CURSOR_FIRST_DECL = CURSOR_UNEXPOSED_DECL;
-const CXCursorKind CURSOR_LAST_DECL = CURSOR_CXX_ACCESS_SPECIFIER;
-
-/* References */
-const CXCursorKind CURSOR_FIRST_REF = 40; /* Decl references */
-const CXCursorKind CURSOR_OBJC_SUPER_CLASS_REF = 40;
-const CXCursorKind CURSOR_OBJC_PROTOCOL_REF = 41;
-const CXCursorKind CURSOR_OBJC_CLASS_REF = 42;
-/**
- * A reference to a type declaration.
- *
- * A type reference occurs anywhere where a type is named but not
- * declared. For example, given:
- *
- * \code
- * typedef CUInt size_type;
- * size_type size;
- * \endcode
- *
- * The typedef is a declaration of size_type (CXCursor_TypedefDecl),
- * while the type of the variable "size" is referenced. The cursor
- * referenced by the type of size is the typedef for size_type.
- */
-const CXCursorKind CURSOR_TYPE_REF = 43;
-const CXCursorKind CURSOR_CXX_BASE_SPECIFIER = 44;
-/**
- * A reference to a class template, function template, template
- * template parameter, or class template partial specialization.
- */
-const CXCursorKind CURSOR_TEMPLATE_REF = 45;
-/**
- * A reference to a namespace or namespace alias.
- */
-const CXCursorKind CURSOR_NAMESPACE_REF = 46;
-/**
- * A reference to a member of a struct, union, or class that occurs in
- * some non-expression context, e.g., a designated initializer.
- */
-const CXCursorKind CURSOR_MEMBER_REF = 47;
-/**
- * A reference to a labeled statement.
- *
- * This cursor kind is used to describe the jump to "start_over" in the
- * goto statement in the following example:
- *
- * \code
- *   start_over:
- *     ++counter;
- *
- *     goto start_over;
- * \endcode
- *
- * A label reference cursor refers to a label statement.
- */
-const CXCursorKind CURSOR_LABEL_REF = 48;
-
-/**
- * A reference to a set of overloaded functions or function templates
- * that has not yet been resolved to a specific function or function template.
- *
- * An overloaded declaration reference cursor occurs in C++ templates where
- * a dependent name refers to a function. For example:
- *
- * \code
- * template<typename T> void swap(T&, T&);
- *
- * struct X { ... };
- * void swap(X&, X&);
- *
- * template<typename T>
- * void reverse(T* first, T* last) {
- *   while (first < last - 1) {
- *     swap(*first, *--last);
- *     ++first;
- *   }
- * }
- *
- * struct Y { };
- * void swap(Y&, Y&);
- * \endcode
- *
- * Here, the identifier "swap" is associated with an overloaded declaration
- * reference. In the template definition, "swap" refers to either of the two
- * "swap" functions declared above, so both results will be available. At
- * instantiation time, "swap" may also refer to other functions found via
- * argument-dependent lookup (e.g., the "swap" function at the end of the
- * example).
- *
- * The functions \c clang_getNumOverloadedDecls() and
- * \c clang_getOverloadedDecl() can be used to retrieve the definitions
- * referenced by this cursor.
- */
-const CXCursorKind CURSOR_OVERLOADED_DECL_REF = 49;
-
-/**
- * A reference to a variable that occurs in some non-expression
- * context, e.g., a C++ lambda capture list.
- */
-const CXCursorKind CURSOR_VARIABLE_REF = 50;
-
-const CXCursorKind CURSOR_LAST_REF = CURSOR_VARIABLE_REF;
-
-/* Error conditions */
-const CXCursorKind CURSOR_FIRST_INVALID = 70;
-const CXCursorKind CURSOR_INVALID_FILE = 70;
-const CXCursorKind CURSOR_NO_DECL_FOUND = 71;
-const CXCursorKind CURSOR_NOT_IMPLEMENTED = 72;
-const CXCursorKind CURSOR_INVALID_CODE = 73;
-const CXCursorKind CURSOR_LAST_INVALID = CURSOR_INVALID_CODE;
-
-/* Expressions */
-const CXCursorKind CURSOR_FIRST_EXPR = 100;
-
-/**
- * An expression whose specific kind is not exposed via this
- * interface.
- *
- * Unexposed expressions have the same operations as any other kind
- * of expression; one can extract their location information,
- * spelling, children, etc. However, the specific kind of the
- * expression is not reported.
- */
-const CXCursorKind CURSOR_UNEXPOSED_EXPR = 100;
-
-/**
- * An expression that refers to some value declaration, such
- * as a function, variable, or enumerator.
- */
-const CXCursorKind CURSOR_DECL_REF_EXPR = 101;
-
-/**
- * An expression that refers to a member of a struct, union,
- * class, Objective-C class, etc.
- */
-const CXCursorKind CURSOR_MEMBER_REF_EXPR = 102;
-
-/** An expression that calls a function. 
-  */
-const CXCursorKind CURSOR_CALL_EXPR = 103;
-
-/** An expression that sends a message to an Objective-C
- object or class. 
-  */
-const CXCursorKind CURSOR_OBJC_MESSAGE_EXPR = 104;
-
-/** An expression that represents a block literal. 
-  */
-const CXCursorKind CURSOR_BLOCK_EXPR = 105;
-
-/** An integer literal.
- */
-const CXCursorKind CURSOR_INTEGER_LITERAL = 106;
-
-/** A floating poCInt number literal.
- */
-const CXCursorKind CURSOR_FLOATING_LITERAL = 107;
-
-/** An imaginary number literal.
- */
-const CXCursorKind CURSOR_IMAGINARY_LITERAL = 108;
-
-/** A string literal.
- */
-const CXCursorKind CURSOR_STRING_LITERAL = 109;
-
-/** A character literal.
- */
-const CXCursorKind CURSOR_CHARACTER_LITERAL = 110;
-
-/** A parenthesized expression, e.g. "(1)".
- *
- * This AST node is only formed if full location information is requested.
- */
-const CXCursorKind CURSOR_PAREN_EXPR = 111;
-
-/** This represents the unary-expression's (except sizeof and
- * alignof).
- */
-const CXCursorKind CURSOR_UNARY_OPERATOR = 112;
-
-/** [C99 6.5.2.1] Array Subscripting.
- */
-const CXCursorKind CURSOR_ARRAY_SUBSCRIPT_EXPR = 113;
-
-/** A builtin binary operation expression such as "x + y" or
- * "x <= y".
- */
-const CXCursorKind CURSOR_BINARY_OPERATOR = 114;
-
-/** Compound assignment such as "+=".
- */
-const CXCursorKind CURSOR_COMPOUND_ASSIGN_OPERATOR = 115;
-
-/** The ?: ternary operator.
- */
-const CXCursorKind CURSOR_CONDITIONAL_OPERATOR = 116;
-
-/** An explicit cast in C (C99 6.5.4) or a C-style cast in C++
- * (C++ [expr.cast]), which uses the syntax (Type)expr.
- *
- * For example: (CInt)f.
- */
-const CXCursorKind CURSOR_C_STYLE_CAST_EXPR = 117;
-
-/** [C99 6.5.2.5]
- */
-const CXCursorKind CURSOR_COMPOUND_LITERAL_EXPR = 118;
-
-/** Describes an C or C++ initializer list.
- */
-const CXCursorKind CURSOR_INIT_LIST_EXPR = 119;
-
-/** The GNU address of label extension, representing &&label.
- */
-const CXCursorKind CURSOR_ADDR_LABEL_EXPR = 120;
-
-/** This is the GNU Statement Expression extension: ({CInt X=4; X;})
- */
-const CXCursorKind CURSOR_STMT_EXPR = 121;
-
-/** Represents a C11 generic selection.
- */
-const CXCursorKind CURSOR_GENERIC_SELECTION_EXPR = 122;
-
-/** Implements the GNU __null extension, which is a name for a null
- * pointer constant that has integral type (e.g., CInt or long) and is the same
- * size and alignment as a pointer.
- *
- * The __null extension is typically only used by system headers, which define
- * NULL as __null in C++ rather than using 0 (which is an integer that may not
- * match the size of a pointer).
- */
-const CXCursorKind CURSOR_GNU_NULL_EXPR = 123;
-
-/** C++'s static_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_STATIC_CAST_EXPR = 124;
-
-/** C++'s dynamic_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_DYNAMIC_CAST_EXPR = 125;
-
-/** C++'s reinterpret_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_REINTERPRET_CAST_EXPR = 126;
-
-/** C++'s const_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_CONST_CAST_EXPR = 127;
-
-/** Represents an explicit C++ type conversion that uses "functional"
- * notion (C++ [expr.type.conv]).
- *
- * Example:
- * \code
- *   x = CInt(0.5);
- * \endcode
- */
-const CXCursorKind CURSOR_CXX_FUNCTIONAL_CAST_EXPR = 128;
-
-/** A C++ typeid expression (C++ [expr.typeid]).
- */
-const CXCursorKind CURSOR_CXX_TYPEID_EXPR = 129;
-
-/** [C++ 2.13.5] C++ Boolean Literal.
- */
-const CXCursorKind CURSOR_CXX_BOOL_LITERAL_EXPR = 130;
-
-/** [C++0x 2.14.7] C++ Pointer Literal.
- */
-const CXCursorKind CURSOR_CXX_NULLPTR_LITERAL_EXPR = 131;
-
-/** Represents the "this" expression in C++
- */
-const CXCursorKind CURSOR_CXX_THIS_EXPR = 132;
-
-/** [C++ 15] C++ Throw Expression.
- *
- * This handles 'throw' and 'throw' assignment-expression. When
- * assignment-expression isn't present, Op will be null.
- */
-const CXCursorKind CURSOR_CXX_THROW_EXPR = 133;
-
-/** A new expression for memory allocation and constructor calls, e.g:
- * "new CXXNewExpr(foo)".
- */
-const CXCursorKind CURSOR_CXX_NEW_EXPR = 134;
-
-/** A delete expression for memory deallocation and destructor calls,
- * e.g. "delete[] pArray".
- */
-const CXCursorKind CURSOR_CXX_DELETE_EXPR = 135;
-
-/** A unary expression. (noexcept, sizeof, or other traits)
- */
-const CXCursorKind CURSOR_UNARY_EXPR = 136;
-
-/** An Objective-C string literal i.e. @"foo".
- */
-const CXCursorKind CURSOR_OBJC_STRINGLITERAL = 137;
-
-/** An Objective-C \@encode expression.
- */
-const CXCursorKind CURSOR_OBJC_ENCODE_EXPR = 138;
-
-/** An Objective-C \@selector expression.
- */
-const CXCursorKind CURSOR_OBJC_SELECTOR_EXPR = 139;
-
-/** An Objective-C \@protocol expression.
- */
-const CXCursorKind CURSOR_OBJC_PROTOCOL_EXPR = 140;
-
-/** An Objective-C "bridged" cast expression, which casts between
- * Objective-C pointers and C pointers, transferring ownership in the process.
- *
- * \code
- *   NSString *str = (__bridge_transfer NSString *)CFCreateString();
- * \endcode
- */
-const CXCursorKind CURSOR_OBJC_BRIDGED_CAST_EXPR = 141;
-
-/** Represents a C++0x pack expansion that produces a sequence of
- * expressions.
- *
- * A pack expansion expression contains a pattern (which itself is an
- * expression) followed by an ellipsis. For example:
- *
- * \code
- * template<typename F, typename ...Types>
- * void forward(F f, Types &&...args) {
- *  f(static_cast<Types&&>(args)...);
- * }
- * \endcode
- */
-const CXCursorKind CURSOR_PACK_EXPANSION_EXPR = 142;
-
-/** Represents an expression that computes the length of a parameter
- * pack.
- *
- * \code
- * template<typename ...Types>
- * struct count {
- *   static const CUInt value = sizeof...(Types);
- * };
- * \endcode
- */
-const CXCursorKind CURSOR_SIZEOF_PACK_EXPR = 143;
-
-/* Represents a C++ lambda expression that produces a local function
- * object.
- *
- * \code
- * void abssort(float *x, CUInt N) {
- *   std::sort(x, x + N,
- *             [](float a, float b) {
- *               return std::abs(a) < std::abs(b);
- *             });
- * }
- * \endcode
- */
-const CXCursorKind CURSOR_LAMBDA_EXPR = 144;
-
-/** Objective-c Boolean Literal.
- */
-const CXCursorKind CURSOR_OBJC_BOOL_LITERAL_EXPR = 145;
-
-/** Represents the "self" expression in an Objective-C method.
- */
-const CXCursorKind CURSOR_OBJC_SELF_EXPR = 146;
-
-/** OpenMP 5.0 [2.1.5, Array Section].
- */
-const CXCursorKind CURSOR_OMP_ARRAY_SECTION_EXPR = 147;
-
-/** Represents an @available(...) check.
- */
-const CXCursorKind CURSOR_OBJC_AVAILABILITY_CHECK_EXPR = 148;
-
-/**
- * Fixed poCInt literal
- */
-const CXCursorKind CURSOR_FIXED_POINT_LITERAL = 149;
-
-/** OpenMP 5.0 [2.1.4, Array Shaping].
- */
-const CXCursorKind CURSOR_OMP_ARRAY_SHAPING_EXPR = 150;
-
-/**
- * OpenMP 5.0 [2.1.6 Iterators]
- */
-const CXCursorKind CURSOR_OMP_ITERATOR_EXPR = 151;
-
-/** OpenCL's addrspace_cast<> expression.
- */
-const CXCursorKind CURSOR_CXX_ADDR_SPACE_CAST_EXPR = 152;
-
-/**
- * Expression that references a C++20 concept.
- */
-const CXCursorKind CURSOR_CONCEPT_SPECIALIZATION_EXPR = 153;
-
-/**
- * Expression that references a C++20 concept.
- */
-const CXCursorKind CURSOR_REQUIRES_EXPR = 154;
-
-/**
- * Expression that references a C++20 parenthesized list aggregate
- * initializer.
- */
-const CXCursorKind CURSOR_CXX_PAREN_LIST_INIT_EXPR = 155;
-
-const CXCursorKind CURSOR_LASTEXPR = CURSOR_CXX_PAREN_LIST_INIT_EXPR;
-
-/* Statements */
-const CXCursorKind CURSOR_FIRST_STMT = 200;
-/**
- * A statement whose specific kind is not exposed via this
- * interface.
- *
- * Unexposed statements have the same operations as any other kind of
- * statement; one can extract their location information, spelling,
- * children, etc. However, the specific kind of the statement is not
- * reported.
- */
-const CXCursorKind CURSOR_UNEXPOSED_STMT = 200;
-
-/** A labelled statement in a function.
- *
- * This cursor kind is used to describe the "start_over:" label statement in
- * the following example:
- *
- * \code
- *   start_over:
- *     ++counter;
- * \endcode
- *
- */
-const CXCursorKind CURSOR_LABEL_STMT = 201;
-
-/** A group of statements like { stmt stmt }.
- *
- * This cursor kind is used to describe compound statements, e.g. function
- * bodies.
- */
-const CXCursorKind CURSOR_COMPOUND_STMT = 202;
-
-/** A case statement.
- */
-const CXCursorKind CURSOR_CASE_STMT = 203;
-
-/** A default statement.
- */
-const CXCursorKind CURSOR_DEFAULT_STMT = 204;
-
-/** An if statement
- */
-const CXCursorKind CURSOR_IF_STMT = 205;
-
-/** A switch statement.
- */
-const CXCursorKind CURSOR_SWITCH_STMT = 206;
-
-/** A while statement.
- */
-const CXCursorKind CURSOR_WHILE_STMT = 207;
-
-/** A do statement.
- */
-const CXCursorKind CURSOR_DO_STMT = 208;
-
-/** A for statement.
- */
-const CXCursorKind CURSOR_FOR_STMT = 209;
-
-/** A goto statement.
- */
-const CXCursorKind CURSOR_GOTO_STMT = 210;
-
-/** An indirect goto statement.
- */
-const CXCursorKind CURSOR_INDIRECT_GOTO_STMT = 211;
-
-/** A continue statement.
- */
-const CXCursorKind CURSOR_CONTINUE_STMT = 212;
-
-/** A break statement.
- */
-const CXCursorKind CURSOR_BREAK_STMT = 213;
-
-/** A return statement.
- */
-const CXCursorKind CURSOR_RETURN_STMT = 214;
-
-/** A GCC inline assembly statement extension.
- */
-const CXCursorKind CURSOR_GCC_ASM_STMT = 215;
-const CXCursorKind CURSOR_ASMSTMT = CURSOR_GCC_ASM_STMT;
-
-/** Objective-C's overall \@try-\@catch-\@finally statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_TRY_STMT = 216;
-
-/** Objective-C's \@catch statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_CATCH_STMT = 217;
-
-/** Objective-C's \@finally statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_FINALLY_STMT = 218;
-
-/** Objective-C's \@throw statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_THROW_STMT = 219;
-
-/** Objective-C's \@synchronized statement.
- */
-const CXCursorKind CURSOR_OBJC_AT_SYNCHRONIZED_STMT = 220;
-
-/** Objective-C's autorelease pool statement.
- */
-const CXCursorKind CURSOR_OBJC_AUTORELEASE_POOL_STMT = 221;
-
-/** Objective-C's collection statement.
- */
-const CXCursorKind CURSOR_OBJC_FOR_COLLECTION_STMT = 222;
-
-/** C++'s catch statement.
- */
-const CXCursorKind CURSOR_CXX_CATCH_STMT = 223;
-
-/** C++'s try statement.
- */
-const CXCursorKind CURSOR_CXX_TRY_STMT = 224;
-
-/** C++'s for (* : *) statement.
- */
-const CXCursorKind CURSOR_CXX_FOR_RANGE_STMT = 225;
-
-/** Windows Structured Exception Handling's try statement.
- */
-const CXCursorKind CURSOR_SEH_TRY_STMT = 226;
-
-/** Windows Structured Exception Handling's except statement.
- */
-const CXCursorKind CURSOR_SEH_EXCEPT_STMT = 227;
-
-/** Windows Structured Exception Handling's finally statement.
- */
-const CXCursorKind CURSOR_SEH_FINALLY_STMT = 228;
-
-/** A MS inline assembly statement extension.
- */
-const CXCursorKind CURSOR_MS_ASM_STMT = 229;
-
-/** The null statement ";": C99 6.8.3p3.
- *
- * This cursor kind is used to describe the null statement.
- */
-const CXCursorKind CURSOR_NULL_STMT = 230;
-
-/** Adaptor class for mixing declarations with statements and
- * expressions.
- */
-const CXCursorKind CURSOR_DECL_STMT = 231;
-
-/** OpenMP parallel directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_DIRECTIVE = 232;
-
-/** OpenMP SIMD directive.
- */
-const CXCursorKind CURSOR_OMP_SIMD_DIRECTIVE = 233;
-
-/** OpenMP for directive.
- */
-const CXCursorKind CURSOR_OMP_FOR_DIRECTIVE = 234;
-
-/** OpenMP sections directive.
- */
-const CXCursorKind CURSOR_OMP_SECTIONS_DIRECTIVE = 235;
-
-/** OpenMP section directive.
- */
-const CXCursorKind CURSOR_OMP_SECTION_DIRECTIVE = 236;
-
-/** OpenMP single directive.
- */
-const CXCursorKind CURSOR_OMP_SINGLE_DIRECTIVE = 237;
-
-/** OpenMP parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_FOR_DIRECTIVE = 238;
-
-/** OpenMP parallel sections directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_SECTIONS_DIRECTIVE = 239;
-
-/** OpenMP task directive.
- */
-const CXCursorKind CURSOR_OMP_TASK_DIRECTIVE = 240;
-
-/** OpenMP master directive.
- */
-const CXCursorKind CURSOR_OMP_MASTER_DIRECTIVE = 241;
-
-/** OpenMP critical directive.
- */
-const CXCursorKind CURSOR_OMP_CRITICAL_DIRECTIVE = 242;
-
-/** OpenMP taskyield directive.
- */
-const CXCursorKind CURSOR_OMP_TASKYIELD_DIRECTIVE = 243;
-
-/** OpenMP barrier directive.
- */
-const CXCursorKind CURSOR_OMP_BARRIER_DIRECTIVE = 244;
-
-/** OpenMP taskwait directive.
- */
-const CXCursorKind CURSOR_OMP_TASKWAIT_DIRECTIVE = 245;
-
-/** OpenMP flush directive.
- */
-const CXCursorKind CURSOR_OMP_FLUSH_DIRECTIVE = 246;
-
-/** Windows Structured Exception Handling's leave statement.
- */
-const CXCursorKind CURSOR_SEH_LEAVE_STMT = 247;
-
-/** OpenMP ordered directive.
- */
-const CXCursorKind CURSOR_OMP_ORDERED_DIRECTIVE = 248;
-
-/** OpenMP atomic directive.
- */
-const CXCursorKind CURSOR_OMP_ATOMIC_DIRECTIVE = 249;
-
-/** OpenMP for SIMD directive.
- */
-const CXCursorKind CURSOR_OMP_FOR_SIMD_DIRECTIVE = 250;
-
-/** OpenMP parallel for SIMD directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_FOR_SIMD_DIRECTIVE = 251;
-
-/** OpenMP target directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_DIRECTIVE = 252;
-
-/** OpenMP teams directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DIRECTIVE = 253;
-
-/** OpenMP taskgroup directive.
- */
-const CXCursorKind CURSOR_OMP_TASKGROUP_DIRECTIVE = 254;
-
-/** OpenMP cancellation poCInt directive.
- */
-const CXCursorKind CURSOR_OMP_CANCELLATION_POINT_DIRECTIVE = 255;
-
-/** OpenMP cancel directive.
- */
-const CXCursorKind CURSOR_OMP_CANCEL_DIRECTIVE = 256;
-
-/** OpenMP target data directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_DATA_DIRECTIVE = 257;
-
-/** OpenMP taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_TASK_LOOP_DIRECTIVE = 258;
-
-/** OpenMP taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_TASK_LOOP_SIMD_DIRECTIVE = 259;
-
-/** OpenMP distribute directive.
- */
-const CXCursorKind CURSOR_OMP_DISTRIBUTE_DIRECTIVE = 260;
-
-/** OpenMP target enter data directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_ENTER_DATA_DIRECTIVE = 261;
-
-/** OpenMP target exit data directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_EXIT_DATA_DIRECTIVE = 262;
-
-/** OpenMP target parallel directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_PARALLEL_DIRECTIVE = 263;
-
-/** OpenMP target parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_PARALLEL_FOR_DIRECTIVE = 264;
-
-/** OpenMP target update directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_UPDATE_DIRECTIVE = 265;
-
-/** OpenMP distribute parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 266;
-
-/** OpenMP distribute parallel for simd directive.
- */
-const CXCursorKind CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 267;
-
-/** OpenMP distribute simd directive.
- */
-const CXCursorKind CURSOR_OMP_DISTRIBUTE_SIMD_DIRECTIVE = 268;
-
-/** OpenMP target parallel for simd directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_PARALLEL_FOR_SIMD_DIRECTIVE = 269;
-
-/** OpenMP target simd directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_SIMD_DIRECTIVE = 270;
-
-/** OpenMP teams distribute directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DISTRIBUTE_DIRECTIVE = 271;
-
-/** OpenMP teams distribute simd directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 272;
-
-/** OpenMP teams distribute parallel for simd directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 273;
-
-/** OpenMP teams distribute parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 274;
-
-/** OpenMP target teams directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DIRECTIVE = 275;
-
-/** OpenMP target teams distribute directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_DIRECTIVE = 276;
-
-/** OpenMP target teams distribute parallel for directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 277;
-
-/** OpenMP target teams distribute parallel for simd directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 278;
-
-/** OpenMP target teams distribute simd directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 279;
-
-/** C++2a std::bit_cast expression.
- */
-const CXCursorKind CURSOR_BUILTIN_BIT_CAST_EXPR = 280;
-
-/** OpenMP master taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_MASTER_TASK_LOOP_DIRECTIVE = 281;
-
-/** OpenMP parallel master taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_DIRECTIVE = 282;
-
-/** OpenMP master taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 283;
-
-/** OpenMP parallel master taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 284;
-
-/** OpenMP parallel master directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASTER_DIRECTIVE = 285;
-
-/** OpenMP depobj directive.
- */
-const CXCursorKind CURSOR_OMP_DEPOBJ_DIRECTIVE = 286;
-
-/** OpenMP scan directive.
- */
-const CXCursorKind CURSOR_OMP_SCAN_DIRECTIVE = 287;
-
-/** OpenMP tile directive.
- */
-const CXCursorKind CURSOR_OMP_TILE_DIRECTIVE = 288;
-
-/** OpenMP canonical loop.
- */
-const CXCursorKind CURSOR_OMP_CANONICAL_LOOP = 289;
-
-/** OpenMP interop directive.
- */
-const CXCursorKind CURSOR_OMP_INTEROP_DIRECTIVE = 290;
-
-/** OpenMP dispatch directive.
- */
-const CXCursorKind CURSOR_OMP_DISPATCH_DIRECTIVE = 291;
-
-/** OpenMP masked directive.
- */
-const CXCursorKind CURSOR_OMP_MASKED_DIRECTIVE = 292;
-
-/** OpenMP unroll directive.
- */
-const CXCursorKind CURSOR_OMP_UNROLL_DIRECTIVE = 293;
-
-/** OpenMP metadirective directive.
- */
-const CXCursorKind CURSOR_OMP_META_DIRECTIVE = 294;
-
-/** OpenMP loop directive.
- */
-const CXCursorKind CURSOR_OMP_GENERIC_LOOP_DIRECTIVE = 295;
-
-/** OpenMP teams loop directive.
- */
-const CXCursorKind CURSOR_OMP_TEAMS_GENERIC_LOOP_DIRECTIVE = 296;
-
-/** OpenMP target teams loop directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_TEAMS_GENERIC_LOOP_DIRECTIVE = 297;
-
-/** OpenMP parallel loop directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_GENERIC_LOOP_DIRECTIVE = 298;
-
-/** OpenMP target parallel loop directive.
- */
-const CXCursorKind CURSOR_OMP_TARGET_PARALLEL_GENERIC_LOOP_DIRECTIVE = 299;
-
-/** OpenMP parallel masked directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASKED_DIRECTIVE = 300;
-
-/** OpenMP masked taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_MASKED_TASK_LOOP_DIRECTIVE = 301;
-
-/** OpenMP masked taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 302;
-
-/** OpenMP parallel masked taskloop directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_DIRECTIVE = 303;
-
-/** OpenMP parallel masked taskloop simd directive.
- */
-const CXCursorKind CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 304;
-
-/** OpenMP error directive.
- */
-const CXCursorKind CURSOR_OMP_ERROR_DIRECTIVE = 305;
-
-/** OpenMP scope directive.
- */
-const CXCursorKind CURSOR_OMP_SCOPE_DIRECTIVE = 306;
-
-const CXCursorKind CURSOR_LAST_STMT = CURSOR_OMP_ERROR_DIRECTIVE;
-
-/**
- * Cursor that represents the translation unit itself.
- *
- * The translation unit cursor exists primarily to act as the root
- * cursor for traversing the contents of a translation unit.
- */
-const CXCursorKind CURSOR_TRANSLATION_UNIT = 350;
-
-/* Attributes */
-const CXCursorKind CURSOR_FIRST_ATTR = 400;
-/**
- * An attribute whose specific kind is not exposed via this
- * interface.
- */
-const CXCursorKind CURSOR_UNEXPOSED_ATTR = 400;
-
-const CXCursorKind CURSOR_IB_ACTION_ATTR = 401;
-const CXCursorKind CURSOR_IB_OUTLET_ATTR = 402;
-const CXCursorKind CURSOR_IB_OUTLET_COLLECTION_ATTR = 403;
-const CXCursorKind CURSOR_CXX_FINAL_ATTR = 404;
-const CXCursorKind CURSOR_CXX_OVERRIDE_ATTR = 405;
-const CXCursorKind CURSOR_ANNOTATE_ATTR = 406;
-const CXCursorKind CURSOR_ASM_LABEL_ATTR = 407;
-const CXCursorKind CURSOR_PACKED_ATTR = 408;
-const CXCursorKind CURSOR_PURE_ATTR = 409;
-const CXCursorKind CURSOR_CONST_ATTR = 410;
-const CXCursorKind CURSOR_NO_DUPLICATE_ATTR = 411;
-const CXCursorKind CURSOR_CUDA_CONSTANT_ATTR = 412;
-const CXCursorKind CURSOR_CUDA_DEVICE_ATTR = 413;
-const CXCursorKind CURSOR_CUDA_GLOBAL_ATTR = 414;
-const CXCursorKind CURSOR_CUDA_HOST_ATTR = 415;
-const CXCursorKind CURSOR_CUDA_SHARED_ATTR = 416;
-const CXCursorKind CURSOR_VISIBILITY_ATTR = 417;
-const CXCursorKind CURSOR_DLL_EXPORT = 418;
-const CXCursorKind CURSOR_DLL_IMPORT = 419;
-const CXCursorKind CURSOR_NS_RETURNS_RETAINED = 420;
-const CXCursorKind CURSOR_NS_RETURNS_NOT_RETAINED = 421;
-const CXCursorKind CURSOR_NS_RETURNS_AUTORELEASED = 422;
-const CXCursorKind CURSOR_NS_CONSUMES_SELF = 423;
-const CXCursorKind CURSOR_NS_CONSUMED = 424;
-const CXCursorKind CURSOR_OBJC_EXCEPTION = 425;
-const CXCursorKind CURSOR_OBJC_NS_OBJECT = 426;
-const CXCursorKind CURSOR_OBJC_INDEPENDENT_CLASS = 427;
-const CXCursorKind CURSOR_OBJC_PRECISE_LIFETIME = 428;
-const CXCursorKind CURSOR_OBJC_RETURNS_INNER_POINTER = 429;
-const CXCursorKind CURSOR_OBJC_REQUIRES_SUPER = 430;
-const CXCursorKind CURSOR_OBJC_ROOT_CLASS = 431;
-const CXCursorKind CURSOR_OBJC_SUBCLASSING_RESTRICTED = 432;
-const CXCursorKind CURSOR_OBJC_EXPLICIT_PROTOCOL_IMPL = 433;
-const CXCursorKind CURSOR_OBJC_DESIGNATED_INITIALIZER = 434;
-const CXCursorKind CURSOR_OBJC_RUNTIME_VISIBLE = 435;
-const CXCursorKind CURSOR_OBJC_BOXABLE = 436;
-const CXCursorKind CURSOR_FLAG_ENUM = 437;
-const CXCursorKind CURSOR_CONVERGENT_ATTR = 438;
-const CXCursorKind CURSOR_WARN_UNUSED_ATTR = 439;
-const CXCursorKind CURSOR_WARN_UNUSED_RESULT_ATTR = 440;
-const CXCursorKind CURSOR_ALIGNED_ATTR = 441;
-const CXCursorKind CURSOR_LAST_ATTR = CURSOR_ALIGNED_ATTR;
-
-/* Preprocessing */
-const CXCursorKind CURSOR_PREPROCESSING_DIRECTIVE = 500;
-const CXCursorKind CURSOR_MACRO_DEFINITION = 501;
-const CXCursorKind CURSOR_MACRO_EXPANSION = 502;
-const CXCursorKind CURSOR_MACRO_INSTANTIATION = CURSOR_MACRO_EXPANSION;
-const CXCursorKind CURSOR_INCLUSION_DIRECTIVE = 503;
-const CXCursorKind CURSOR_FIRST_PREPROCESSING = CURSOR_PREPROCESSING_DIRECTIVE;
-const CXCursorKind CURSOR_LAST_PREPROCESSING = CURSOR_INCLUSION_DIRECTIVE;
-
-/* Extra Declarations */
-/**
- * A module import declaration.
- */
-const CXCursorKind CURSOR_MODULE_IMPORT_DECL = 600;
-const CXCursorKind CURSOR_TYPE_ALIAS_TEMPLATE_DECL = 601;
-/**
- * A static_assert or _Static_assert node
- */
-const CXCursorKind CURSOR_STATIC_ASSERT = 602;
-/**
- * a friend declaration.
- */
-const CXCursorKind CURSOR_FRIEND_DECL = 603;
-/**
- * a concept declaration.
- */
-const CXCursorKind CURSOR_CONCEPT_DECL = 604;
-
-const CXCursorKind CURSOR_FIRST_EXTRA_DECL = CURSOR_MODULE_IMPORT_DECL;
-const CXCursorKind CURSOR_LAST_EXTRA_DECL = CURSOR_CONCEPT_DECL;
-
-/**
- * A code completion overload candidate.
- */
-const CXCursorKind CURSOR_OVERLOAD_CANDIDATE = 700;
-
-/**
- * A cursor representing some element in the abstract syntax tree for
- * a translation unit.
- *
- * The cursor abstraction unifies the different kinds of entities in a
- * program--declaration, statements, expressions, references to declarations,
- * etc.--under a single "cursor" abstraction with a common set of operations.
- * Common operation for a cursor include: getting the physical location in
- * a source file where the cursor points, getting the name associated with a
- * cursor, and retrieving cursors for any child nodes of a particular cursor.
- *
- * Cursors can be produced in two specific ways.
- * clang_getTranslationUnitCursor() produces a cursor for a translation unit,
- * from which one can use clang_visitChildren() to explore the rest of the
- * translation unit. clang_getCursor() maps from a physical source location
- * to the entity that resides at that location, allowing one to map from the
- * source code into the AST.
- */
+<*
+  Return the memory usage of a translation unit.  This object
+  should be released with clang_disposeCXTUResourceUsage().
+*>
+extern fn CXTUResourceUsage getCXTUResourceUsage(
+  CXTranslationUnit tu)
+@cname("clang_getCXTUResourceUsage");
+
+extern fn void disposeCXTUResourceUsage(
+  CXTUResourceUsage usage)
+@cname("clang_disposeCXTUResourceUsage");
+
+<*
+  Get target information for this translation unit.
+  The CXTargetInfo object cannot outlive the CXTranslationUnit object.
+*>
+extern fn CXTargetInfo getTranslationUnitTargetInfo(
+  CXTranslationUnit ct_unit)
+@cname("clang_getTranslationUnitTargetInfo");
+
+<*
+  Destroy the CXTargetInfo object.
+*>
+extern fn void targetInfo_dispose(
+  CXTargetInfo info)
+@cname("clang_TargetInfo_dispose");
+
+<*
+  Get the normalized target triple as a string.
+  Returns the empty string in case of any error.
+*>
+extern fn CXString targetInfo_getTriple(
+  CXTargetInfo info)
+@cname("clang_TargetInfo_getTriple");
+
+<*
+  Get the pointer width of the target in bits.
+  Returns -1 in case of error.
+*>
+extern fn CInt targetInfo_getPointerWidth(
+  CXTargetInfo info)
+@cname("clang_TargetInfo_getPointerWidth");
+
+<*
+  Describes the kind of entity that a cursor refers to.
+*>
+constdef CXCursorKind : CInt {
+
+  <*
+    A declaration whose specific kind is not exposed via this
+    interface.
+    Unexposed declarations have the same operations as any other kind
+    of declaration; one can extract their location information,
+    spelling, find their definitions, etc. However, the specific kind
+    of the declaration is not reported.
+  *>
+  CURSOR_UNEXPOSED_DECL = 1,
+
+  <*
+    A C or C++ struct. *
+  *>
+  CURSOR_STRUCT_DECL = 2,
+
+  <*
+    A C or C++ union. *
+  *>
+  CURSOR_UNION_DECL = 3,
+
+  <*
+    A C++ class. *
+  *>
+  CURSOR_CLASS_DECL = 4,
+
+  <*
+    An enumeration. *
+  *>
+  CURSOR_ENUM_DECL = 5,
+
+  <*
+    A field (in C) or non-static data member (in C++) in a
+    struct, union, or C++ class.
+  *>
+  CURSOR_FIELD_DECL = 6,
+
+  <*
+    An enumerator constant. *
+  *>
+  CURSOR_ENUM_CONSTANT_DECL = 7,
+
+  <*
+    A function. *
+  *>
+  CURSOR_FUNCTION_DECL = 8,
+
+  <*
+    A variable. *
+  *>
+  CURSOR_VAR_DECL = 9,
+
+  <*
+    A function or method parameter. *
+  *>
+  CURSOR_PARM_DECL = 10,
+
+  <*
+    An Objective-C \@interface. *
+  *>
+  CURSOR_OBJ_C_INTERFACE_DECL = 11,
+
+  <*
+    An Objective-C \@interface for a category. *
+  *>
+  CURSOR_OBJ_C_CATEGORY_DECL = 12,
+
+  <*
+    An Objective-C \@protocol declaration. *
+  *>
+  CURSOR_OBJ_C_PROTOCOL_DECL = 13,
+
+  <*
+    An Objective-C \@property declaration. *
+  *>
+  CURSOR_OBJ_C_PROPERTY_DECL = 14,
+
+  <*
+    An Objective-C instance variable. *
+  *>
+  CURSOR_OBJ_C_IVAR_DECL = 15,
+
+  <*
+    An Objective-C instance method. *
+  *>
+  CURSOR_OBJ_C_INSTANCE_METHOD_DECL = 16,
+
+  <*
+    An Objective-C class method. *
+  *>
+  CURSOR_OBJ_C_CLASS_METHOD_DECL = 17,
+
+  <*
+    An Objective-C \@implementation. *
+  *>
+  CURSOR_OBJ_C_IMPLEMENTATION_DECL = 18,
+
+  <*
+    An Objective-C \@implementation for a category. *
+  *>
+  CURSOR_OBJ_C_CATEGORY_IMPL_DECL = 19,
+
+  <*
+    A typedef. *
+  *>
+  CURSOR_TYPEDEF_DECL = 20,
+
+  <*
+    A C++ class method. *
+  *>
+  CURSOR_CXX_METHOD = 21,
+
+  <*
+    A C++ namespace. *
+  *>
+  CURSOR_NAMESPACE = 22,
+
+  <*
+    A linkage specification, e.g. 'extern "C"'. *
+  *>
+  CURSOR_LINKAGE_SPEC = 23,
+
+  <*
+    A C++ constructor. *
+  *>
+  CURSOR_CONSTRUCTOR = 24,
+
+  <*
+    A C++ destructor. *
+  *>
+  CURSOR_DESTRUCTOR = 25,
+
+  <*
+    A C++ conversion function. *
+  *>
+  CURSOR_CONVERSION_FUNCTION = 26,
+
+  <*
+    A C++ template type parameter. *
+  *>
+  CURSOR_TEMPLATE_TYPE_PARAMETER = 27,
+
+  <*
+    A C++ non-type template parameter. *
+  *>
+  CURSOR_NON_TYPE_TEMPLATE_PARAMETER = 28,
+
+  <*
+    A C++ template template parameter. *
+  *>
+  CURSOR_TEMPLATE_TEMPLATE_PARAMETER = 29,
+
+  <*
+    A C++ function template. *
+  *>
+  CURSOR_FUNCTION_TEMPLATE = 30,
+
+  <*
+    A C++ class template. *
+  *>
+  CURSOR_CLASS_TEMPLATE = 31,
+
+  <*
+    A C++ class template partial specialization. *
+  *>
+  CURSOR_CLASS_TEMPLATE_PARTIAL_SPECIALIZATION = 32,
+
+  <*
+    A C++ namespace alias declaration. *
+  *>
+  CURSOR_NAMESPACE_ALIAS = 33,
+
+  <*
+    A C++ using directive. *
+  *>
+  CURSOR_USING_DIRECTIVE = 34,
+
+  <*
+    A C++ using declaration. *
+  *>
+  CURSOR_USING_DECLARATION = 35,
+
+  <*
+    A C++ alias declaration *
+  *>
+  CURSOR_TYPE_ALIAS_DECL = 36,
+
+  <*
+    An Objective-C \@synthesize definition. *
+  *>
+  CURSOR_OBJ_C_SYNTHESIZE_DECL = 37,
+
+  <*
+    An Objective-C \@dynamic definition. *
+  *>
+  CURSOR_OBJ_C_DYNAMIC_DECL = 38,
+
+  <*
+    An access specifier. *
+  *>
+  CURSOR_CXX_ACCESS_SPECIFIER = 39,
+
+  <*
+    An access specifier. *
+  *>
+  CURSOR_FIRST_DECL = 1,
+
+  <*
+    An access specifier. *
+  *>
+  CURSOR_LAST_DECL = 39,
+
+  <*
+    An access specifier. *
+  *>
+  CURSOR_FIRST_REF = 40,
+
+  <*
+    An access specifier. *
+  *>
+  CURSOR_OBJ_C_SUPER_CLASS_REF = 40,
+
+  <*
+    An access specifier. *
+  *>
+  CURSOR_OBJ_C_PROTOCOL_REF = 41,
+
+  <*
+    An access specifier. *
+  *>
+  CURSOR_OBJ_C_CLASS_REF = 42,
+
+  <*
+    A reference to a type declaration.
+    A type reference occurs anywhere where a type is named but not
+    declared. For example, given:
+    \code
+    typedef unsigned size_type;
+    size_type size;
+    \endcode
+    The typedef is a declaration of size_type (CXCursor_TypedefDecl),
+    while the type of the variable "size" is referenced. The cursor
+    referenced by the type of size is the typedef for size_type.
+  *>
+  CURSOR_TYPE_REF = 43,
+
+  <*
+    A reference to a type declaration.
+    A type reference occurs anywhere where a type is named but not
+    declared. For example, given:
+    \code
+    typedef unsigned size_type;
+    size_type size;
+    \endcode
+    The typedef is a declaration of size_type (CXCursor_TypedefDecl),
+    while the type of the variable "size" is referenced. The cursor
+    referenced by the type of size is the typedef for size_type.
+  *>
+  CURSOR_CXX_BASE_SPECIFIER = 44,
+
+  <*
+    A reference to a class template, function template, template
+    template parameter, or class template partial specialization.
+  *>
+  CURSOR_TEMPLATE_REF = 45,
+
+  <*
+    A reference to a namespace or namespace alias.
+  *>
+  CURSOR_NAMESPACE_REF = 46,
+
+  <*
+    A reference to a member of a struct, union, or class that occurs in
+    some non-expression context, e.g., a designated initializer.
+  *>
+  CURSOR_MEMBER_REF = 47,
+
+  <*
+    A reference to a labeled statement.
+    This cursor kind is used to describe the jump to "start_over" in the
+    goto statement in the following example:
+    \code
+    start_over:
+    ++counter;
+    goto start_over;
+    \endcode
+    A label reference cursor refers to a label statement.
+  *>
+  CURSOR_LABEL_REF = 48,
+
+  <*
+    A reference to a set of overloaded functions or function templates
+    that has not yet been resolved to a specific function or function template.
+    An overloaded declaration reference cursor occurs in C++ templates where
+    a dependent name refers to a function. For example:
+    \code
+    template<typename T> void swap(T&, T&);
+    struct X { ... };
+    void swap(X&, X&);
+    template<typename T>
+    void reverse(T* first, T* last) {
+    while (first < last - 1) {
+    swap(*first, *--last);
+    ++first;
+    }
+    }
+    struct Y { };
+    void swap(Y&, Y&);
+    \endcode
+    Here, the identifier "swap" is associated with an overloaded declaration
+    reference. In the template definition, "swap" refers to either of the two
+    "swap" functions declared above, so both results will be available. At
+    instantiation time, "swap" may also refer to other functions found via
+    argument-dependent lookup (e.g., the "swap" function at the end of the
+    example).
+    The functions \c clang_getNumOverloadedDecls() and
+    \c clang_getOverloadedDecl() can be used to retrieve the definitions
+    referenced by this cursor.
+  *>
+  CURSOR_OVERLOADED_DECL_REF = 49,
+
+  <*
+    A reference to a variable that occurs in some non-expression
+    context, e.g., a C++ lambda capture list.
+  *>
+  CURSOR_VARIABLE_REF = 50,
+
+  <*
+    A reference to a variable that occurs in some non-expression
+    context, e.g., a C++ lambda capture list.
+  *>
+  CURSOR_LAST_REF = 50,
+
+  <*
+    A reference to a variable that occurs in some non-expression
+    context, e.g., a C++ lambda capture list.
+  *>
+  CURSOR_FIRST_INVALID = 70,
+
+  <*
+    A reference to a variable that occurs in some non-expression
+    context, e.g., a C++ lambda capture list.
+  *>
+  CURSOR_INVALID_FILE = 70,
+
+  <*
+    A reference to a variable that occurs in some non-expression
+    context, e.g., a C++ lambda capture list.
+  *>
+  CURSOR_NO_DECL_FOUND = 71,
+
+  <*
+    A reference to a variable that occurs in some non-expression
+    context, e.g., a C++ lambda capture list.
+  *>
+  CURSOR_NOT_IMPLEMENTED = 72,
+
+  <*
+    A reference to a variable that occurs in some non-expression
+    context, e.g., a C++ lambda capture list.
+  *>
+  CURSOR_INVALID_CODE = 73,
+
+  <*
+    A reference to a variable that occurs in some non-expression
+    context, e.g., a C++ lambda capture list.
+  *>
+  CURSOR_LAST_INVALID = 73,
+
+  <*
+    A reference to a variable that occurs in some non-expression
+    context, e.g., a C++ lambda capture list.
+  *>
+  CURSOR_FIRST_EXPR = 100,
+
+  <*
+    An expression whose specific kind is not exposed via this
+    interface.
+    Unexposed expressions have the same operations as any other kind
+    of expression; one can extract their location information,
+    spelling, children, etc. However, the specific kind of the
+    expression is not reported.
+  *>
+  CURSOR_UNEXPOSED_EXPR = 100,
+
+  <*
+    An expression that refers to some value declaration, such
+    as a function, variable, or enumerator.
+  *>
+  CURSOR_DECL_REF_EXPR = 101,
+
+  <*
+    An expression that refers to a member of a struct, union,
+    class, Objective-C class, etc.
+  *>
+  CURSOR_MEMBER_REF_EXPR = 102,
+
+  <*
+    An expression that calls a function. *
+  *>
+  CURSOR_CALL_EXPR = 103,
+
+  <*
+    An expression that sends a message to an Objective-C
+    object or class. *
+  *>
+  CURSOR_OBJ_C_MESSAGE_EXPR = 104,
+
+  <*
+    An expression that represents a block literal. *
+  *>
+  CURSOR_BLOCK_EXPR = 105,
+
+  <*
+    An integer literal.
+  *>
+  CURSOR_INTEGER_LITERAL = 106,
+
+  <*
+    A floating point number literal.
+  *>
+  CURSOR_FLOATING_LITERAL = 107,
+
+  <*
+    An imaginary number literal.
+  *>
+  CURSOR_IMAGINARY_LITERAL = 108,
+
+  <*
+    A string literal.
+  *>
+  CURSOR_STRING_LITERAL = 109,
+
+  <*
+    A character literal.
+  *>
+  CURSOR_CHARACTER_LITERAL = 110,
+
+  <*
+    A parenthesized expression, e.g. "(1)".
+    This AST node is only formed if full location information is requested.
+  *>
+  CURSOR_PAREN_EXPR = 111,
+
+  <*
+    This represents the unary-expression's (except sizeof and
+    alignof).
+  *>
+  CURSOR_UNARY_OPERATOR = 112,
+
+  <*
+    [C99 6.5.2.1] Array Subscripting.
+  *>
+  CURSOR_ARRAY_SUBSCRIPT_EXPR = 113,
+
+  <*
+    A builtin binary operation expression such as "x + y" or
+    "x <= y".
+  *>
+  CURSOR_BINARY_OPERATOR = 114,
+
+  <*
+    Compound assignment such as "+=".
+  *>
+  CURSOR_COMPOUND_ASSIGN_OPERATOR = 115,
+
+  <*
+    The ?: ternary operator.
+  *>
+  CURSOR_CONDITIONAL_OPERATOR = 116,
+
+  <*
+    An explicit cast in C (C99 6.5.4) or a C-style cast in C++
+    (C++ [expr.cast]), which uses the syntax (Type)expr.
+    For example: (int)f.
+  *>
+  CURSOR_C_STYLE_CAST_EXPR = 117,
+
+  <*
+    [C99 6.5.2.5]
+  *>
+  CURSOR_COMPOUND_LITERAL_EXPR = 118,
+
+  <*
+    Describes an C or C++ initializer list.
+  *>
+  CURSOR_INIT_LIST_EXPR = 119,
+
+  <*
+    The GNU address of label extension, representing &&label.
+  *>
+  CURSOR_ADDR_LABEL_EXPR = 120,
+
+  <*
+    This is the GNU Statement Expression extension: ({int X=4; X;})
+  *>
+  CURSOR_STMT_EXPR = 121,
+
+  <*
+    Represents a C11 generic selection.
+  *>
+  CURSOR_GENERIC_SELECTION_EXPR = 122,
+
+  <*
+    Implements the GNU __null extension, which is a name for a null
+    pointer constant that has integral type (e.g., int or long) and is the same
+    size and alignment as a pointer.
+    The __null extension is typically only used by system headers, which define
+    NULL as __null in C++ rather than using 0 (which is an integer that may not
+    match the size of a pointer).
+  *>
+  CURSOR_GNU_NULL_EXPR = 123,
+
+  <*
+    C++'s static_cast<> expression.
+  *>
+  CURSOR_CXX_STATIC_CAST_EXPR = 124,
+
+  <*
+    C++'s dynamic_cast<> expression.
+  *>
+  CURSOR_CXX_DYNAMIC_CAST_EXPR = 125,
+
+  <*
+    C++'s reinterpret_cast<> expression.
+  *>
+  CURSOR_CXX_REINTERPRET_CAST_EXPR = 126,
+
+  <*
+    C++'s const_cast<> expression.
+  *>
+  CURSOR_CXX_CONST_CAST_EXPR = 127,
+
+  <*
+    Represents an explicit C++ type conversion that uses "functional"
+    notion (C++ [expr.type.conv]).
+    Example:
+    \code
+    x = int(0.5);
+    \endcode
+  *>
+  CURSOR_CXX_FUNCTIONAL_CAST_EXPR = 128,
+
+  <*
+    A C++ typeid expression (C++ [expr.typeid]).
+  *>
+  CURSOR_CXX_TYPEID_EXPR = 129,
+
+  <*
+    [C++ 2.13.5] C++ Boolean Literal.
+  *>
+  CURSOR_CXX_BOOL_LITERAL_EXPR = 130,
+
+  <*
+    [C++0x 2.14.7] C++ Pointer Literal.
+  *>
+  CURSOR_CXX_NULL_PTR_LITERAL_EXPR = 131,
+
+  <*
+    Represents the "this" expression in C++
+  *>
+  CURSOR_CXX_THIS_EXPR = 132,
+
+  <*
+    [C++ 15] C++ Throw Expression.
+    This handles 'throw' and 'throw' assignment-expression. When
+    assignment-expression isn't present, Op will be null.
+  *>
+  CURSOR_CXX_THROW_EXPR = 133,
+
+  <*
+    A new expression for memory allocation and constructor calls, e.g:
+    "new CXXNewExpr(foo)".
+  *>
+  CURSOR_CXX_NEW_EXPR = 134,
+
+  <*
+    A delete expression for memory deallocation and destructor calls,
+    e.g. "delete[] pArray".
+  *>
+  CURSOR_CXX_DELETE_EXPR = 135,
+
+  <*
+    A unary expression. (noexcept, sizeof, or other traits)
+  *>
+  CURSOR_UNARY_EXPR = 136,
+
+  <*
+    An Objective-C string literal i.e. @"foo".
+  *>
+  CURSOR_OBJ_C_STRING_LITERAL = 137,
+
+  <*
+    An Objective-C \@encode expression.
+  *>
+  CURSOR_OBJ_C_ENCODE_EXPR = 138,
+
+  <*
+    An Objective-C \@selector expression.
+  *>
+  CURSOR_OBJ_C_SELECTOR_EXPR = 139,
+
+  <*
+    An Objective-C \@protocol expression.
+  *>
+  CURSOR_OBJ_C_PROTOCOL_EXPR = 140,
+
+  <*
+    An Objective-C "bridged" cast expression, which casts between
+    Objective-C pointers and C pointers, transferring ownership in the process.
+    \code
+    NSString *str = (__bridge_transfer NSString *)CFCreateString();
+    \endcode
+  *>
+  CURSOR_OBJ_C_BRIDGED_CAST_EXPR = 141,
+
+  <*
+    Represents a C++0x pack expansion that produces a sequence of
+    expressions.
+    A pack expansion expression contains a pattern (which itself is an
+    expression) followed by an ellipsis. For example:
+    \code
+    template<typename F, typename ...Types>
+    void forward(F f, Types &&...args) {
+    f(static_cast<Types&&>(args)...);
+    }
+    \endcode
+  *>
+  CURSOR_PACK_EXPANSION_EXPR = 142,
+
+  <*
+    Represents an expression that computes the length of a parameter
+    pack.
+    \code
+    template<typename ...Types>
+    struct count {
+    static const unsigned value = sizeof...(Types);
+    };
+    \endcode
+  *>
+  CURSOR_SIZE_OF_PACK_EXPR = 143,
+  CURSOR_LAMBDA_EXPR = 144,
+
+  <*
+    Objective-c Boolean Literal.
+  *>
+  CURSOR_OBJ_C_BOOL_LITERAL_EXPR = 145,
+
+  <*
+    Represents the "self" expression in an Objective-C method.
+  *>
+  CURSOR_OBJ_C_SELF_EXPR = 146,
+
+  <*
+    OpenMP 5.0 [2.1.5, Array Section].
+    OpenACC 3.3 [2.7.1, Data Specification for Data Clauses (Sub Arrays)]
+  *>
+  CURSOR_ARRAY_SECTION_EXPR = 147,
+
+  <*
+    Represents an @available(...) check.
+  *>
+  CURSOR_OBJ_C_AVAILABILITY_CHECK_EXPR = 148,
+
+  <*
+    Fixed point literal
+  *>
+  CURSOR_FIXED_POINT_LITERAL = 149,
+
+  <*
+    OpenMP 5.0 [2.1.4, Array Shaping].
+  *>
+  CURSOR_OMP_ARRAY_SHAPING_EXPR = 150,
+
+  <*
+    OpenMP 5.0 [2.1.6 Iterators]
+  *>
+  CURSOR_OMP_ITERATOR_EXPR = 151,
+
+  <*
+    OpenCL's addrspace_cast<> expression.
+  *>
+  CURSOR_CXX_ADDRSPACE_CAST_EXPR = 152,
+
+  <*
+    Expression that references a C++20 concept.
+  *>
+  CURSOR_CONCEPT_SPECIALIZATION_EXPR = 153,
+
+  <*
+    Expression that references a C++20 requires expression.
+  *>
+  CURSOR_REQUIRES_EXPR = 154,
+
+  <*
+    Expression that references a C++20 parenthesized list aggregate
+    initializer.
+  *>
+  CURSOR_CXX_PAREN_LIST_INIT_EXPR = 155,
+
+  <*
+    Represents a C++26 pack indexing expression.
+  *>
+  CURSOR_PACK_INDEXING_EXPR = 156,
+
+  <*
+    Represents a C++26 pack indexing expression.
+  *>
+  CURSOR_LAST_EXPR = 156,
+
+  <*
+    Represents a C++26 pack indexing expression.
+  *>
+  CURSOR_FIRST_STMT = 200,
+
+  <*
+    A statement whose specific kind is not exposed via this
+    interface.
+    Unexposed statements have the same operations as any other kind of
+    statement; one can extract their location information, spelling,
+    children, etc. However, the specific kind of the statement is not
+    reported.
+  *>
+  CURSOR_UNEXPOSED_STMT = 200,
+
+  <*
+    A labelled statement in a function.
+    This cursor kind is used to describe the "start_over:" label statement in
+    the following example:
+    \code
+    start_over:
+    ++counter;
+    \endcode
+  *>
+  CURSOR_LABEL_STMT = 201,
+
+  <*
+    A group of statements like { stmt stmt }.
+    This cursor kind is used to describe compound statements, e.g. function
+    bodies.
+  *>
+  CURSOR_COMPOUND_STMT = 202,
+
+  <*
+    A case statement.
+  *>
+  CURSOR_CASE_STMT = 203,
+
+  <*
+    A default statement.
+  *>
+  CURSOR_DEFAULT_STMT = 204,
+
+  <*
+    An if statement
+  *>
+  CURSOR_IF_STMT = 205,
+
+  <*
+    A switch statement.
+  *>
+  CURSOR_SWITCH_STMT = 206,
+
+  <*
+    A while statement.
+  *>
+  CURSOR_WHILE_STMT = 207,
+
+  <*
+    A do statement.
+  *>
+  CURSOR_DO_STMT = 208,
+
+  <*
+    A for statement.
+  *>
+  CURSOR_FOR_STMT = 209,
+
+  <*
+    A goto statement.
+  *>
+  CURSOR_GOTO_STMT = 210,
+
+  <*
+    An indirect goto statement.
+  *>
+  CURSOR_INDIRECT_GOTO_STMT = 211,
+
+  <*
+    A continue statement.
+  *>
+  CURSOR_CONTINUE_STMT = 212,
+
+  <*
+    A break statement.
+  *>
+  CURSOR_BREAK_STMT = 213,
+
+  <*
+    A return statement.
+  *>
+  CURSOR_RETURN_STMT = 214,
+
+  <*
+    A GCC inline assembly statement extension.
+  *>
+  CURSOR_GCC_ASM_STMT = 215,
+
+  <*
+    A GCC inline assembly statement extension.
+  *>
+  CURSOR_ASM_STMT = 215,
+
+  <*
+    Objective-C's overall \@try-\@catch-\@finally statement.
+  *>
+  CURSOR_OBJ_C_AT_TRY_STMT = 216,
+
+  <*
+    Objective-C's \@catch statement.
+  *>
+  CURSOR_OBJ_C_AT_CATCH_STMT = 217,
+
+  <*
+    Objective-C's \@finally statement.
+  *>
+  CURSOR_OBJ_C_AT_FINALLY_STMT = 218,
+
+  <*
+    Objective-C's \@throw statement.
+  *>
+  CURSOR_OBJ_C_AT_THROW_STMT = 219,
+
+  <*
+    Objective-C's \@synchronized statement.
+  *>
+  CURSOR_OBJ_C_AT_SYNCHRONIZED_STMT = 220,
+
+  <*
+    Objective-C's autorelease pool statement.
+  *>
+  CURSOR_OBJ_C_AUTORELEASE_POOL_STMT = 221,
+
+  <*
+    Objective-C's collection statement.
+  *>
+  CURSOR_OBJ_C_FOR_COLLECTION_STMT = 222,
+
+  <*
+    C++'s catch statement.
+  *>
+  CURSOR_CXX_CATCH_STMT = 223,
+
+  <*
+    C++'s try statement.
+  *>
+  CURSOR_CXX_TRY_STMT = 224,
+
+  <*
+    C++'s for (* : *) statement.
+  *>
+  CURSOR_CXX_FOR_RANGE_STMT = 225,
+
+  <*
+    Windows Structured Exception Handling's try statement.
+  *>
+  CURSOR_SEH_TRY_STMT = 226,
+
+  <*
+    Windows Structured Exception Handling's except statement.
+  *>
+  CURSOR_SEH_EXCEPT_STMT = 227,
+
+  <*
+    Windows Structured Exception Handling's finally statement.
+  *>
+  CURSOR_SEH_FINALLY_STMT = 228,
+
+  <*
+    A MS inline assembly statement extension.
+  *>
+  CURSOR_MS_ASM_STMT = 229,
+
+  <*
+    The null statement ";": C99 6.8.3p3.
+    This cursor kind is used to describe the null statement.
+  *>
+  CURSOR_NULL_STMT = 230,
+
+  <*
+    Adaptor class for mixing declarations with statements and
+    expressions.
+  *>
+  CURSOR_DECL_STMT = 231,
+
+  <*
+    OpenMP parallel directive.
+  *>
+  CURSOR_OMP_PARALLEL_DIRECTIVE = 232,
+
+  <*
+    OpenMP SIMD directive.
+  *>
+  CURSOR_OMP_SIMD_DIRECTIVE = 233,
+
+  <*
+    OpenMP for directive.
+  *>
+  CURSOR_OMP_FOR_DIRECTIVE = 234,
+
+  <*
+    OpenMP sections directive.
+  *>
+  CURSOR_OMP_SECTIONS_DIRECTIVE = 235,
+
+  <*
+    OpenMP section directive.
+  *>
+  CURSOR_OMP_SECTION_DIRECTIVE = 236,
+
+  <*
+    OpenMP single directive.
+  *>
+  CURSOR_OMP_SINGLE_DIRECTIVE = 237,
+
+  <*
+    OpenMP parallel for directive.
+  *>
+  CURSOR_OMP_PARALLEL_FOR_DIRECTIVE = 238,
+
+  <*
+    OpenMP parallel sections directive.
+  *>
+  CURSOR_OMP_PARALLEL_SECTIONS_DIRECTIVE = 239,
+
+  <*
+    OpenMP task directive.
+  *>
+  CURSOR_OMP_TASK_DIRECTIVE = 240,
+
+  <*
+    OpenMP master directive.
+  *>
+  CURSOR_OMP_MASTER_DIRECTIVE = 241,
+
+  <*
+    OpenMP critical directive.
+  *>
+  CURSOR_OMP_CRITICAL_DIRECTIVE = 242,
+
+  <*
+    OpenMP taskyield directive.
+  *>
+  CURSOR_OMP_TASKYIELD_DIRECTIVE = 243,
+
+  <*
+    OpenMP barrier directive.
+  *>
+  CURSOR_OMP_BARRIER_DIRECTIVE = 244,
+
+  <*
+    OpenMP taskwait directive.
+  *>
+  CURSOR_OMP_TASKWAIT_DIRECTIVE = 245,
+
+  <*
+    OpenMP flush directive.
+  *>
+  CURSOR_OMP_FLUSH_DIRECTIVE = 246,
+
+  <*
+    Windows Structured Exception Handling's leave statement.
+  *>
+  CURSOR_SEH_LEAVE_STMT = 247,
+
+  <*
+    OpenMP ordered directive.
+  *>
+  CURSOR_OMP_ORDERED_DIRECTIVE = 248,
+
+  <*
+    OpenMP atomic directive.
+  *>
+  CURSOR_OMP_ATOMIC_DIRECTIVE = 249,
+
+  <*
+    OpenMP for SIMD directive.
+  *>
+  CURSOR_OMP_FOR_SIMD_DIRECTIVE = 250,
+
+  <*
+    OpenMP parallel for SIMD directive.
+  *>
+  CURSOR_OMP_PARALLEL_FOR_SIMD_DIRECTIVE = 251,
+
+  <*
+    OpenMP target directive.
+  *>
+  CURSOR_OMP_TARGET_DIRECTIVE = 252,
+
+  <*
+    OpenMP teams directive.
+  *>
+  CURSOR_OMP_TEAMS_DIRECTIVE = 253,
+
+  <*
+    OpenMP taskgroup directive.
+  *>
+  CURSOR_OMP_TASKGROUP_DIRECTIVE = 254,
+
+  <*
+    OpenMP cancellation point directive.
+  *>
+  CURSOR_OMP_CANCELLATION_POINT_DIRECTIVE = 255,
+
+  <*
+    OpenMP cancel directive.
+  *>
+  CURSOR_OMP_CANCEL_DIRECTIVE = 256,
+
+  <*
+    OpenMP target data directive.
+  *>
+  CURSOR_OMP_TARGET_DATA_DIRECTIVE = 257,
+
+  <*
+    OpenMP taskloop directive.
+  *>
+  CURSOR_OMP_TASK_LOOP_DIRECTIVE = 258,
+
+  <*
+    OpenMP taskloop simd directive.
+  *>
+  CURSOR_OMP_TASK_LOOP_SIMD_DIRECTIVE = 259,
+
+  <*
+    OpenMP distribute directive.
+  *>
+  CURSOR_OMP_DISTRIBUTE_DIRECTIVE = 260,
+
+  <*
+    OpenMP target enter data directive.
+  *>
+  CURSOR_OMP_TARGET_ENTER_DATA_DIRECTIVE = 261,
+
+  <*
+    OpenMP target exit data directive.
+  *>
+  CURSOR_OMP_TARGET_EXIT_DATA_DIRECTIVE = 262,
+
+  <*
+    OpenMP target parallel directive.
+  *>
+  CURSOR_OMP_TARGET_PARALLEL_DIRECTIVE = 263,
+
+  <*
+    OpenMP target parallel for directive.
+  *>
+  CURSOR_OMP_TARGET_PARALLEL_FOR_DIRECTIVE = 264,
+
+  <*
+    OpenMP target update directive.
+  *>
+  CURSOR_OMP_TARGET_UPDATE_DIRECTIVE = 265,
+
+  <*
+    OpenMP distribute parallel for directive.
+  *>
+  CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 266,
+
+  <*
+    OpenMP distribute parallel for simd directive.
+  *>
+  CURSOR_OMP_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 267,
+
+  <*
+    OpenMP distribute simd directive.
+  *>
+  CURSOR_OMP_DISTRIBUTE_SIMD_DIRECTIVE = 268,
+
+  <*
+    OpenMP target parallel for simd directive.
+  *>
+  CURSOR_OMP_TARGET_PARALLEL_FOR_SIMD_DIRECTIVE = 269,
+
+  <*
+    OpenMP target simd directive.
+  *>
+  CURSOR_OMP_TARGET_SIMD_DIRECTIVE = 270,
+
+  <*
+    OpenMP teams distribute directive.
+  *>
+  CURSOR_OMP_TEAMS_DISTRIBUTE_DIRECTIVE = 271,
+
+  <*
+    OpenMP teams distribute simd directive.
+  *>
+  CURSOR_OMP_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 272,
+
+  <*
+    OpenMP teams distribute parallel for simd directive.
+  *>
+  CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 273,
+
+  <*
+    OpenMP teams distribute parallel for directive.
+  *>
+  CURSOR_OMP_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 274,
+
+  <*
+    OpenMP target teams directive.
+  *>
+  CURSOR_OMP_TARGET_TEAMS_DIRECTIVE = 275,
+
+  <*
+    OpenMP target teams distribute directive.
+  *>
+  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_DIRECTIVE = 276,
+
+  <*
+    OpenMP target teams distribute parallel for directive.
+  *>
+  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_DIRECTIVE = 277,
+
+  <*
+    OpenMP target teams distribute parallel for simd directive.
+  *>
+  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_PARALLEL_FOR_SIMD_DIRECTIVE = 278,
+
+  <*
+    OpenMP target teams distribute simd directive.
+  *>
+  CURSOR_OMP_TARGET_TEAMS_DISTRIBUTE_SIMD_DIRECTIVE = 279,
+
+  <*
+    C++2a std::bit_cast expression.
+  *>
+  CURSOR_BUILTIN_BIT_CAST_EXPR = 280,
+
+  <*
+    OpenMP master taskloop directive.
+  *>
+  CURSOR_OMP_MASTER_TASK_LOOP_DIRECTIVE = 281,
+
+  <*
+    OpenMP parallel master taskloop directive.
+  *>
+  CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_DIRECTIVE = 282,
+
+  <*
+    OpenMP master taskloop simd directive.
+  *>
+  CURSOR_OMP_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 283,
+
+  <*
+    OpenMP parallel master taskloop simd directive.
+  *>
+  CURSOR_OMP_PARALLEL_MASTER_TASK_LOOP_SIMD_DIRECTIVE = 284,
+
+  <*
+    OpenMP parallel master directive.
+  *>
+  CURSOR_OMP_PARALLEL_MASTER_DIRECTIVE = 285,
+
+  <*
+    OpenMP depobj directive.
+  *>
+  CURSOR_OMP_DEPOBJ_DIRECTIVE = 286,
+
+  <*
+    OpenMP scan directive.
+  *>
+  CURSOR_OMP_SCAN_DIRECTIVE = 287,
+
+  <*
+    OpenMP tile directive.
+  *>
+  CURSOR_OMP_TILE_DIRECTIVE = 288,
+
+  <*
+    OpenMP canonical loop.
+  *>
+  CURSOR_OMP_CANONICAL_LOOP = 289,
+
+  <*
+    OpenMP interop directive.
+  *>
+  CURSOR_OMP_INTEROP_DIRECTIVE = 290,
+
+  <*
+    OpenMP dispatch directive.
+  *>
+  CURSOR_OMP_DISPATCH_DIRECTIVE = 291,
+
+  <*
+    OpenMP masked directive.
+  *>
+  CURSOR_OMP_MASKED_DIRECTIVE = 292,
+
+  <*
+    OpenMP unroll directive.
+  *>
+  CURSOR_OMP_UNROLL_DIRECTIVE = 293,
+
+  <*
+    OpenMP metadirective directive.
+  *>
+  CURSOR_OMP_META_DIRECTIVE = 294,
+
+  <*
+    OpenMP loop directive.
+  *>
+  CURSOR_OMP_GENERIC_LOOP_DIRECTIVE = 295,
+
+  <*
+    OpenMP teams loop directive.
+  *>
+  CURSOR_OMP_TEAMS_GENERIC_LOOP_DIRECTIVE = 296,
+
+  <*
+    OpenMP target teams loop directive.
+  *>
+  CURSOR_OMP_TARGET_TEAMS_GENERIC_LOOP_DIRECTIVE = 297,
+
+  <*
+    OpenMP parallel loop directive.
+  *>
+  CURSOR_OMP_PARALLEL_GENERIC_LOOP_DIRECTIVE = 298,
+
+  <*
+    OpenMP target parallel loop directive.
+  *>
+  CURSOR_OMP_TARGET_PARALLEL_GENERIC_LOOP_DIRECTIVE = 299,
+
+  <*
+    OpenMP parallel masked directive.
+  *>
+  CURSOR_OMP_PARALLEL_MASKED_DIRECTIVE = 300,
+
+  <*
+    OpenMP masked taskloop directive.
+  *>
+  CURSOR_OMP_MASKED_TASK_LOOP_DIRECTIVE = 301,
+
+  <*
+    OpenMP masked taskloop simd directive.
+  *>
+  CURSOR_OMP_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 302,
+
+  <*
+    OpenMP parallel masked taskloop directive.
+  *>
+  CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_DIRECTIVE = 303,
+
+  <*
+    OpenMP parallel masked taskloop simd directive.
+  *>
+  CURSOR_OMP_PARALLEL_MASKED_TASK_LOOP_SIMD_DIRECTIVE = 304,
+
+  <*
+    OpenMP error directive.
+  *>
+  CURSOR_OMP_ERROR_DIRECTIVE = 305,
+
+  <*
+    OpenMP scope directive.
+  *>
+  CURSOR_OMP_SCOPE_DIRECTIVE = 306,
+
+  <*
+    OpenMP reverse directive.
+  *>
+  CURSOR_OMP_REVERSE_DIRECTIVE = 307,
+
+  <*
+    OpenMP interchange directive.
+  *>
+  CURSOR_OMP_INTERCHANGE_DIRECTIVE = 308,
+
+  <*
+    OpenMP assume directive.
+  *>
+  CURSOR_OMP_ASSUME_DIRECTIVE = 309,
+
+  <*
+    OpenMP assume directive.
+  *>
+  CURSOR_OMP_STRIPE_DIRECTIVE = 310,
+
+  <*
+    OpenMP fuse directive
+  *>
+  CURSOR_OMP_FUSE_DIRECTIVE = 311,
+
+  <*
+    OpenACC Compute Construct.
+  *>
+  CURSOR_OPEN_ACC_COMPUTE_CONSTRUCT = 320,
+
+  <*
+    OpenACC Loop Construct.
+  *>
+  CURSOR_OPEN_ACC_LOOP_CONSTRUCT = 321,
+
+  <*
+    OpenACC Combined Constructs.
+  *>
+  CURSOR_OPEN_ACC_COMBINED_CONSTRUCT = 322,
+
+  <*
+    OpenACC data Construct.
+  *>
+  CURSOR_OPEN_ACC_DATA_CONSTRUCT = 323,
+
+  <*
+    OpenACC enter data Construct.
+  *>
+  CURSOR_OPEN_ACC_ENTER_DATA_CONSTRUCT = 324,
+
+  <*
+    OpenACC exit data Construct.
+  *>
+  CURSOR_OPEN_ACC_EXIT_DATA_CONSTRUCT = 325,
+
+  <*
+    OpenACC host_data Construct.
+  *>
+  CURSOR_OPEN_ACC_HOST_DATA_CONSTRUCT = 326,
+
+  <*
+    OpenACC wait Construct.
+  *>
+  CURSOR_OPEN_ACC_WAIT_CONSTRUCT = 327,
+
+  <*
+    OpenACC init Construct.
+  *>
+  CURSOR_OPEN_ACC_INIT_CONSTRUCT = 328,
+
+  <*
+    OpenACC shutdown Construct.
+  *>
+  CURSOR_OPEN_ACC_SHUTDOWN_CONSTRUCT = 329,
+
+  <*
+    OpenACC set Construct.
+  *>
+  CURSOR_OPEN_ACC_SET_CONSTRUCT = 330,
+
+  <*
+    OpenACC update Construct.
+  *>
+  CURSOR_OPEN_ACC_UPDATE_CONSTRUCT = 331,
+
+  <*
+    OpenACC atomic Construct.
+  *>
+  CURSOR_OPEN_ACC_ATOMIC_CONSTRUCT = 332,
+
+  <*
+    OpenACC cache Construct.
+  *>
+  CURSOR_OPEN_ACC_CACHE_CONSTRUCT = 333,
+
+  <*
+    OpenACC cache Construct.
+  *>
+  CURSOR_LAST_STMT = 333,
+
+  <*
+    Cursor that represents the translation unit itself.
+    The translation unit cursor exists primarily to act as the root
+    cursor for traversing the contents of a translation unit.
+  *>
+  CURSOR_TRANSLATION_UNIT = 350,
+
+  <*
+    Cursor that represents the translation unit itself.
+    The translation unit cursor exists primarily to act as the root
+    cursor for traversing the contents of a translation unit.
+  *>
+  CURSOR_FIRST_ATTR = 400,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_UNEXPOSED_ATTR = 400,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_IB_ACTION_ATTR = 401,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_IB_OUTLET_ATTR = 402,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_IB_OUTLET_COLLECTION_ATTR = 403,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_CXX_FINAL_ATTR = 404,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_CXX_OVERRIDE_ATTR = 405,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_ANNOTATE_ATTR = 406,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_ASM_LABEL_ATTR = 407,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_PACKED_ATTR = 408,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_PURE_ATTR = 409,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_CONST_ATTR = 410,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_NO_DUPLICATE_ATTR = 411,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_CUDA_CONSTANT_ATTR = 412,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_CUDA_DEVICE_ATTR = 413,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_CUDA_GLOBAL_ATTR = 414,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_CUDA_HOST_ATTR = 415,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_CUDA_SHARED_ATTR = 416,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_VISIBILITY_ATTR = 417,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_DLL_EXPORT = 418,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_DLL_IMPORT = 419,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_NS_RETURNS_RETAINED = 420,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_NS_RETURNS_NOT_RETAINED = 421,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_NS_RETURNS_AUTORELEASED = 422,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_NS_CONSUMES_SELF = 423,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_NS_CONSUMED = 424,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_EXCEPTION = 425,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_CNS_OBJECT = 426,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_INDEPENDENT_CLASS = 427,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_PRECISE_LIFETIME = 428,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_RETURNS_INNER_POINTER = 429,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_REQUIRES_SUPER = 430,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_ROOT_CLASS = 431,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_SUBCLASSING_RESTRICTED = 432,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_EXPLICIT_PROTOCOL_IMPL = 433,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_DESIGNATED_INITIALIZER = 434,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_RUNTIME_VISIBLE = 435,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_OBJ_C_BOXABLE = 436,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_FLAG_ENUM = 437,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_CONVERGENT_ATTR = 438,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_WARN_UNUSED_ATTR = 439,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_WARN_UNUSED_RESULT_ATTR = 440,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_ALIGNED_ATTR = 441,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_LAST_ATTR = 441,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_PREPROCESSING_DIRECTIVE = 500,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_MACRO_DEFINITION = 501,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_MACRO_EXPANSION = 502,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_MACRO_INSTANTIATION = 502,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_INCLUSION_DIRECTIVE = 503,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_FIRST_PREPROCESSING = 500,
+
+  <*
+    An attribute whose specific kind is not exposed via this
+    interface.
+  *>
+  CURSOR_LAST_PREPROCESSING = 503,
+
+  <*
+    A module import declaration.
+  *>
+  CURSOR_MODULE_IMPORT_DECL = 600,
+
+  <*
+    A module import declaration.
+  *>
+  CURSOR_TYPE_ALIAS_TEMPLATE_DECL = 601,
+
+  <*
+    A static_assert or _Static_assert node
+  *>
+  CURSOR_STATIC_ASSERT = 602,
+
+  <*
+    a friend declaration.
+  *>
+  CURSOR_FRIEND_DECL = 603,
+
+  <*
+    a concept declaration.
+  *>
+  CURSOR_CONCEPT_DECL = 604,
+
+  <*
+    a concept declaration.
+  *>
+  CURSOR_FIRST_EXTRA_DECL = 600,
+
+  <*
+    a concept declaration.
+  *>
+  CURSOR_LAST_EXTRA_DECL = 604,
+
+  <*
+    A code completion overload candidate.
+  *>
+  CURSOR_OVERLOAD_CANDIDATE = 700
+}
+
+<*
+  A cursor representing some element in the abstract syntax tree for
+  a translation unit.
+  The cursor abstraction unifies the different kinds of entities in a
+  program--declaration, statements, expressions, references to declarations,
+  etc.--under a single "cursor" abstraction with a common set of operations.
+  Common operation for a cursor include: getting the physical location in
+  a source file where the cursor points, getting the name associated with a
+  cursor, and retrieving cursors for any child nodes of a particular cursor.
+  Cursors can be produced in two specific ways.
+  clang_getTranslationUnitCursor() produces a cursor for a translation unit,
+  from which one can use clang_visitChildren() to explore the rest of the
+  translation unit. clang_getCursor() maps from a physical source location
+  to the entity that resides at that location, allowing one to map from the
+  source code into the AST.
+*>
 struct CXCursor {
   CXCursorKind kind;
   CInt xdata;
   void*[3] data;
 }
 
-/**
- * Retrieve the NULL cursor, which represents no entity.
- */
-fn CXCursor getNullCursor() 
-@extern("clang_getNullCursor");
+<*
+  Retrieve the NULL cursor, which represents no entity.
+*>
+extern fn CXCursor getNullCursor()
+@cname("clang_getNullCursor");
 
-/**
- * Retrieve the cursor that represents the given translation unit.
- *
- * The translation unit cursor can be used to start traversing the
- * various declarations within the given translation unit.
- */
-fn CXCursor getTranslationUnitCursor(
-  CXTranslationUnit tu) 
-@extern("clang_getTranslationUnitCursor");
+<*
+  Retrieve the cursor that represents the given translation unit.
+  The translation unit cursor can be used to start traversing the
+  various declarations within the given translation unit.
+*>
+extern fn CXCursor getTranslationUnitCursor(
+  CXTranslationUnit)
+@cname("clang_getTranslationUnitCursor");
 
-/**
- * Determine whether two cursors are equivalent.
- */
-fn CUInt equalCursors(
-  CXCursor cursor1, 
-  CXCursor cursor2) 
-@extern("clang_equalCursors");
+<*
+  Determine whether two cursors are equivalent.
+*>
+extern fn CUInt equalCursors(
+  CXCursor,
+  CXCursor)
+@cname("clang_equalCursors");
 
-/**
- * Returns non-zero if \p cursor is null.
- */
-fn CInt isNull_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_isNull");
+<*
+  Returns non-zero if \p cursor is null.
+*>
+extern fn CInt cursor_isNull(
+  CXCursor cursor)
+@cname("clang_Cursor_isNull");
 
-/**
- * Compute a hash value for the given cursor.
- */
-fn CUInt hashCursor(
-  CXCursor cursor) 
-@extern("clang_hashCursor");
+<*
+  Compute a hash value for the given cursor.
+*>
+extern fn CUInt hashCursor(
+  CXCursor)
+@cname("clang_hashCursor");
 
-/**
- * Retrieve the kind of the given cursor.
- */
-fn CXCursorKind getCursorKind(
-  CXCursor cursor) 
-@extern("clang_getCursorKind");
+<*
+  Retrieve the kind of the given cursor.
+*>
+extern fn CXCursorKind getCursorKind(
+  CXCursor)
+@cname("clang_getCursorKind");
 
-/**
- * Determine whether the given cursor kind represents a declaration.
- */
-fn CUInt isDeclaration(
-  CXCursorKind cursor_kind) 
-@extern("clang_isDeclaration");
+<*
+  Determine whether the given cursor kind represents a declaration.
+*>
+extern fn CUInt isDeclaration(
+  CXCursorKind)
+@cname("clang_isDeclaration");
 
-/**
- * Determine whether the given declaration is invalid.
- *
- * A declaration is invalid if it could not be parsed successfully.
- *
- * \returns non-zero if the cursor represents a declaration and it is
- * invalid, otherwise NULL.
- */
-fn CUInt isInvalidDeclaration(
-  CXCursor cursor) 
-@extern("clang_isInvalidDeclaration");
+<*
+  Determine whether the given declaration is invalid.
+  A declaration is invalid if it could not be parsed successfully.
+  \returns non-zero if the cursor represents a declaration and it is
+  invalid, otherwise NULL.
+*>
+extern fn CUInt isInvalidDeclaration(
+  CXCursor)
+@cname("clang_isInvalidDeclaration");
 
-/**
- * Determine whether the given cursor kind represents a simple
- * reference.
- *
- * Note that other kinds of cursors (such as expressions) can also refer to
- * other cursors. Use clang_getCursorReferenced() to determine whether a
- * particular cursor refers to another entity.
- */
-fn CUInt isReference(
-  CXCursorKind kind) 
-@extern("clang_isReference");
+<*
+  Determine whether the given cursor kind represents a simple
+  reference.
+  Note that other kinds of cursors (such as expressions) can also refer to
+  other cursors. Use clang_getCursorReferenced() to determine whether a
+  particular cursor refers to another entity.
+*>
+extern fn CUInt isReference(
+  CXCursorKind)
+@cname("clang_isReference");
 
-/**
- * Determine whether the given cursor kind represents an expression.
- */
-fn CUInt isExpression(
-  CXCursorKind kind) 
-@extern("clang_isExpression");
+<*
+  Determine whether the given cursor kind represents an expression.
+*>
+extern fn CUInt isExpression(
+  CXCursorKind)
+@cname("clang_isExpression");
 
-/**
- * Determine whether the given cursor kind represents a statement.
- */
-fn CUInt isStatement(
-  CXCursorKind kind) 
-@extern("clang_isStatement");
+<*
+  Determine whether the given cursor kind represents a statement.
+*>
+extern fn CUInt isStatement(
+  CXCursorKind)
+@cname("clang_isStatement");
 
-/**
- * Determine whether the given cursor kind represents an attribute.
- */
-fn CUInt isAttribute(
-  CXCursorKind kind) 
-@extern("clang_isAttribute");
+<*
+  Determine whether the given cursor kind represents an attribute.
+*>
+extern fn CUInt isAttribute(
+  CXCursorKind)
+@cname("clang_isAttribute");
 
-/**
- * Determine whether the given cursor has any attributes.
- */
-fn CUInt hasAttrs_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_hasAttrs");
+<*
+  Determine whether the given cursor has any attributes.
+*>
+extern fn CUInt cursor_hasAttrs(
+  CXCursor c)
+@cname("clang_Cursor_hasAttrs");
 
-/**
- * Determine whether the given cursor kind represents an invalid
- * cursor.
- */
-fn CUInt isInvalid(
-  CXCursorKind kind) 
-@extern("clang_isInvalid");
+<*
+  Determine whether the given cursor kind represents an invalid
+  cursor.
+*>
+extern fn CUInt isInvalid(
+  CXCursorKind)
+@cname("clang_isInvalid");
 
-/**
- * Determine whether the given cursor kind represents a translation
- * unit.
- */
-fn CUInt isTranslationUnit(
-  CXCursorKind kind) 
-@extern("clang_isTranslationUnit");
+<*
+  Determine whether the given cursor kind represents a translation
+  unit.
+*>
+extern fn CUInt isTranslationUnit(
+  CXCursorKind)
+@cname("clang_isTranslationUnit");
 
-/***
- * Determine whether the given cursor represents a preprocessing
- * element, such as a preprocessor directive or macro instantiation.
- */
-fn CUInt isPreprocessing(
-  CXCursorKind kind) 
-@extern("clang_isPreprocessing");
+<*
+  Determine whether the given cursor represents a preprocessing
+  element, such as a preprocessor directive or macro instantiation.
+*>
+extern fn CUInt isPreprocessing(
+  CXCursorKind)
+@cname("clang_isPreprocessing");
 
-/***
- * Determine whether the given cursor represents a currently
- *  unexposed piece of the AST (e.g., CXCursor_UnexposedStmt).
- */
-fn CUInt isUnexposed(
-  CXCursorKind kind) 
-@extern("clang_isUnexposed");
+<*
+  Determine whether the given cursor represents a currently
+  unexposed piece of the AST (e.g., CXCursor_UnexposedStmt).
+*>
+extern fn CUInt isUnexposed(
+  CXCursorKind)
+@cname("clang_isUnexposed");
 
-/**
- * Describe the linkage of the entity referred to by a cursor.
- */
-typedef CXLinkageKind = inline CInt;
+<*
+  Describe the linkage of the entity referred to by a cursor.
+*>
+constdef CXLinkageKind : CInt {
 
-/** This value indicates that no linkage information is available
- * for a provided CXCursor. 
- */
-const CXLinkageKind LINKAGE_INVALID = 0;
-/**
- * This is the linkage for variables, parameters, and so on that
- *  have automatic storage.  This covers normal (non-extern) local variables.
- */
-const CXLinkageKind LINKAGE_NO_LINKAGE = 1;
-/** This is the linkage for static variables and static functions. 
- */
-const CXLinkageKind LINKAGE_INTERNAL = 2;
-/** This is the linkage for entities with external linkage that live
- * in C++ anonymous namespaces.
- */
-const CXLinkageKind LINKAGE_UNIQUE_EXTERNAL = 3;
-/** This is the linkage for entities with true, external linkage. 
- */
-const CXLinkageKind LINKAGE_EXTERNAL = 4;
+  <*
+    This value indicates that no linkage information is available
+    for a provided CXCursor. *
+  *>
+  LINKAGE_INVALID = 0,
 
-/**
- * Determine the linkage of the entity referred to by a given cursor.
- */
-fn CXLinkageKind getCursorLinkage(
-  CXCursor cursor) 
-@extern("clang_getCursorLinkage");
+  <*
+    This is the linkage for variables, parameters, and so on that
+    have automatic storage.  This covers normal (non-extern) local variables.
+  *>
+  LINKAGE_NO_LINKAGE = 1,
 
-typedef CXVisibilityKind = inline CInt;
+  <*
+    This is the linkage for static variables and static functions. *
+  *>
+  LINKAGE_INTERNAL = 2,
 
-/** This value indicates that no visibility information is available
- * for a provided CXCursor. 
- */
-const CXVisibilityKind VISIBILITY_INVALID = 0;
-/** Symbol not seen by the linker. 
- */
-const CXVisibilityKind VISIBILITY_HIDDEN = 1;
-/** Symbol seen by the linker but resolves to a symbol inside this object. 
- */
-const CXVisibilityKind VISIBILITY_PROTECTED = 2;
-/** Symbol seen by the linker and acts like a normal symbol. 
- */
-const CXVisibilityKind VISIBILITY_DEFAULT = 3;
+  <*
+    This is the linkage for entities with external linkage that live
+    in C++ anonymous namespaces.*
+  *>
+  LINKAGE_UNIQUE_EXTERNAL = 3,
 
-/**
- * Describe the visibility of the entity referred to by a cursor.
- *
- * This returns the default visibility if not explicitly specified by
- * a visibility attribute. The default visibility may be changed by
- * commandline arguments.
- *
- * \param cursor The cursor to query.
- *
- * \returns The visibility of the cursor.
- */
-fn CXVisibilityKind getCursorVisibility(
-  CXCursor cursor) 
-@extern("clang_getCursorVisibility");
+  <*
+    This is the linkage for entities with true, external linkage. *
+  *>
+  LINKAGE_EXTERNAL = 4
+}
 
-/**
- * Determine the availability of the entity that this cursor refers to,
- * taking the current target platform into account.
- *
- * \param cursor The cursor to query.
- *
- * \returns The availability of the cursor.
- */
-fn CXAvailabilityKind getCursorAvailability(
-  CXCursor cursor) 
-@extern("clang_getCursorAvailability");
+<*
+  Determine the linkage of the entity referred to by a given cursor.
+*>
+extern fn CXLinkageKind getCursorLinkage(
+  CXCursor cursor)
+@cname("clang_getCursorLinkage");
 
-/**
- * Describes the availability of a given entity on a particular platform, e.g.,
- * a particular class might only be available on Mac OS 10.7 or newer.
- */
+constdef CXVisibilityKind : CInt {
+
+  <*
+    This value indicates that no visibility information is available
+    for a provided CXCursor. *
+  *>
+  VISIBILITY_INVALID = 0,
+
+  <*
+    Symbol not seen by the linker. *
+  *>
+  VISIBILITY_HIDDEN = 1,
+
+  <*
+    Symbol seen by the linker but resolves to a symbol inside this object. *
+  *>
+  VISIBILITY_PROTECTED = 2,
+
+  <*
+    Symbol seen by the linker and acts like a normal symbol. *
+  *>
+  VISIBILITY_DEFAULT = 3
+}
+
+<*
+  Describe the visibility of the entity referred to by a cursor.
+  This returns the default visibility if not explicitly specified by
+  a visibility attribute. The default visibility may be changed by
+  commandline arguments.
+  \param cursor The cursor to query.
+  \returns The visibility of the cursor.
+*>
+extern fn CXVisibilityKind getCursorVisibility(
+  CXCursor cursor)
+@cname("clang_getCursorVisibility");
+
+<*
+  Determine the availability of the entity that this cursor refers to,
+  taking the current target platform into account.
+  \param cursor The cursor to query.
+  \returns The availability of the cursor.
+*>
+extern fn CXAvailabilityKind getCursorAvailability(
+  CXCursor cursor)
+@cname("clang_getCursorAvailability");
+
+<*
+  Describes the availability of a given entity on a particular platform, e.g.,
+  a particular class might only be available on Mac OS 10.7 or newer.
+*>
 struct CXPlatformAvailability {
-  /*
-   * A string that describes the platform for which this structure
-   * provides availability information.
-   *
-   * Possible values are "ios" or "macos".
-   */
   CXString platform;
-  /*
-   * The version number in which this entity was introduced.
-   */
   CXVersion introduced;
-  /*
-   * The version number in which this entity was deprecated (but is
-   * still available).
-   */
   CXVersion deprecated;
-  /*
-   * The version number in which this entity was obsoleted, and therefore
-   * is no longer available.
-   */
   CXVersion obsoleted;
-  /*
-   * Whether the entity is unconditionally unavailable on this platform.
-   */
   CInt unavailable;
-  /*
-   * An optional message to provide to a user of this API, e.g., to
-   * suggest replacement APIs.
-   */
   CXString message;
 }
 
-/**
- * Determine the availability of the entity that this cursor refers to
- * on any platforms for which availability information is known.
- *
- * \param cursor The cursor to query.
- *
- * \param always_deprecated If non-NULL, will be set to indicate whether the
- * entity is deprecated on all platforms.
- *
- * \param deprecated_message If non-NULL, will be set to the message text
- * provided along with the unconditional deprecation of this entity. The client
- * is responsible for deallocating this string.
- *
- * \param always_unavailable If non-NULL, will be set to indicate whether the
- * entity is unavailable on all platforms.
- *
- * \param unavailable_message If non-NULL, will be set to the message text
- * provided along with the unconditional unavailability of this entity. The
- * client is responsible for deallocating this string.
- *
- * \param availability If non-NULL, an array of CXPlatformAvailability instances
- * that will be populated with platform availability information, up to either
- * the number of platforms for which availability information is available (as
- * returned by this function) or \c availability_size, whichever is smaller.
- *
- * \param availability_size The number of elements available in the
- * \c availability array.
- *
- * \returns The number of platforms (N) for which availability information is
- * available (which is unrelated to \c availability_size).
- *
- * Note that the client is responsible for calling
- * \c clang_disposeCXPlatformAvailability to free each of the
- * platform-availability structures returned. There are
- * \c min(N, availability_size) such structures.
- */
-fn CInt getCursorPlatformAvailability(
-  CXCursor cursor, 
-  CInt* always_deprecated, 
-  CXString* deprecated_message, 
-  CInt* always_unavailable, 
-  CXString* unavailable_message, 
-  CXPlatformAvailability* availability, 
-  CInt availability_size) 
-@extern("clang_getCursorPlatformAvailability");
+<*
+  Determine the availability of the entity that this cursor refers to
+  on any platforms for which availability information is known.
+  \param cursor The cursor to query.
+  \param always_deprecated If non-NULL, will be set to indicate whether the
+  entity is deprecated on all platforms.
+  \param deprecated_message If non-NULL, will be set to the message text
+  provided along with the unconditional deprecation of this entity. The client
+  is responsible for deallocating this string.
+  \param always_unavailable If non-NULL, will be set to indicate whether the
+  entity is unavailable on all platforms.
+  \param unavailable_message If non-NULL, will be set to the message text
+  provided along with the unconditional unavailability of this entity. The
+  client is responsible for deallocating this string.
+  \param availability If non-NULL, an array of CXPlatformAvailability instances
+  that will be populated with platform availability information, up to either
+  the number of platforms for which availability information is available (as
+  returned by this function) or \c availability_size, whichever is smaller.
+  \param availability_size The number of elements available in the
+  \c availability array.
+  \returns The number of platforms (N) for which availability information is
+  available (which is unrelated to \c availability_size).
+  Note that the client is responsible for calling
+  \c clang_disposeCXPlatformAvailability to free each of the
+  platform-availability structures returned. There are
+  \c min(N, availability_size) such structures.
+*>
+extern fn CInt getCursorPlatformAvailability(
+  CXCursor cursor,
+  CInt* always_deprecated,
+  CXString* deprecated_message,
+  CInt* always_unavailable,
+  CXString* unavailable_message,
+  CXPlatformAvailability* availability,
+  CInt availability_size)
+@cname("clang_getCursorPlatformAvailability");
 
-/**
- * Free the memory associated with a \c CXPlatformAvailability structure.
- */
-fn void disposeCXPlatformAvailability(
-  CXPlatformAvailability* availability) 
-@extern("clang_disposeCXPlatformAvailability");
+<*
+  Free the memory associated with a \c CXPlatformAvailability structure.
+*>
+extern fn void disposeCXPlatformAvailability(
+  CXPlatformAvailability* availability)
+@cname("clang_disposeCXPlatformAvailability");
 
-/**
- * If cursor refers to a variable declaration and it has initializer returns
- * cursor referring to the initializer otherwise return null cursor.
- */
-fn CXCursor getVarDeclInitializer_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_getVarDeclInitializer");
+<*
+  If cursor refers to a variable declaration and it has initializer returns
+  cursor referring to the initializer otherwise return null cursor.
+*>
+extern fn CXCursor cursor_getVarDeclInitializer(
+  CXCursor cursor)
+@cname("clang_Cursor_getVarDeclInitializer");
 
-/**
- * If cursor refers to a variable declaration that has global storage returns 1.
- * If cursor refers to a variable declaration that doesn't have global storage
- * returns 0. Otherwise returns -1.
- */
-fn CInt hasVarDeclGlobalStorage_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_hasVarDeclGlobalStorage");
+<*
+  If cursor refers to a variable declaration that has global storage returns 1.
+  If cursor refers to a variable declaration that doesn't have global storage
+  returns 0. Otherwise returns -1.
+*>
+extern fn CInt cursor_hasVarDeclGlobalStorage(
+  CXCursor cursor)
+@cname("clang_Cursor_hasVarDeclGlobalStorage");
 
-/**
- * If cursor refers to a variable declaration that has external storage
- * returns 1. If cursor refers to a variable declaration that doesn't have
- * external storage returns 0. Otherwise returns -1.
- */
-fn CInt hasVarDeclExternalStorage_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_hasVarDeclExternalStorage");
+<*
+  If cursor refers to a variable declaration that has external storage
+  returns 1. If cursor refers to a variable declaration that doesn't have
+  external storage returns 0. Otherwise returns -1.
+*>
+extern fn CInt cursor_hasVarDeclExternalStorage(
+  CXCursor cursor)
+@cname("clang_Cursor_hasVarDeclExternalStorage");
 
-/**
- * Describe the "language" of the entity referred to by a cursor.
- */
-typedef CXLanguageKind = inline CInt;
-const CXLinkageKind LANGUAGE_INVALID = 0;
-const CXLinkageKind LANGUAGE_C = 1;
-const CXLinkageKind LANGUAGE_OBJC = 2;
-const CXLinkageKind LANGUAGE_C_PLUS_PLUS = 3;
+<*
+  Describe the "language" of the entity referred to by a cursor.
+*>
+constdef CXLanguageKind : CInt {
+  LANGUAGE_INVALID = 0,
+  LANGUAGE_C = 1,
+  LANGUAGE_OBJ_C = 2,
+  LANGUAGE_C_PLUS_PLUS = 3
+}
 
-/**
- * Determine the "language" of the entity referred to by a given cursor.
- */
-fn CXLanguageKind getCursorLanguage(
-  CXCursor cursor) 
-@extern("clang_getCursorLanguage");
+<*
+  Determine the "language" of the entity referred to by a given cursor.
+*>
+extern fn CXLanguageKind getCursorLanguage(
+  CXCursor cursor)
+@cname("clang_getCursorLanguage");
 
-/**
- * Describe the "thread-local storage (TLS) kind" of the declaration
- * referred to by a cursor.
- */
-typedef CXTLSKind = inline CInt;
-const CXTLSKind TLS_NONE = 0;
-const CXTLSKind TLS_DYNAMIC = 1;
-const CXTLSKind TLS_STATIC = 2;
+<*
+  Describe the "thread-local storage (TLS) kind" of the declaration
+  referred to by a cursor.
+*>
+constdef CXTLSKind : CInt {
+  TLS_NONE = 0,
+  TLS_DYNAMIC = 1,
+  TLS_STATIC = 2
+}
 
-/**
- * Determine the "thread-local storage (TLS) kind" of the declaration
- * referred to by a cursor.
- */
-fn CXTLSKind getCursorTLSKind(
-  CXCursor cursor) 
-@extern("clang_getCursorTLSKind");
+<*
+  Determine the "thread-local storage (TLS) kind" of the declaration
+  referred to by a cursor.
+*>
+extern fn CXTLSKind getCursorTLSKind(
+  CXCursor cursor)
+@cname("clang_getCursorTLSKind");
 
-/**
- * Returns the translation unit that a cursor originated from.
- */
-fn CXTranslationUnit getTranslationUnit_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_getTranslationUnit");
+<*
+  Returns the translation unit that a cursor originated from.
+*>
+extern fn CXTranslationUnit cursor_getTranslationUnit(
+  CXCursor)
+@cname("clang_Cursor_getTranslationUnit");
 
-/**
- * A fast container representing a set of CXCursors.
- */
-typedef CXCursorSet = inline void*;
+alias CXCursorSet = void*;
 
-/**
- * Creates an empty CXCursorSet.
- */
-fn CXCursorSet createCXCursorSet() 
-@extern("clang_createCXCursorSet");
+<*
+  Creates an empty CXCursorSet.
+*>
+extern fn CXCursorSet createCXCursorSet()
+@cname("clang_createCXCursorSet");
 
-/**
- * Disposes a CXCursorSet and releases its associated memory.
- */
-fn void disposeCXCursorSet(
-  CXCursorSet cset) 
-@extern("clang_disposeCXCursorSet");
+<*
+  Disposes a CXCursorSet and releases its associated memory.
+*>
+extern fn void disposeCXCursorSet(
+  CXCursorSet cset)
+@cname("clang_disposeCXCursorSet");
 
-/**
- * Queries a CXCursorSet to see if it contains a specific CXCursor.
- *
- * \returns non-zero if the set contains the specified cursor.
- */
-fn CUInt contains_CursorSet(
-  CXCursorSet cset, 
-  CXCursor cursor) 
-@extern("clang_CXCursorSet_contains");
+<*
+  Queries a CXCursorSet to see if it contains a specific CXCursor.
+  \returns non-zero if the set contains the specified cursor.
+*>
+extern fn CUInt cXCursorSet_contains(
+  CXCursorSet cset,
+  CXCursor cursor)
+@cname("clang_CXCursorSet_contains");
 
-/**
- * Inserts a CXCursor into a CXCursorSet.
- *
- * \returns zero if the CXCursor was already in the set, and non-zero otherwise.
- */
-fn CUInt insert_CursorSet(
-  CXCursorSet cset, 
-  CXCursor cursor) 
-@extern("clang_CXCursorSet_insert");
+<*
+  Inserts a CXCursor into a CXCursorSet.
+  \returns zero if the CXCursor was already in the set, and non-zero otherwise.
+*>
+extern fn CUInt cXCursorSet_insert(
+  CXCursorSet cset,
+  CXCursor cursor)
+@cname("clang_CXCursorSet_insert");
 
-/**
- * Determine the semantic parent of the given cursor.
- *
- * The semantic parent of a cursor is the cursor that semantically contains
- * the given \p cursor. For many declarations, the lexical and semantic parents
- * are equivalent (the lexical parent is returned by
- * \c clang_getCursorLexicalParent()). They diverge when declarations or
- * definitions are provided out-of-line. For example:
- *
- * \code
- * class C {
- *  void f();
- * };
- *
- * void C::f() { }
- * \endcode
- *
- * In the out-of-line definition of \c C::f, the semantic parent is
- * the class \c C, of which this function is a member. The lexical parent is
- * the place where the declaration actually occurs in the source code; in this
- * case, the definition occurs in the translation unit. In general, the
- * lexical parent for a given entity can change without affecting the semantics
- * of the program, and the lexical parent of different declarations of the
- * same entity may be different. Changing the semantic parent of a declaration,
- * on the other hand, can have a major impact on semantics, and redeclarations
- * of a particular entity should all have the same semantic context.
- *
- * In the example above, both declarations of \c C::f have \c C as their
- * semantic context, while the lexical context of the first \c C::f is \c C
- * and the lexical context of the second \c C::f is the translation unit.
- *
- * For global declarations, the semantic parent is the translation unit.
- */
-fn CXCursor getCursorSemanticParent(
-  CXCursor cursor) 
-@extern("clang_getCursorSemanticParent");
+<*
+  Determine the semantic parent of the given cursor.
+  The semantic parent of a cursor is the cursor that semantically contains
+  the given \p cursor. For many declarations, the lexical and semantic parents
+  are equivalent (the lexical parent is returned by
+  \c clang_getCursorLexicalParent()). They diverge when declarations or
+  definitions are provided out-of-line. For example:
+  \code
+  class C {
+  void f();
+  };
+  void C::f() { }
+  \endcode
+  In the out-of-line definition of \c C::f, the semantic parent is
+  the class \c C, of which this function is a member. The lexical parent is
+  the place where the declaration actually occurs in the source code; in this
+  case, the definition occurs in the translation unit. In general, the
+  lexical parent for a given entity can change without affecting the semantics
+  of the program, and the lexical parent of different declarations of the
+  same entity may be different. Changing the semantic parent of a declaration,
+  on the other hand, can have a major impact on semantics, and redeclarations
+  of a particular entity should all have the same semantic context.
+  In the example above, both declarations of \c C::f have \c C as their
+  semantic context, while the lexical context of the first \c C::f is \c C
+  and the lexical context of the second \c C::f is the translation unit.
+  For global declarations, the semantic parent is the translation unit.
+*>
+extern fn CXCursor getCursorSemanticParent(
+  CXCursor cursor)
+@cname("clang_getCursorSemanticParent");
 
-/**
- * Determine the lexical parent of the given cursor.
- *
- * The lexical parent of a cursor is the cursor in which the given \p cursor
- * was actually written. For many declarations, the lexical and semantic parents
- * are equivalent (the semantic parent is returned by
- * \c clang_getCursorSemanticParent()). They diverge when declarations or
- * definitions are provided out-of-line. For example:
- *
- * \code
- * class C {
- *  void f();
- * };
- *
- * void C::f() { }
- * \endcode
- *
- * In the out-of-line definition of \c C::f, the semantic parent is
- * the class \c C, of which this function is a member. The lexical parent is
- * the place where the declaration actually occurs in the source code; in this
- * case, the definition occurs in the translation unit. In general, the
- * lexical parent for a given entity can change without affecting the semantics
- * of the program, and the lexical parent of different declarations of the
- * same entity may be different. Changing the semantic parent of a declaration,
- * on the other hand, can have a major impact on semantics, and redeclarations
- * of a particular entity should all have the same semantic context.
- *
- * In the example above, both declarations of \c C::f have \c C as their
- * semantic context, while the lexical context of the first \c C::f is \c C
- * and the lexical context of the second \c C::f is the translation unit.
- *
- * For declarations written in the global scope, the lexical parent is
- * the translation unit.
- */
-fn CXCursor getCursorLexicalParent(
-  CXCursor cursor) 
-@extern("clang_getCursorLexicalParent");
+<*
+  Determine the lexical parent of the given cursor.
+  The lexical parent of a cursor is the cursor in which the given \p cursor
+  was actually written. For many declarations, the lexical and semantic parents
+  are equivalent (the semantic parent is returned by
+  \c clang_getCursorSemanticParent()). They diverge when declarations or
+  definitions are provided out-of-line. For example:
+  \code
+  class C {
+  void f();
+  };
+  void C::f() { }
+  \endcode
+  In the out-of-line definition of \c C::f, the semantic parent is
+  the class \c C, of which this function is a member. The lexical parent is
+  the place where the declaration actually occurs in the source code; in this
+  case, the definition occurs in the translation unit. In general, the
+  lexical parent for a given entity can change without affecting the semantics
+  of the program, and the lexical parent of different declarations of the
+  same entity may be different. Changing the semantic parent of a declaration,
+  on the other hand, can have a major impact on semantics, and redeclarations
+  of a particular entity should all have the same semantic context.
+  In the example above, both declarations of \c C::f have \c C as their
+  semantic context, while the lexical context of the first \c C::f is \c C
+  and the lexical context of the second \c C::f is the translation unit.
+  For declarations written in the global scope, the lexical parent is
+  the translation unit.
+*>
+extern fn CXCursor getCursorLexicalParent(
+  CXCursor cursor)
+@cname("clang_getCursorLexicalParent");
 
-/**
- * Determine the set of methods that are overridden by the given
- * method.
- *
- * In both Objective-C and C++, a method (aka virtual member function,
- * in C++) can override a virtual method in a base class. For
- * Objective-C, a method is said to override any method in the class's
- * base class, its protocols, or its categories' protocols, that has the same
- * selector and is of the same kind (class or instance).
- * If no such method exists, the search continues to the class's superclass,
- * its protocols, and its categories, and so on. A method from an Objective-C
- * implementation is considered to override the same methods as its
- * corresponding method in the interface.
- *
- * For C++, a virtual member function overrides any virtual member
- * function with the same signature that occurs in its base
- * classes. With multiple inheritance, a virtual member function can
- * override several virtual member functions coming from different
- * base classes.
- *
- * In all cases, this function determines the immediate overridden
- * method, rather than all of the overridden methods. For example, if
- * a method is originally declared in a class A, then overridden in B
- * (which in inherits from A) and also in C (which inherited from B),
- * then the only overridden method returned from this function when
- * invoked on C's method will be B's method. The client may then
- * invoke this function again, given the previously-found overridden
- * methods, to map out the complete method-override set.
- *
- * \param cursor A cursor representing an Objective-C or C++
- * method. This routine will compute the set of methods that this
- * method overrides.
- *
- * \param overridden A pointer whose pointee will be replaced with a
- * pointer to an array of cursors, representing the set of overridden
- * methods. If there are no overridden methods, the pointee will be
- * set to NULL. The pointee must be freed via a call to
- * \c clang_disposeOverriddenCursors().
- *
- * \param num_overridden A pointer to the number of overridden
- * functions, will be set to the number of overridden functions in the
- * array pointed to by \p overridden.
- */
-fn void getOverriddenCursors(
-  CXCursor cursor, 
-  CXCursor** overridden, 
-  CUInt* num_overridden) 
-@extern("clang_getOverriddenCursors");
+<*
+  Determine the set of methods that are overridden by the given
+  method.
+  In both Objective-C and C++, a method (aka virtual member function,
+  in C++) can override a virtual method in a base class. For
+  Objective-C, a method is said to override any method in the class's
+  base class, its protocols, or its categories' protocols, that has the same
+  selector and is of the same kind (class or instance).
+  If no such method exists, the search continues to the class's superclass,
+  its protocols, and its categories, and so on. A method from an Objective-C
+  implementation is considered to override the same methods as its
+  corresponding method in the interface.
+  For C++, a virtual member function overrides any virtual member
+  function with the same signature that occurs in its base
+  classes. With multiple inheritance, a virtual member function can
+  override several virtual member functions coming from different
+  base classes.
+  In all cases, this function determines the immediate overridden
+  method, rather than all of the overridden methods. For example, if
+  a method is originally declared in a class A, then overridden in B
+  (which in inherits from A) and also in C (which inherited from B),
+  then the only overridden method returned from this function when
+  invoked on C's method will be B's method. The client may then
+  invoke this function again, given the previously-found overridden
+  methods, to map out the complete method-override set.
+  \param cursor A cursor representing an Objective-C or C++
+  method. This routine will compute the set of methods that this
+  method overrides.
+  \param overridden A pointer whose pointee will be replaced with a
+  pointer to an array of cursors, representing the set of overridden
+  methods. If there are no overridden methods, the pointee will be
+  set to NULL. The pointee must be freed via a call to
+  \c clang_disposeOverriddenCursors().
+  \param num_overridden A pointer to the number of overridden
+  functions, will be set to the number of overridden functions in the
+  array pointed to by \p overridden.
+*>
+extern fn void getOverriddenCursors(
+  CXCursor cursor,
+  CXCursor** overridden,
+  CUInt* num_overridden)
+@cname("clang_getOverriddenCursors");
 
-/**
- * Free the set of overridden cursors returned by \c
- * clang_getOverriddenCursors().
- */
-fn void disposeOverriddenCursors(
-  CXCursor* overridden) 
-@extern("clang_disposeOverriddenCursors");
+<*
+  Free the set of overridden cursors returned by \c
+  clang_getOverriddenCursors().
+*>
+extern fn void disposeOverriddenCursors(
+  CXCursor* overridden)
+@cname("clang_disposeOverriddenCursors");
 
-/**
- * Retrieve the file that is included by the given inclusion directive
- * cursor.
- */
-fn CXFile getIncludedFile(
-  CXCursor cursor) 
-@extern("clang_getIncludedFile");
+<*
+  Retrieve the file that is included by the given inclusion directive
+  cursor.
+*>
+extern fn CXFile getIncludedFile(
+  CXCursor cursor)
+@cname("clang_getIncludedFile");
 
-/**
- * Map a source location to the cursor that describes the entity at that
- * location in the source code.
- *
- * clang_getCursor() maps an arbitrary source location within a translation
- * unit down to the most specific cursor that describes the entity at that
- * location. For example, given an expression \c x + y, invoking
- * clang_getCursor() with a source location pointing to "x" will return the
- * cursor for "x"; similarly for "y". If the cursor points anywhere between
- * "x" or "y" (e.g., on the + or the whitespace around it), clang_getCursor()
- * will return a cursor referring to the "+" expression.
- *
- * \returns a cursor representing the entity at the given source location, or
- * a NULL cursor if no such entity can be found.
- */
-fn CXCursor getCursor(
-  CXTranslationUnit tu, 
-  CXSourceLocation source_location) 
-@extern("clang_getCursor");
+<*
+  Map a source location to the cursor that describes the entity at that
+  location in the source code.
+  clang_getCursor() maps an arbitrary source location within a translation
+  unit down to the most specific cursor that describes the entity at that
+  location. For example, given an expression \c x + y, invoking
+  clang_getCursor() with a source location pointing to "x" will return the
+  cursor for "x"; similarly for "y". If the cursor points anywhere between
+  "x" or "y" (e.g., on the + or the whitespace around it), clang_getCursor()
+  will return a cursor referring to the "+" expression.
+  \returns a cursor representing the entity at the given source location, or
+  a NULL cursor if no such entity can be found.
+*>
+extern fn CXCursor getCursor(
+  CXTranslationUnit,
+  CXSourceLocation)
+@cname("clang_getCursor");
 
-/**
- * Retrieve the physical location of the source constructor referenced
- * by the given cursor.
- *
- * The location of a declaration is typically the location of the name of that
- * declaration, where the name of that declaration would occur if it is
- * unnamed, or some keyword that introduces that particular declaration.
- * The location of a reference is where that reference occurs within the
- * source code.
- */
-fn CXSourceLocation getCursorLocation(
-  CXCursor cursor) 
-@extern("clang_getCursorLocation");
+<*
+  Retrieve the physical location of the source constructor referenced
+  by the given cursor.
+  The location of a declaration is typically the location of the name of that
+  declaration, where the name of that declaration would occur if it is
+  unnamed, or some keyword that introduces that particular declaration.
+  The location of a reference is where that reference occurs within the
+  source code.
+*>
+extern fn CXSourceLocation getCursorLocation(
+  CXCursor)
+@cname("clang_getCursorLocation");
 
-/**
- * Retrieve the physical extent of the source construct referenced by
- * the given cursor.
- *
- * The extent of a cursor starts with the file/line/column pointing at the
- * first character within the source construct that the cursor refers to and
- * ends with the last character within that source construct. For a
- * declaration, the extent covers the declaration itself. For a reference,
- * the extent covers the location of the reference (e.g., where the referenced
- * entity was actually used).
- */
-fn CXSourceRange getCursorExtent(
-  CXCursor cursor) 
-@extern("clang_getCursorExtent");
+<*
+  Retrieve the physical extent of the source construct referenced by
+  the given cursor.
+  The extent of a cursor starts with the file/line/column pointing at the
+  first character within the source construct that the cursor refers to and
+  ends with the last character within that source construct. For a
+  declaration, the extent covers the declaration itself. For a reference,
+  the extent covers the location of the reference (e.g., where the referenced
+  entity was actually used).
+*>
+extern fn CXSourceRange getCursorExtent(
+  CXCursor)
+@cname("clang_getCursorExtent");
 
-/**
- * Describes the kind of type
- */
-typedef CXTypeKind = inline CInt;
+<*
+  Describes the kind of type
+*>
+constdef CXTypeKind : CInt {
 
-/**
- * Represents an invalid type (e.g., where no type is available).
- */
-const CXTypeKind TYPE_INVALID = 0;
+  <*
+    Represents an invalid type (e.g., where no type is available).
+  *>
+  TYPE_INVALID = 0,
 
-/**
- * A type whose specific kind is not exposed via this
- * interface.
- */
-const CXTypeKind TYPE_UNEXPOSED = 1;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_UNEXPOSED = 1,
 
-/* Builtin types */
-const CXTypeKind TYPE_VOID = 2;
-const CXTypeKind TYPE_BOOL = 3;
-const CXTypeKind TYPE_CHAR_U = 4;
-const CXTypeKind TYPE_UCHAR = 5;
-const CXTypeKind TYPE_CHAR16 = 6;
-const CXTypeKind TYPE_CHAR32 = 7;
-const CXTypeKind TYPE_USHORT = 8;
-const CXTypeKind TYPE_UINT = 9;
-const CXTypeKind TYPE_ULONG = 10;
-const CXTypeKind TYPE_ULONGLONG = 11;
-const CXTypeKind TYPE_UINT128 = 12;
-const CXTypeKind TYPE_CHAR_S = 13;
-const CXTypeKind TYPE_SCHAR = 14;
-const CXTypeKind TYPE_WCHAR = 15;
-const CXTypeKind TYPE_SHORT = 16;
-const CXTypeKind TYPE_INT = 17;
-const CXTypeKind TYPE_LONG = 18;
-const CXTypeKind TYPE_LONGLONG = 19;
-const CXTypeKind TYPE_INT128 = 20;
-const CXTypeKind TYPE_FLOAT = 21;
-const CXTypeKind TYPE_DOUBLE = 22;
-const CXTypeKind TYPE_LONGDOUBLE = 23;
-const CXTypeKind TYPE_NULLPTR = 24;
-const CXTypeKind TYPE_OVERLOAD = 25;
-const CXTypeKind TYPE_DEPENDENT = 26;
-const CXTypeKind TYPE_OBJC_ID = 27;
-const CXTypeKind TYPE_OBJC_CLASS = 28;
-const CXTypeKind TYPE_OBJC_SEL = 29;
-const CXTypeKind TYPE_FLOAT128 = 30;
-const CXTypeKind TYPE_HALF = 31;
-const CXTypeKind TYPE_FLOAT16 = 32;
-const CXTypeKind TYPE_SHORT_ACCUM = 33;
-const CXTypeKind TYPE_ACCUM = 34;
-const CXTypeKind TYPE_LONG_ACCUM = 35;
-const CXTypeKind TYPE_USHORT_ACCUM = 36;
-const CXTypeKind TYPE_UACCUM = 37;
-const CXTypeKind TYPE_ULONG_ACCUM = 38;
-const CXTypeKind TYPE_BFLOAT16 = 39;
-const CXTypeKind TYPE_IBM128 = 40;
-const CXTypeKind TYPE_FIRST_BUILTIN = TYPE_VOID;
-const CXTypeKind TYPE_LAST_BUILTIN = TYPE_IBM128;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_VOID = 2,
 
-const CXTypeKind TYPE_COMPLEX = 100;
-const CXTypeKind TYPE_POINTER = 101;
-const CXTypeKind TYPE_BLOCKPOINTER = 102;
-const CXTypeKind TYPE_LVALUE_REFERENCE = 103;
-const CXTypeKind TYPE_RVALUE_REFERENCE = 104;
-const CXTypeKind TYPE_RECORD = 105;
-const CXTypeKind TYPE_ENUM = 106;
-const CXTypeKind TYPE_TYPEDEF = 107;
-const CXTypeKind TYPE_OBJC_INTERFACE = 108;
-const CXTypeKind TYPE_OBJC_OBJECT_POINTER = 109;
-const CXTypeKind TYPE_FUNCTION_NO_PROTO = 110;
-const CXTypeKind TYPE_FUNCTION_PROTO = 111;
-const CXTypeKind TYPE_CONSTANT_ARRAY = 112;
-const CXTypeKind TYPE_VECTOR = 113;
-const CXTypeKind TYPE_INCOMPLETE_ARRAY = 114;
-const CXTypeKind TYPE_VARIABLE_ARRAY = 115;
-const CXTypeKind TYPE_DEPENDENT_SIZED_ARRAY = 116;
-const CXTypeKind TYPE_MEMBER_POINTER = 117;
-const CXTypeKind TYPE_AUTO = 118;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_BOOL = 3,
 
-/**
- * Represents a type that was referred to using an elaborated type keyword.
- *
- * E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
- */
-const CXTypeKind TYPE_ELABORATED = 119;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_CHARU = 4,
 
-/* OpenCL PipeType. */
-const CXTypeKind TYPE_PIPE = 120;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_UCHAR = 5,
 
-/* OpenCL builtin types. */
-const CXTypeKind TYPE_OCL_IMAGE_1D_RO = 121;
-const CXTypeKind TYPE_OCL_IMAGE_1D_ARRAY_RO = 122;
-const CXTypeKind TYPE_OCL_IMAGE_1D_BUFFER_RO = 123;
-const CXTypeKind TYPE_OCL_IMAGE_2D_RO = 124;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_RO = 125;
-const CXTypeKind TYPE_OCL_IMAGE_2D_DEPTH_RO = 126;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_DEPTH_RO = 127;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_RO = 128;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_RO = 129;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_DEPTH_RO = 130;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_DEPTH_RO = 131;
-const CXTypeKind TYPE_OCL_IMAGE_3D_RO = 132;
-const CXTypeKind TYPE_OCL_IMAGE_1D_WO = 133;
-const CXTypeKind TYPE_OCL_IMAGE_1D_ARRAY_WO = 134;
-const CXTypeKind TYPE_OCL_IMAGE_1D_BUFFER_WO = 135;
-const CXTypeKind TYPE_OCL_IMAGE_2D_WO = 136;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_WO = 137;
-const CXTypeKind TYPE_OCL_IMAGE_2D_DEPTH_WO = 138;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_DEPTH_WO = 139;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_WO = 140;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_WO = 141;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_DEPTH_WO = 142;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_DEPTH_WO = 143;
-const CXTypeKind TYPE_OCL_IMAGE_3D_WO = 144;
-const CXTypeKind TYPE_OCL_IMAGE_1D_RW = 145;
-const CXTypeKind TYPE_OCL_IMAGE_1D_ARRAY_RW = 146;
-const CXTypeKind TYPE_OCL_IMAGE_1D_BUFFER_RW = 147;
-const CXTypeKind TYPE_OCL_IMAGE_2D_RW = 148;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_RW = 149;
-const CXTypeKind TYPE_OCL_IMAGE_2D_DEPTH_RW = 150;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_DEPTH_RW = 151;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_RW = 152;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_RW = 153;
-const CXTypeKind TYPE_OCL_IMAGE_2D_MSAA_DEPTH_RW = 154;
-const CXTypeKind TYPE_OCL_IMAGE_2D_ARRAY_MSAA_DEPTH_RW = 155;
-const CXTypeKind TYPE_OCL_IMAGE_3D_RW = 156;
-const CXTypeKind TYPE_OCL_SAMPLER = 157;
-const CXTypeKind TYPE_OCL_EVENT = 158;
-const CXTypeKind TYPE_OCL_QUEUE = 159;
-const CXTypeKind TYPE_OCL_RESERVE_ID = 160;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_CHAR_16 = 6,
 
-const CXTypeKind TYPE_OBJC_OBJECT = 161;
-const CXTypeKind TYPE_OBJC_TYPE_PARAM = 162;
-const CXTypeKind TYPE_ATTRIBUTED = 163;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_CHAR_32 = 7,
 
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_PAYLOAD = 164;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_PAYLOAD = 165;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_REF_PAYLOAD = 166;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_PAYLOAD = 167;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_RESULT = 168;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT = 169;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_REF_RESULT = 170;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_RESULT = 171;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REFERENCE_STREAMOUT = 172;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REFERENCE_STREAMOUT = 173;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REFERENCE_STREAMIN = 174;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REFERENCE_STREAMIN = 175;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_USHORT = 8,
 
-/* Old aliases for AVC OpenCL extension types. */
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REF_STREAMOUT = 172;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REF_STREAMOUT = 173;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REF_STREAMIN = 174;
-const CXTypeKind TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REF_STREAMIN = 175;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_UINT = 9,
 
-const CXTypeKind TYPE_EXT_VECTOR = 176;
-const CXTypeKind TYPE_ATOMIC = 177;
-const CXTypeKind TYPE_BTF_TAG_ATTRIBUTED = 17;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_ULONG = 10,
 
-/**
- * Describes the calling convention of a function type
- */
-typedef CXCallingConv = inline CInt;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_ULONGLONG = 11,
 
-const CXCallingConv CALLING_CONV_DEFAULT = 0;
-const CXCallingConv CALLING_CONV_C = 1;
-const CXCallingConv CALLING_CONV_X86_STD_CALL = 2;
-const CXCallingConv CALLING_CONV_X86_FAST_CALL = 3;
-const CXCallingConv CALLING_CONV_X86_THIS_CALL = 4;
-const CXCallingConv CALLING_CONV_X86_PASCAL = 5;
-const CXCallingConv CALLING_CONV_AAPCS = 6;
-const CXCallingConv CALLING_CONV_AAPCS_VFP = 7;
-const CXCallingConv CALLING_CONV_X86REGCALL = 8;
-const CXCallingConv CALLING_CONV_INTEL_OCL_BICC = 9;
-const CXCallingConv CALLING_CONV_WIN64 = 10;
-/* Alias for compatibility with older versions of API. */
-const CXCallingConv CALLING_CONV_X86_64_WIN64 = CALLING_CONV_WIN64;
-const CXCallingConv CALLING_CONV_X86_64_SYSV = 11;
-const CXCallingConv CALLING_CONV_X86_VECTOR_CALL = 12;
-const CXCallingConv CALLING_CONV_SWIFT = 13;
-const CXCallingConv CALLING_CONV_PRESERVE_MOST = 14;
-const CXCallingConv CALLING_CONV_PRESERVE_ALL = 15;
-const CXCallingConv CALLING_CONV_AARCH64_VECTOR_CALL = 16;
-const CXCallingConv CALLING_CONV_SWIFT_ASYNC = 17;
-const CXCallingConv CALLING_CONV_AARCH64_SVEPCS = 18;
-const CXCallingConv CALLING_CONV_M68K_RTD = 19;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_UINT128 = 12,
 
-const CXCallingConv CALLING_CONV_INVALID = 100;
-const CXCallingConv CALLING_CONV_UNEXPOSED = 200;
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_CHARS = 13,
 
-/**
- * The type of an element in the abstract syntax tree.
- *
- */
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_SCHAR = 14,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_WCHAR = 15,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_SHORT = 16,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_INT = 17,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_LONG = 18,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_LONG_LONG = 19,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_INT_128 = 20,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_FLOAT = 21,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_DOUBLE = 22,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_LONG_DOUBLE = 23,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_NULL_PTR = 24,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_OVERLOAD = 25,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_DEPENDENT = 26,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_OBJ_C_ID = 27,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_OBJ_C_CLASS = 28,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_OBJ_C_SEL = 29,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_FLOAT_128 = 30,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_HALF = 31,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_FLOAT_16 = 32,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_SHORT_ACCUM = 33,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_ACCUM = 34,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_LONG_ACCUM = 35,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_U_SHORT_ACCUM = 36,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_U_ACCUM = 37,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_U_LONG_ACCUM = 38,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_B_FLOAT_16 = 39,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_IBM_128 = 40,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_FIRST_BUILTIN = 2,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_LAST_BUILTIN = 40,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_COMPLEX = 100,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_POINTER = 101,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_BLOCK_POINTER = 102,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_L_VALUE_REFERENCE = 103,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_R_VALUE_REFERENCE = 104,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_RECORD = 105,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_ENUM = 106,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_TYPEDEF = 107,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_OBJ_C_INTERFACE = 108,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_OBJ_C_OBJECT_POINTER = 109,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_FUNCTION_NO_PROTO = 110,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_FUNCTION_PROTO = 111,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_CONSTANT_ARRAY = 112,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_VECTOR = 113,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_INCOMPLETE_ARRAY = 114,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_VARIABLE_ARRAY = 115,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_DEPENDENT_SIZED_ARRAY = 116,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_MEMBER_POINTER = 117,
+
+  <*
+    A type whose specific kind is not exposed via this
+    interface.
+  *>
+  TYPE_AUTO = 118,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_ELABORATED = 119,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_PIPE = 120,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_1_D_RO = 121,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_1_D_ARRAY_RO = 122,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_1_D_BUFFER_RO = 123,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_RO = 124,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_RO = 125,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_DEPTH_RO = 126,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_RO = 127,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_MSAARO = 128,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAARO = 129,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_RO = 130,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_RO = 131,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_3_D_RO = 132,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_1_D_WO = 133,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_1_D_ARRAY_WO = 134,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_1_D_BUFFER_WO = 135,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_WO = 136,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_WO = 137,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_DEPTH_WO = 138,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_WO = 139,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_MSAAWO = 140,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAAWO = 141,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_WO = 142,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_WO = 143,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_3_D_WO = 144,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_1_D_RW = 145,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_1_D_ARRAY_RW = 146,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_1_D_BUFFER_RW = 147,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_RW = 148,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_RW = 149,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_DEPTH_RW = 150,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_DEPTH_RW = 151,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_MSAARW = 152,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAARW = 153,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_MSAA_DEPTH_RW = 154,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_2_D_ARRAY_MSAA_DEPTH_RW = 155,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_IMAGE_3_D_RW = 156,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_SAMPLER = 157,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_EVENT = 158,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_QUEUE = 159,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_RESERVE_ID = 160,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OBJ_C_OBJECT = 161,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OBJ_C_TYPE_PARAM = 162,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_ATTRIBUTED = 163,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_PAYLOAD = 164,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_PAYLOAD = 165,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_REF_PAYLOAD = 166,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_PAYLOAD = 167,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_MCE_RESULT = 168,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT = 169,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_REF_RESULT = 170,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_SIC_RESULT = 171,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REFERENCE_STREAMOUT = 172,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REFERENCE_STREAMOUT = 173,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REFERENCE_STREAMIN = 174,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REFERENCE_STREAMIN = 175,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_SINGLE_REF_STREAMOUT = 172,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_RESULT_DUAL_REF_STREAMOUT = 173,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_SINGLE_REF_STREAMIN = 174,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_OCL_INTEL_SUBGROUP_AVC_IME_DUAL_REF_STREAMIN = 175,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_EXT_VECTOR = 176,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_ATOMIC = 177,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_BTF_TAG_ATTRIBUTED = 178,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_HLSL_RESOURCE = 179,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_HLSL_ATTRIBUTED_RESOURCE = 180,
+
+  <*
+    Represents a type that was referred to using an elaborated type keyword.
+    E.g., struct S, or via a qualified name, e.g., N::M::type, or both.
+  *>
+  TYPE_HLSL_INLINE_SPIRV = 181
+}
+
+<*
+  Describes the calling convention of a function type
+*>
+constdef CXCallingConv : CInt {
+  CALLING_CONV_DEFAULT = 0,
+  CALLING_CONV_C = 1,
+  CALLING_CONV_X86_STD_CALL = 2,
+  CALLING_CONV_X86_FAST_CALL = 3,
+  CALLING_CONV_X86_THIS_CALL = 4,
+  CALLING_CONV_X86_PASCAL = 5,
+  CALLING_CONV_AAPCS = 6,
+  CALLING_CONV_AAPCS_VFP = 7,
+  CALLING_CONV_X86_REG_CALL = 8,
+  CALLING_CONV_INTEL_OCL_BICC = 9,
+  CALLING_CONV_WIN_64 = 10,
+  CALLING_CONV_X86_64_WIN_64 = 10,
+  CALLING_CONV_X86_64_SYS_V = 11,
+  CALLING_CONV_X86_VECTOR_CALL = 12,
+  CALLING_CONV_SWIFT = 13,
+  CALLING_CONV_PRESERVE_MOST = 14,
+  CALLING_CONV_PRESERVE_ALL = 15,
+  CALLING_CONV_A_ARCH_64_VECTOR_CALL = 16,
+  CALLING_CONV_SWIFT_ASYNC = 17,
+  CALLING_CONV_A_ARCH_64_SVEPCS = 18,
+  CALLING_CONV_M68_K_RTD = 19,
+  CALLING_CONV_PRESERVE_NONE = 20,
+  CALLING_CONV_RISCV_VECTOR_CALL = 21,
+  CALLING_CONV_RISCVVLS_CALL_32 = 22,
+  CALLING_CONV_RISCVVLS_CALL_64 = 23,
+  CALLING_CONV_RISCVVLS_CALL_128 = 24,
+  CALLING_CONV_RISCVVLS_CALL_256 = 25,
+  CALLING_CONV_RISCVVLS_CALL_512 = 26,
+  CALLING_CONV_RISCVVLS_CALL_1024 = 27,
+  CALLING_CONV_RISCVVLS_CALL_2048 = 28,
+  CALLING_CONV_RISCVVLS_CALL_4096 = 29,
+  CALLING_CONV_RISCVVLS_CALL_8192 = 30,
+  CALLING_CONV_RISCVVLS_CALL_16384 = 31,
+  CALLING_CONV_RISCVVLS_CALL_32768 = 32,
+  CALLING_CONV_RISCVVLS_CALL_65536 = 33,
+  CALLING_CONV_INVALID = 100,
+  CALLING_CONV_UNEXPOSED = 200
+}
+
+<*
+  The type of an element in the abstract syntax tree.
+*>
 struct CXType {
   CXTypeKind kind;
   void*[2] data;
 }
 
-/**
- * Retrieve the type of a CXCursor (if any).
- */
-fn CXType getCursorType(
-  CXCursor cursor) 
-@extern("clang_getCursorType");
-
-/**
- * Pretty-print the underlying type using the rules of the
- * language of the translation unit from which it came.
- *
- * If the type is invalid, an empty string is returned.
- */
-fn CXString getTypeSpelling(
-  CXType ct) 
-@extern("clang_getTypeSpelling");
-
-/**
- * Retrieve the underlying type of a typedef declaration.
- *
- * If the cursor does not reference a typedef declaration, an invalid type is
- * returned.
- */
-fn CXType getTypedefDeclUnderlyingType(
-  CXCursor cursor) 
-@extern("clang_getTypedefDeclUnderlyingType");
-
-/**
- * Retrieve the integer type of an enum declaration.
- *
- * If the cursor does not reference an enum declaration, an invalid type is
- * returned.
- */
-fn CXType getEnumDeclIntegerType(
-  CXCursor c) 
-@extern("clang_getEnumDeclIntegerType");
-
-/**
- * Retrieve the integer value of an enum constant declaration as a signed
- *  CLongLong.
- *
- * If the cursor does not reference an enum constant declaration, LLONG_MIN is
- * returned. Since this is also potentially a valid constant value, the kind of
- * the cursor must be verified before calling this function.
- */
-fn CLongLong getEnumConstantDeclValue(
-  CXCursor c) 
-@extern("clang_getEnumConstantDeclValue");
-
-/**
- * Retrieve the integer value of an enum constant declaration as an CUInt
- *  CLongLong.
- *
- * If the cursor does not reference an enum constant declaration, ULLONG_MAX is
- * returned. Since this is also potentially a valid constant value, the kind of
- * the cursor must be verified before calling this function.
- */
-fn CULongLong getEnumConstantDeclUnsignedValue(
-  CXCursor c) 
-@extern("clang_getEnumConstantDeclUnsignedValue");
-
-/**
- * Returns non-zero if the cursor specifies a Record member that is a bit-field.
- */
-fn CUInt isBitField_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isBitField");
-
-/**
- * Retrieve the bit width of a bit-field declaration as an integer.
- *
- * If the cursor does not reference a bit-field, or if the bit-field's width
- * expression cannot be evaluated, -1 is returned.
- *
- * For example:
- * \code
- * if (clang_Cursor_isBitField(Cursor)) {
- *   CInt Width = clang_getFieldDeclBitWidth(Cursor);
- *   if (Width != -1) {
- *     // The bit-field width is not value-dependent.
- *   }
- * }
- * \endcode
- */
-fn CInt getFieldDeclBitWidth(
-  CXCursor c) 
-@extern("clang_getFieldDeclBitWidth");
-
-/**
- * Retrieve the number of non-variadic arguments associated with a given
- * cursor.
- *
- * The number of arguments can be determined for calls as well as for
- * declarations of functions or methods. For other cursors -1 is returned.
- */
-fn CInt getNumArguments_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getNumArguments");
-
-/**
- * Retrieve the argument cursor of a function or method.
- *
- * The argument cursor can be determined for calls as well as for declarations
- * of functions or methods. For other cursors and for invalid indices, an
- * invalid cursor is returned.
- */
-fn CXCursor getArgument_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getArgument");
-
-/**
- * Describes the kind of a template argument.
- *
- * See the definition of llvm::clang::TemplateArgument::ArgKind for full
- * element descriptions.
- */
-typedef CXTemplateArgumentKind = inline CInt;
-
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_NULL = 0;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_TYPE = 1;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_DECLARATION = 2;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_NULLPTR = 3;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_INTEGRAL = 4;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_TEMPLATE = 5;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_TEMPLATEEXPANSION = 6;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_EXPRESSION = 7;
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_PACK = 8;
-/* Indicates an error case, preventing the kind from being deduced. */
-const CXTemplateArgumentKind TEMPLATE_ARGUMENT_KIND_INVALID = 9;
-
-/**
- * Returns the number of template args of a function, struct, or class decl
- * representing a template specialization.
- *
- * If the argument cursor cannot be converted into a template function
- * declaration, -1 is returned.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, -7, true>();
- *
- * The value 3 would be returned from this call.
- */
-fn CInt getNumTemplateArguments_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getNumTemplateArguments");
-
-/**
- * Retrieve the kind of the I'th template argument of the CXCursor C.
- *
- * If the argument CXCursor does not represent a FunctionDecl, StructDecl, or
- * ClassTemplatePartialSpecialization, an invalid template argument kind is
- * returned.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, -7, true>();
- *
- * For I = 0, 1, and 2, Type, Integral, and Integral will be returned,
- * respectively.
- */
-fn CXTemplateArgumentKind getTemplateArgumentKind_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getTemplateArgumentKind");
-
-/**
- * Retrieve a CXType representing the type of a TemplateArgument of a
- *  function decl representing a template specialization.
- *
- * If the argument CXCursor does not represent a FunctionDecl, StructDecl,
- * ClassDecl or ClassTemplatePartialSpecialization whose I'th template argument
- * has a kind of CXTemplateArgKind_Integral, an invalid type is returned.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, -7, true>();
- *
- * If called with I = 0, "float", will be returned.
- * Invalid types will be returned for I == 1 or 2.
- */
-fn CXType getTemplateArgumentType_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getTemplateArgumentType");
-
-/**
- * Retrieve the value of an Integral TemplateArgument (of a function
- *  decl representing a template specialization) as a signed CLongLong.
- *
- * It is undefined to call this function on a CXCursor that does not represent a
- * FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization
- * whose I'th template argument is not an integral value.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, -7, true>();
- *
- * If called with I = 1 or 2, -7 or true will be returned, respectively.
- * For I == 0, this function's behavior is undefined.
- */
-fn CLongLong getTemplateArgumentValue_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getTemplateArgumentValue");
-
-/**
- * Retrieve the value of an Integral TemplateArgument (of a function
- *  decl representing a template specialization) as an CUInt CLongLong.
- *
- * It is undefined to call this function on a CXCursor that does not represent a
- * FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization or
- * whose I'th template argument is not an integral value.
- *
- * For example, for the following declaration and specialization:
- *   template <typename T, CInt kInt, bool kBool>
- *   void foo() { ... }
- *
- *   template <>
- *   void foo<float, 2147483649, true>();
- *
- * If called with I = 1 or 2, 2147483649 or true will be returned, respectively.
- * For I == 0, this function's behavior is undefined.
- */
-fn CULongLong getTemplateArgumentUnsignedValue_Cursor(
-  CXCursor c, 
-  CUInt i) 
-@extern("clang_Cursor_getTemplateArgumentUnsignedValue");
-
-/**
- * Determine whether two CXTypes represent the same type.
- *
- * \returns non-zero if the CXTypes represent the same type and
- *          zero otherwise.
- */
-fn CUInt equalTypes(
-  CXType a, 
-  CXType b) 
-@extern("clang_equalTypes");
-
-/**
- * Return the canonical type for a CXType.
- *
- * Clang's type system explicitly models typedefs and all the ways
- * a specific type can be represented.  The canonical type is the underlying
- * type with all the "sugar" removed.  For example, if 'T' is a typedef
- * for 'CInt', the canonical type for 'T' would be 'CInt'.
- */
-fn CXType getCanonicalType(
-  CXType t) 
-@extern("clang_getCanonicalType");
-
-/**
- * Determine whether a CXType has the "const" qualifier set,
- * without looking through typedefs that may have added "const" at a
- * different level.
- */
-fn CUInt isConstQualifiedType(
-  CXType t) 
-@extern("clang_isConstQualifiedType");
-
-/**
- * Determine whether a  CXCursor that is a macro, is
- * function like.
- */
-fn CUInt isMacroFunctionLike_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isMacroFunctionLike");
-
-/**
- * Determine whether a  CXCursor that is a macro, is a
- * builtin one.
- */
-fn CUInt isMacroBuiltin_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isMacroBuiltin");
-
-/**
- * Determine whether a  CXCursor that is a function declaration, is an
- * inline declaration.
- */
-fn CUInt isFunctionInlined_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isFunctionInlined");
-
-/**
- * Determine whether a CXType has the "volatile" qualifier set,
- * without looking through typedefs that may have added "volatile" at
- * a different level.
- */
-fn CUInt isVolatileQualifiedType(
-  CXType t) 
-@extern("clang_isVolatileQualifiedType");
-
-/**
- * Determine whether a CXType has the "restrict" qualifier set,
- * without looking through typedefs that may have added "restrict" at a
- * different level.
- */
-fn CUInt isRestrictQualifiedType(
-  CXType t) 
-@extern("clang_isRestrictQualifiedType");
-
-/**
- * Returns the address space of the given type.
- */
-fn CUInt getAddressSpace(
-  CXType t) 
-@extern("clang_getAddressSpace");
-
-/**
- * Returns the typedef name of the given type.
- */
-fn CXString getTypedefName(
-  CXType ct) 
-@extern("clang_getTypedefName");
-
-/**
- * For pointer types, returns the type of the pointee.
- */
-fn CXType getPointeeType(
-  CXType t) 
-@extern("clang_getPointeeType");
-
-/**
- * Retrieve the unqualified variant of the given type, removing as
- * little sugar as possible.
- *
- * For example, given the following series of typedefs:
- *
- * \code
- * typedef CInt Integer;
- * typedef const Integer CInteger;
- * typedef CInteger DifferenceType;
- * \endcode
- *
- * Executing \c clang_getUnqualifiedType() on a \c CXType that
- * represents \c DifferenceType, will desugar to a type representing
- * \c Integer, that has no qualifiers.
- *
- * And, executing \c clang_getUnqualifiedType() on the type of the
- * first argument of the following function declaration:
- *
- * \code
- * void foo(const CInt);
- * \endcode
- *
- * Will return a type representing \c CInt, removing the \c const
- * qualifier.
- *
- * Sugar over array types is not desugared.
- *
- * A type can be checked for qualifiers with \c
- * clang_isConstQualifiedType(), \c clang_isVolatileQualifiedType()
- * and \c clang_isRestrictQualifiedType().
- *
- * A type that resulted from a call to \c clang_getUnqualifiedType
- * will return \c false for all of the above calls.
- */
-fn CXType getUnqualifiedType(
-  CXType ct) 
-@extern("clang_getUnqualifiedType");
-
-/**
- * For reference types (e.g., "const CInt&"), returns the type that the
- * reference refers to (e.g "const CInt").
- *
- * Otherwise, returns the type itself.
- *
- * A type that has kind \c CXType_LValueReference or
- * \c CXType_RValueReference is a reference type.
- */
-fn CXType getNonReferenceType(
-  CXType ct) 
-@extern("clang_getNonReferenceType");
-
-/**
- * Return the cursor for the declaration of the given type.
- */
-fn CXCursor getTypeDeclaration(
-  CXType t) 
-@extern("clang_getTypeDeclaration");
-
-/**
- * Returns the Objective-C type encoding for the specified declaration.
- */
-fn CXString getDeclObjCTypeEncoding(
-  CXCursor c) 
-@extern("clang_getDeclObjCTypeEncoding");
-
-/**
- * Returns the Objective-C type encoding for the specified CXType.
- */
-fn CXString getObjCEncoding_Type(
-  CXType type) 
-@extern("clang_Type_getObjCEncoding");
-
-/**
- * Retrieve the spelling of a given CXTypeKind.
- */
-fn CXString getTypeKindSpelling(
-  CXTypeKind k) 
-@extern("clang_getTypeKindSpelling");
-
-/**
- * Retrieve the calling convention associated with a function type.
- *
- * If a non-function type is passed in, CXCallingConv_Invalid is returned.
- */
-fn CXCallingConv getFunctionTypeCallingConv(
-  CXType t) 
-@extern("clang_getFunctionTypeCallingConv");
-
-/**
- * Retrieve the return type associated with a function type.
- *
- * If a non-function type is passed in, an invalid type is returned.
- */
-fn CXType getResultType(
-  CXType t) 
-@extern("clang_getResultType");
-
-/**
- * Retrieve the exception specification type associated with a function type.
- * This is a value of type CXCursor_ExceptionSpecificationKind.
- *
- * If a non-function type is passed in, an error code of -1 is returned.
- */
-fn CInt getExceptionSpecificationType(
-  CXType t) 
-@extern("clang_getExceptionSpecificationType");
-
-/**
- * Retrieve the number of non-variadic parameters associated with a
- * function type.
- *
- * If a non-function type is passed in, -1 is returned.
- */
-fn CInt getNumArgTypes(
-  CXType t) 
-@extern("clang_getNumArgTypes");
-
-/**
- * Retrieve the type of a parameter of a function type.
- *
- * If a non-function type is passed in or the function does not have enough
- * parameters, an invalid type is returned.
- */
-fn CXType getArgType(
-  CXType t, 
-  CUInt i) 
-@extern("clang_getArgType");
-
-/**
- * Retrieves the base type of the ObjCObjectType.
- *
- * If the type is not an ObjC object, an invalid type is returned.
- */
-fn CXType getObjCObjectBaseType_Type(
-  CXType t) 
-@extern("clang_Type_getObjCObjectBaseType");
-
-/**
- * Retrieve the number of protocol references associated with an ObjC object/id.
- *
- * If the type is not an ObjC object, 0 is returned.
- */
-fn CUInt getNumObjCProtocolRefs_Type(
-  CXType t) 
-@extern("clang_Type_getNumObjCProtocolRefs");
-
-/**
- * Retrieve the decl for a protocol reference for an ObjC object/id.
- *
- * If the type is not an ObjC object or there are not enough protocol
- * references, an invalid cursor is returned.
- */
-fn CXCursor getObjCProtocolDecl_Type(
-  CXType t, 
-  CUInt i) 
-@extern("clang_Type_getObjCProtocolDecl");
-
-/**
- * Retrieve the number of type arguments associated with an ObjC object.
- *
- * If the type is not an ObjC object, 0 is returned.
- */
-fn CUInt getNumObjCTypeArgs_Type(
-  CXType t) 
-@extern("clang_Type_getNumObjCTypeArgs");
-
-/**
- * Retrieve a type argument associated with an ObjC object.
- *
- * If the type is not an ObjC or the index is not valid,
- * an invalid type is returned.
- */
-fn CXType getObjCTypeArg_Type(
-  CXType t, 
-  CUInt i) 
-@extern("clang_Type_getObjCTypeArg");
-
-/**
- * Return 1 if the CXType is a variadic function type, and 0 otherwise.
- */
-fn CUInt isFunctionTypeVariadic(
-  CXType t) 
-@extern("clang_isFunctionTypeVariadic");
-
-/**
- * Retrieve the return type associated with a given cursor.
- *
- * This only returns a valid type if the cursor refers to a function or method.
- */
-fn CXType getCursorResultType(
-  CXCursor c) 
-@extern("clang_getCursorResultType");
-
-/**
- * Retrieve the exception specification type associated with a given cursor.
- * This is a value of type CXCursor_ExceptionSpecificationKind.
- *
- * This only returns a valid result if the cursor refers to a function or
- * method.
- */
-fn CInt getCursorExceptionSpecificationType(
-  CXCursor c) 
-@extern("clang_getCursorExceptionSpecificationType");
-
-/**
- * Return 1 if the CXType is a POD (plain old data) type, and 0
- *  otherwise.
- */
-fn CUInt isPODType(
-  CXType t) 
-@extern("clang_isPODType");
-
-/**
- * Return the element type of an array, complex, or vector type.
- *
- * If a type is passed in that is not an array, complex, or vector type,
- * an invalid type is returned.
- */
-fn CXType getElementType(
-  CXType t) 
-@extern("clang_getElementType");
-
-/**
- * Return the number of elements of an array or vector type.
- *
- * If a type is passed in that is not an array or vector type,
- * -1 is returned.
- */
-fn CLongLong getNumElements(
-  CXType t) 
-@extern("clang_getNumElements");
-
-/**
- * Return the element type of an array type.
- *
- * If a non-array type is passed in, an invalid type is returned.
- */
-fn CXType getArrayElementType(
-  CXType t) 
-@extern("clang_getArrayElementType");
-
-/**
- * Return the array size of a constant array.
- *
- * If a non-array type is passed in, -1 is returned.
- */
-fn CLongLong getArraySize(
-  CXType t) 
-@extern("clang_getArraySize");
-
-/**
- * Retrieve the type named by the qualified-id.
- *
- * If a non-elaborated type is passed in, an invalid type is returned.
- */
-fn CXType getNamedType_Type(
-  CXType t) 
-@extern("clang_Type_getNamedType");
-
-/**
- * Determine if a typedef is 'transparent' tag.
- *
- * A typedef is considered 'transparent' if it shares a name and spelling
- * location with its underlying tag type, as is the case with the NS_ENUM macro.
- *
- * \returns non-zero if transparent and zero otherwise.
- */
-fn CUInt isTransparentTagTypedef_Type(
-  CXType t) 
-@extern("clang_Type_isTransparentTagTypedef");
-
-typedef CXTypeNullabilityKind = inline CInt;
-/**
- * Values of this type can never be null.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_NON_NULL = 0;
-/**
- * Values of this type can be null.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_NULLABLE = 1;
-/**
- * Whether values of this type can be null is (explicitly)
- * unspecified. This captures a (fairly rare) case where we
- * can't conclude anything about the nullability of the type even
- * though it has been considered.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_UNSPECIFIED = 2;
-/**
- * Nullability is not applicable to this type.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_INVALID = 3;
-
-/**
- * Generally behaves like Nullable, except when used in a block parameter that
- * was imported into a swift async method. There, swift will assume that the
- * parameter can get null even if no error occurred. _Nullable parameters are
- * assumed to only get null on error.
- */
-const CXTypeNullabilityKind TYPE_NULLABILITY_NULLABLE_RESULT = 4;
-
-/**
- * Retrieve the nullability kind of a pointer type.
- */
-fn CXTypeNullabilityKind getNullability_Type(
-  CXType t) 
-@extern("clang_Type_getNullability");
-
-/**
- * List the possible error codes for \c clang_Type_getSizeOf,
- *   \c clang_Type_getAlignOf, \c clang_Type_getOffsetOf and
- *   \c clang_Cursor_getOffsetOf.
- *
- * A value of this enumeration type can be returned if the target type is not
- * a valid argument to sizeof, alignof or offsetof.
- */
-typedef CXTypeLayoutError = inline CInt;
-
-/**
- * Type is of kind CXType_Invalid.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_INVALID = -1;
-/**
- * The type is an incomplete Type.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_INCOMPLETE = -2;
-/**
- * The type is a dependent Type.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_DEPENDENT = -3;
-/**
- * The type is not a constant size type.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_NOT_CONSTANT_SIZE = -4;
-/**
- * The Field name is not valid for this record.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_INVALID_FIELD_NAME = -5;
-/**
- * The type is undeduced.
- */
-const CXTypeLayoutError TYPE_LAYOUT_ERROR_UNDEDUCED = -6;
-
-/**
- * Return the alignment of a type in bytes as per C++[expr.alignof]
- *   standard.
- *
- * If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
- * If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
- *   is returned.
- * If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
- *   returned.
- * If the type declaration is not a constant size type,
- *   CXTypeLayoutError_NotConstantSize is returned.
- */
-fn CLongLong getAlignOf_Type(
-  CXType t) 
-@extern("clang_Type_getAlignOf");
-
-/**
- * Return the class type of an member pointer type.
- *
- * If a non-member-pointer type is passed in, an invalid type is returned.
- */
-fn CXType getClassType_Type(
-  CXType t) 
-@extern("clang_Type_getClassType");
-
-/**
- * Return the size of a type in bytes as per C++[expr.sizeof] standard.
- *
- * If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
- * If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
- *   is returned.
- * If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
- *   returned.
- */
-fn CLongLong getSizeOf_Type(
-  CXType t) 
-@extern("clang_Type_getSizeOf");
-
-/**
- * Return the offset of a field named S in a record of type T in bits
- *   as it would be returned by __offsetof__ as per C++11[18.2p4]
- *
- * If the cursor is not a record field declaration, CXTypeLayoutError_Invalid
- *   is returned.
- * If the field's type declaration is an incomplete type,
- *   CXTypeLayoutError_Incomplete is returned.
- * If the field's type declaration is a dependent type,
- *   CXTypeLayoutError_Dependent is returned.
- * If the field's name S is not found,
- *   CXTypeLayoutError_InvalidFieldName is returned.
- */
-fn CLongLong getOffsetOf_Type(
-  CXType t, 
-  ZString s) 
-@extern("clang_Type_getOffsetOf");
-
-/**
- * Return the type that was modified by this attributed type.
- *
- * If the type is not an attributed type, an invalid type is returned.
- */
-fn CXType getModifiedType_Type(
-  CXType t) 
-@extern("clang_Type_getModifiedType");
-
-/**
- * If a non-atomic type is passed in, an invalid type is returned.
- */
-fn CXType getValueType_Type(
-  CXType ct) 
-@extern("clang_Type_getValueType");
-
-/**
- * Return the offset of the field represented by the Cursor.
- *
- * If the cursor is not a field declaration, -1 is returned.
- * If the cursor semantic parent is not a record field declaration,
- *   CXTypeLayoutError_Invalid is returned.
- * If the field's type declaration is an incomplete type,
- *   CXTypeLayoutError_Incomplete is returned.
- * If the field's type declaration is a dependent type,
- *   CXTypeLayoutError_Dependent is returned.
- * If the field's name S is not found,
- *   CXTypeLayoutError_InvalidFieldName is returned.
- */
-fn CLongLong getOffsetOfField_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getOffsetOfField");
-
-/**
- * Determine whether the given cursor represents an anonymous
- * tag or namespace
- */
-fn CUInt isAnonymous_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isAnonymous");
-
-/**
- * Determine whether the given cursor represents an anonymous record
- * declaration.
- */
-fn CUInt isAnonymousRecordDecl_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isAnonymousRecordDecl");
-
-/**
- * Determine whether the given cursor represents an inline namespace
- * declaration.
- */
-fn CUInt isInlineNamespace_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isInlineNamespace");
-
-typedef CXRefQualifierKind = inline CInt;
-
-/** No ref-qualifier was provided. 
-  */
-const CXRefQualifierKind REF_QUALIFIER_NONE = 0;
-/** An lvalue ref-qualifier was provided (\c &). 
-  */
-const CXRefQualifierKind REF_QUALIFIER_LVALUE = 1;
-/** An rvalue ref-qualifier was provided (\c &&). 
-  */
-const CXRefQualifierKind REF_QUALIFIER_RVALUE = 2;
-
-/**
- * Returns the number of template arguments for given template
- * specialization, or -1 if type \c T is not a template specialization.
- */
-fn CInt getNumTemplateArguments_Type(
-  CXType t) 
-@extern("clang_Type_getNumTemplateArguments");
-
-/**
- * Returns the type template argument of a template class specialization
- * at given index.
- *
- * This function only returns template type arguments and does not handle
- * template template arguments or variadic packs.
- */
-fn CXType getTemplateArgumentAsType_Type(
-  CXType t, 
-  CUInt i) 
-@extern("clang_Type_getTemplateArgumentAsType");
-
-/**
- * Retrieve the ref-qualifier kind of a function or method.
- *
- * The ref-qualifier is returned for C++ functions or methods. For other types
- * or non-C++ declarations, CXRefQualifier_None is returned.
- */
-fn CXRefQualifierKind getCXXRefQualifier_Type(
-  CXType t) 
-@extern("clang_Type_getCXXRefQualifier");
-
-/**
- * Returns 1 if the base class specified by the cursor with kind
- *   CX_CXXBaseSpecifier is virtual.
- */
-fn CUInt isVirtualBase(
-  CXCursor c) 
-@extern("clang_isVirtualBase");
-
-/**
- * Represents the C++ access control level to a base class for a
- * cursor with kind CX_CXXBaseSpecifier.
- */
-typedef CX_CXXAccessSpecifier = inline CInt;
-
-const CX_CXXAccessSpecifier CXX_INVALID_ACCESS_SPECIFIER = 0;
-const CX_CXXAccessSpecifier CXX_PUBLIC = 1;
-const CX_CXXAccessSpecifier CXX_PROTECTED = 2;
-const CX_CXXAccessSpecifier CXX_PRIVATE = 3;
-
-/**
- * Returns the access control level for the referenced object.
- *
- * If the cursor refers to a C++ declaration, its access control level within
- * its parent scope is returned. Otherwise, if the cursor refers to a base
- * specifier or access specifier, the specifier itself is returned.
- */
-fn CX_CXXAccessSpecifier getCXXAccessSpecifier(
-  CXCursor c) 
-@extern("clang_getCXXAccessSpecifier");
-
-/**
- * Represents the storage classes as declared in the source. CX_SC_Invalid
- * was added for the case that the passed cursor in not a declaration.
- */
-typedef CX_StorageClass = inline CInt;
-
-const CX_StorageClass SC_INVALID = 0;
-const CX_StorageClass SC_NONE = 1;
-const CX_StorageClass SC_EXTERN = 2;
-const CX_StorageClass SC_STATIC = 3;
-const CX_StorageClass SC_PRIVATE_EXTERN = 4;
-const CX_StorageClass SC_OPENCL_WORK_GROUP_LOCAL = 5;
-const CX_StorageClass SC_AUTO = 6;
-const CX_StorageClass SC_REGISTER = 7;
-
-/**
- * Returns the storage class for a function or variable declaration.
- *
- * If the passed in Cursor is not a function or variable declaration,
- * CX_SC_Invalid is returned else the storage class.
- */
-fn CX_StorageClass getStorageClass_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getStorageClass");
-
-/**
- * Determine the number of overloaded declarations referenced by a
- * \c CXCursor_OverloadedDeclRef cursor.
- *
- * \param cursor The cursor whose overloaded declarations are being queried.
- *
- * \returns The number of overloaded declarations referenced by \c cursor. If it
- * is not a \c CXCursor_OverloadedDeclRef cursor, returns 0.
- */
-fn CUInt getNumOverloadedDecls(
-  CXCursor cursor) 
-@extern("clang_getNumOverloadedDecls");
-
-/**
- * Retrieve a cursor for one of the overloaded declarations referenced
- * by a \c CXCursor_OverloadedDeclRef cursor.
- *
- * \param cursor The cursor whose overloaded declarations are being queried.
- *
- * \param index The zero-based index into the set of overloaded declarations in
- * the cursor.
- *
- * \returns A cursor representing the declaration referenced by the given
- * \c cursor at the specified \c index. If the cursor does not have an
- * associated set of overloaded declarations, or if the index is out of bounds,
- * returns \c clang_getNullCursor();
- */
-fn CXCursor getOverloadedDecl(
-  CXCursor cursor, 
-  CUInt index) 
-@extern("clang_getOverloadedDecl");
-
-/**
- * For cursors representing an iboutletcollection attribute,
- *  this function returns the collection element type.
- *
- */
-fn CXType getIBOutletCollectionType(
-  CXCursor c) 
-@extern("clang_getIBOutletCollectionType");
-
-/**
- * Describes how the traversal of the children of a particular
- * cursor should proceed after visiting a particular child cursor.
- *
- * A value of this enumeration type should be returned by each
- * \c CXCursorVisitor to indicate how clang_visitChildren() proceed.
- */
-typedef CXChildVisitResult = inline CInt;
-/**
- * Terminates the cursor traversal.
- */
-const CXChildVisitResult CHILD_VISIT_BREAK = 0;
-/**
- * Continues the cursor traversal with the next sibling of
- * the cursor just visited, without visiting its children.
- */
-const CXChildVisitResult CHILD_VISIT_CONTINUE = 1;
-/**
- * Recursively traverse the children of this cursor, using
- * the same visitor and client data.
- */
-const CXChildVisitResult CHILD_VISIT_RECURSE = 2;
-
-/**
- * Visitor invoked for each cursor found by a traversal.
- *
- * This visitor function will be invoked for each cursor found by
- * clang_visitCursorChildren(). Its first argument is the cursor being
- * visited, its second argument is the parent visitor for that cursor,
- * and its third argument is the client data provided to
- * clang_visitCursorChildren().
- *
- * The visitor should return one of the \c CXChildVisitResult values
- * to direct clang_visitCursorChildren().
- */
+<*
+  Retrieve the type of a CXCursor (if any).
+*>
+extern fn CXType getCursorType(
+  CXCursor c)
+@cname("clang_getCursorType");
+
+<*
+  Pretty-print the underlying type using the rules of the
+  language of the translation unit from which it came.
+  If the type is invalid, an empty string is returned.
+*>
+extern fn CXString getTypeSpelling(
+  CXType ct)
+@cname("clang_getTypeSpelling");
+
+<*
+  Retrieve the underlying type of a typedef declaration.
+  If the cursor does not reference a typedef declaration, an invalid type is
+  returned.
+*>
+extern fn CXType getTypedefDeclUnderlyingType(
+  CXCursor c)
+@cname("clang_getTypedefDeclUnderlyingType");
+
+<*
+  Retrieve the integer type of an enum declaration.
+  If the cursor does not reference an enum declaration, an invalid type is
+  returned.
+*>
+extern fn CXType getEnumDeclIntegerType(
+  CXCursor c)
+@cname("clang_getEnumDeclIntegerType");
+
+<*
+  Retrieve the integer value of an enum constant declaration as a signed
+  long long.
+  If the cursor does not reference an enum constant declaration, LLONG_MIN is
+  returned. Since this is also potentially a valid constant value, the kind of
+  the cursor must be verified before calling this function.
+*>
+extern fn CLongLong getEnumConstantDeclValue(
+  CXCursor c)
+@cname("clang_getEnumConstantDeclValue");
+
+<*
+  Retrieve the integer value of an enum constant declaration as an unsigned
+  long long.
+  If the cursor does not reference an enum constant declaration, ULLONG_MAX is
+  returned. Since this is also potentially a valid constant value, the kind of
+  the cursor must be verified before calling this function.
+*>
+extern fn CULongLong getEnumConstantDeclUnsignedValue(
+  CXCursor c)
+@cname("clang_getEnumConstantDeclUnsignedValue");
+
+<*
+  Returns non-zero if the cursor specifies a Record member that is a bit-field.
+*>
+extern fn CUInt cursor_isBitField(
+  CXCursor c)
+@cname("clang_Cursor_isBitField");
+
+<*
+  Retrieve the bit width of a bit-field declaration as an integer.
+  If the cursor does not reference a bit-field, or if the bit-field's width
+  expression cannot be evaluated, -1 is returned.
+  For example:
+  \code
+  if (clang_Cursor_isBitField(Cursor)) {
+  int Width = clang_getFieldDeclBitWidth(Cursor);
+  if (Width != -1) {
+  // The bit-field width is not value-dependent.
+  }
+  }
+  \endcode
+*>
+extern fn CInt getFieldDeclBitWidth(
+  CXCursor c)
+@cname("clang_getFieldDeclBitWidth");
+
+<*
+  Retrieve the number of non-variadic arguments associated with a given
+  cursor.
+  The number of arguments can be determined for calls as well as for
+  declarations of functions or methods. For other cursors -1 is returned.
+*>
+extern fn CInt cursor_getNumArguments(
+  CXCursor c)
+@cname("clang_Cursor_getNumArguments");
+
+<*
+  Retrieve the argument cursor of a function or method.
+  The argument cursor can be determined for calls as well as for declarations
+  of functions or methods. For other cursors and for invalid indices, an
+  invalid cursor is returned.
+*>
+extern fn CXCursor cursor_getArgument(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getArgument");
+
+<*
+  Describes the kind of a template argument.
+  See the definition of llvm::clang::TemplateArgument::ArgKind for full
+  element descriptions.
+*>
+constdef CXTemplateArgumentKind : CInt {
+  TEMPLATE_ARGUMENT_KIND_NULL = 0,
+  TEMPLATE_ARGUMENT_KIND_TYPE = 1,
+  TEMPLATE_ARGUMENT_KIND_DECLARATION = 2,
+  TEMPLATE_ARGUMENT_KIND_NULL_PTR = 3,
+  TEMPLATE_ARGUMENT_KIND_INTEGRAL = 4,
+  TEMPLATE_ARGUMENT_KIND_TEMPLATE = 5,
+  TEMPLATE_ARGUMENT_KIND_TEMPLATE_EXPANSION = 6,
+  TEMPLATE_ARGUMENT_KIND_EXPRESSION = 7,
+  TEMPLATE_ARGUMENT_KIND_PACK = 8,
+  TEMPLATE_ARGUMENT_KIND_INVALID = 9
+}
+
+<*
+  Returns the number of template args of a function, struct, or class decl
+  representing a template specialization.
+  If the argument cursor cannot be converted into a template function
+  declaration, -1 is returned.
+  For example, for the following declaration and specialization:
+  template <typename T, int kInt, bool kBool>
+  void foo() { ... }
+  template <>
+  void foo<float, -7, true>();
+  The value 3 would be returned from this call.
+*>
+extern fn CInt cursor_getNumTemplateArguments(
+  CXCursor c)
+@cname("clang_Cursor_getNumTemplateArguments");
+
+<*
+  Retrieve the kind of the I'th template argument of the CXCursor C.
+  If the argument CXCursor does not represent a FunctionDecl, StructDecl, or
+  ClassTemplatePartialSpecialization, an invalid template argument kind is
+  returned.
+  For example, for the following declaration and specialization:
+  template <typename T, int kInt, bool kBool>
+  void foo() { ... }
+  template <>
+  void foo<float, -7, true>();
+  For I = 0, 1, and 2, Type, Integral, and Integral will be returned,
+  respectively.
+*>
+extern fn CXTemplateArgumentKind cursor_getTemplateArgumentKind(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getTemplateArgumentKind");
+
+<*
+  Retrieve a CXType representing the type of a TemplateArgument of a
+  function decl representing a template specialization.
+  If the argument CXCursor does not represent a FunctionDecl, StructDecl,
+  ClassDecl or ClassTemplatePartialSpecialization whose I'th template argument
+  has a kind of CXTemplateArgKind_Integral, an invalid type is returned.
+  For example, for the following declaration and specialization:
+  template <typename T, int kInt, bool kBool>
+  void foo() { ... }
+  template <>
+  void foo<float, -7, true>();
+  If called with I = 0, "float", will be returned.
+  Invalid types will be returned for I == 1 or 2.
+*>
+extern fn CXType cursor_getTemplateArgumentType(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getTemplateArgumentType");
+
+<*
+  Retrieve the value of an Integral TemplateArgument (of a function
+  decl representing a template specialization) as a signed long long.
+  It is undefined to call this function on a CXCursor that does not represent a
+  FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization
+  whose I'th template argument is not an integral value.
+  For example, for the following declaration and specialization:
+  template <typename T, int kInt, bool kBool>
+  void foo() { ... }
+  template <>
+  void foo<float, -7, true>();
+  If called with I = 1 or 2, -7 or true will be returned, respectively.
+  For I == 0, this function's behavior is undefined.
+*>
+extern fn CLongLong cursor_getTemplateArgumentValue(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getTemplateArgumentValue");
+
+<*
+  Retrieve the value of an Integral TemplateArgument (of a function
+  decl representing a template specialization) as an unsigned long long.
+  It is undefined to call this function on a CXCursor that does not represent a
+  FunctionDecl, StructDecl, ClassDecl or ClassTemplatePartialSpecialization or
+  whose I'th template argument is not an integral value.
+  For example, for the following declaration and specialization:
+  template <typename T, int kInt, bool kBool>
+  void foo() { ... }
+  template <>
+  void foo<float, 2147483649, true>();
+  If called with I = 1 or 2, 2147483649 or true will be returned, respectively.
+  For I == 0, this function's behavior is undefined.
+*>
+extern fn CULongLong cursor_getTemplateArgumentUnsignedValue(
+  CXCursor c,
+  CUInt i)
+@cname("clang_Cursor_getTemplateArgumentUnsignedValue");
+
+<*
+  Determine whether two CXTypes represent the same type.
+  \returns non-zero if the CXTypes represent the same type and
+  zero otherwise.
+*>
+extern fn CUInt equalTypes(
+  CXType a,
+  CXType b)
+@cname("clang_equalTypes");
+
+<*
+  Return the canonical type for a CXType.
+  Clang's type system explicitly models typedefs and all the ways
+  a specific type can be represented.  The canonical type is the underlying
+  type with all the "sugar" removed.  For example, if 'T' is a typedef
+  for 'int', the canonical type for 'T' would be 'int'.
+*>
+extern fn CXType getCanonicalType(
+  CXType t)
+@cname("clang_getCanonicalType");
+
+<*
+  Determine whether a CXType has the "const" qualifier set,
+  without looking through typedefs that may have added "const" at a
+  different level.
+*>
+extern fn CUInt isConstQualifiedType(
+  CXType t)
+@cname("clang_isConstQualifiedType");
+
+<*
+  Determine whether a  CXCursor that is a macro, is
+  function like.
+*>
+extern fn CUInt cursor_isMacroFunctionLike(
+  CXCursor c)
+@cname("clang_Cursor_isMacroFunctionLike");
+
+<*
+  Determine whether a  CXCursor that is a macro, is a
+  builtin one.
+*>
+extern fn CUInt cursor_isMacroBuiltin(
+  CXCursor c)
+@cname("clang_Cursor_isMacroBuiltin");
+
+<*
+  Determine whether a  CXCursor that is a function declaration, is an
+  inline declaration.
+*>
+extern fn CUInt cursor_isFunctionInlined(
+  CXCursor c)
+@cname("clang_Cursor_isFunctionInlined");
+
+<*
+  Determine whether a CXType has the "volatile" qualifier set,
+  without looking through typedefs that may have added "volatile" at
+  a different level.
+*>
+extern fn CUInt isVolatileQualifiedType(
+  CXType t)
+@cname("clang_isVolatileQualifiedType");
+
+<*
+  Determine whether a CXType has the "restrict" qualifier set,
+  without looking through typedefs that may have added "restrict" at a
+  different level.
+*>
+extern fn CUInt isRestrictQualifiedType(
+  CXType t)
+@cname("clang_isRestrictQualifiedType");
+
+<*
+  Returns the address space of the given type.
+*>
+extern fn CUInt getAddressSpace(
+  CXType t)
+@cname("clang_getAddressSpace");
+
+<*
+  Returns the typedef name of the given type.
+*>
+extern fn CXString getTypedefName(
+  CXType ct)
+@cname("clang_getTypedefName");
+
+<*
+  For pointer types, returns the type of the pointee.
+*>
+extern fn CXType getPointeeType(
+  CXType t)
+@cname("clang_getPointeeType");
+
+<*
+  Retrieve the unqualified variant of the given type, removing as
+  little sugar as possible.
+  For example, given the following series of typedefs:
+  \code
+  typedef int Integer;
+  typedef const Integer CInteger;
+  typedef CInteger DifferenceType;
+  \endcode
+  Executing \c clang_getUnqualifiedType() on a \c CXType that
+  represents \c DifferenceType, will desugar to a type representing
+  \c Integer, that has no qualifiers.
+  And, executing \c clang_getUnqualifiedType() on the type of the
+  first argument of the following function declaration:
+  \code
+  void foo(const int);
+  \endcode
+  Will return a type representing \c int, removing the \c const
+  qualifier.
+  Sugar over array types is not desugared.
+  A type can be checked for qualifiers with \c
+  clang_isConstQualifiedType(), \c clang_isVolatileQualifiedType()
+  and \c clang_isRestrictQualifiedType().
+  A type that resulted from a call to \c clang_getUnqualifiedType
+  will return \c false for all of the above calls.
+*>
+extern fn CXType getUnqualifiedType(
+  CXType ct)
+@cname("clang_getUnqualifiedType");
+
+<*
+  For reference types (e.g., "const int&"), returns the type that the
+  reference refers to (e.g "const int").
+  Otherwise, returns the type itself.
+  A type that has kind \c CXType_LValueReference or
+  \c CXType_RValueReference is a reference type.
+*>
+extern fn CXType getNonReferenceType(
+  CXType ct)
+@cname("clang_getNonReferenceType");
+
+<*
+  Return the cursor for the declaration of the given type.
+*>
+extern fn CXCursor getTypeDeclaration(
+  CXType t)
+@cname("clang_getTypeDeclaration");
+
+<*
+  Returns the Objective-C type encoding for the specified declaration.
+*>
+extern fn CXString getDeclObjCTypeEncoding(
+  CXCursor c)
+@cname("clang_getDeclObjCTypeEncoding");
+
+<*
+  Returns the Objective-C type encoding for the specified CXType.
+*>
+extern fn CXString type_getObjCEncoding(
+  CXType type)
+@cname("clang_Type_getObjCEncoding");
+
+<*
+  Retrieve the spelling of a given CXTypeKind.
+*>
+extern fn CXString getTypeKindSpelling(
+  CXTypeKind k)
+@cname("clang_getTypeKindSpelling");
+
+<*
+  Retrieve the calling convention associated with a function type.
+  If a non-function type is passed in, CXCallingConv_Invalid is returned.
+*>
+extern fn CXCallingConv getFunctionTypeCallingConv(
+  CXType t)
+@cname("clang_getFunctionTypeCallingConv");
+
+<*
+  Retrieve the return type associated with a function type.
+  If a non-function type is passed in, an invalid type is returned.
+*>
+extern fn CXType getResultType(
+  CXType t)
+@cname("clang_getResultType");
+
+<*
+  Retrieve the exception specification type associated with a function type.
+  This is a value of type CXCursor_ExceptionSpecificationKind.
+  If a non-function type is passed in, an error code of -1 is returned.
+*>
+extern fn CInt getExceptionSpecificationType(
+  CXType t)
+@cname("clang_getExceptionSpecificationType");
+
+<*
+  Retrieve the number of non-variadic parameters associated with a
+  function type.
+  If a non-function type is passed in, -1 is returned.
+*>
+extern fn CInt getNumArgTypes(
+  CXType t)
+@cname("clang_getNumArgTypes");
+
+<*
+  Retrieve the type of a parameter of a function type.
+  If a non-function type is passed in or the function does not have enough
+  parameters, an invalid type is returned.
+*>
+extern fn CXType getArgType(
+  CXType t,
+  CUInt i)
+@cname("clang_getArgType");
+
+<*
+  Retrieves the base type of the ObjCObjectType.
+  If the type is not an ObjC object, an invalid type is returned.
+*>
+extern fn CXType type_getObjCObjectBaseType(
+  CXType t)
+@cname("clang_Type_getObjCObjectBaseType");
+
+<*
+  Retrieve the number of protocol references associated with an ObjC object/id.
+  If the type is not an ObjC object, 0 is returned.
+*>
+extern fn CUInt type_getNumObjCProtocolRefs(
+  CXType t)
+@cname("clang_Type_getNumObjCProtocolRefs");
+
+<*
+  Retrieve the decl for a protocol reference for an ObjC object/id.
+  If the type is not an ObjC object or there are not enough protocol
+  references, an invalid cursor is returned.
+*>
+extern fn CXCursor type_getObjCProtocolDecl(
+  CXType t,
+  CUInt i)
+@cname("clang_Type_getObjCProtocolDecl");
+
+<*
+  Retrieve the number of type arguments associated with an ObjC object.
+  If the type is not an ObjC object, 0 is returned.
+*>
+extern fn CUInt type_getNumObjCTypeArgs(
+  CXType t)
+@cname("clang_Type_getNumObjCTypeArgs");
+
+<*
+  Retrieve a type argument associated with an ObjC object.
+  If the type is not an ObjC or the index is not valid,
+  an invalid type is returned.
+*>
+extern fn CXType type_getObjCTypeArg(
+  CXType t,
+  CUInt i)
+@cname("clang_Type_getObjCTypeArg");
+
+<*
+  Return 1 if the CXType is a variadic function type, and 0 otherwise.
+*>
+extern fn CUInt isFunctionTypeVariadic(
+  CXType t)
+@cname("clang_isFunctionTypeVariadic");
+
+<*
+  Retrieve the return type associated with a given cursor.
+  This only returns a valid type if the cursor refers to a function or method.
+*>
+extern fn CXType getCursorResultType(
+  CXCursor c)
+@cname("clang_getCursorResultType");
+
+<*
+  Retrieve the exception specification type associated with a given cursor.
+  This is a value of type CXCursor_ExceptionSpecificationKind.
+  This only returns a valid result if the cursor refers to a function or
+  method.
+*>
+extern fn CInt getCursorExceptionSpecificationType(
+  CXCursor c)
+@cname("clang_getCursorExceptionSpecificationType");
+
+<*
+  Return 1 if the CXType is a POD (plain old data) type, and 0
+  otherwise.
+*>
+extern fn CUInt isPODType(
+  CXType t)
+@cname("clang_isPODType");
+
+<*
+  Return the element type of an array, complex, or vector type.
+  If a type is passed in that is not an array, complex, or vector type,
+  an invalid type is returned.
+*>
+extern fn CXType getElementType(
+  CXType t)
+@cname("clang_getElementType");
+
+<*
+  Return the number of elements of an array or vector type.
+  If a type is passed in that is not an array or vector type,
+  -1 is returned.
+*>
+extern fn CLongLong getNumElements(
+  CXType t)
+@cname("clang_getNumElements");
+
+<*
+  Return the element type of an array type.
+  If a non-array type is passed in, an invalid type is returned.
+*>
+extern fn CXType getArrayElementType(
+  CXType t)
+@cname("clang_getArrayElementType");
+
+<*
+  Return the array size of a constant array.
+  If a non-array type is passed in, -1 is returned.
+*>
+extern fn CLongLong getArraySize(
+  CXType t)
+@cname("clang_getArraySize");
+
+<*
+  Retrieve the type named by the qualified-id.
+  If a non-elaborated type is passed in, an invalid type is returned.
+*>
+extern fn CXType type_getNamedType(
+  CXType t)
+@cname("clang_Type_getNamedType");
+
+<*
+  Determine if a typedef is 'transparent' tag.
+  A typedef is considered 'transparent' if it shares a name and spelling
+  location with its underlying tag type, as is the case with the NS_ENUM macro.
+  \returns non-zero if transparent and zero otherwise.
+*>
+extern fn CUInt type_isTransparentTagTypedef(
+  CXType t)
+@cname("clang_Type_isTransparentTagTypedef");
+
+constdef CXTypeNullabilityKind : CInt {
+
+  <*
+    Values of this type can never be null.
+  *>
+  TYPE_NULLABILITY_NON_NULL = 0,
+
+  <*
+    Values of this type can be null.
+  *>
+  TYPE_NULLABILITY_NULLABLE = 1,
+
+  <*
+    Whether values of this type can be null is (explicitly)
+    unspecified. This captures a (fairly rare) case where we
+    can't conclude anything about the nullability of the type even
+    though it has been considered.
+  *>
+  TYPE_NULLABILITY_UNSPECIFIED = 2,
+
+  <*
+    Nullability is not applicable to this type.
+  *>
+  TYPE_NULLABILITY_INVALID = 3,
+
+  <*
+    Generally behaves like Nullable, except when used in a block parameter that
+    was imported into a swift async method. There, swift will assume that the
+    parameter can get null even if no error occurred. _Nullable parameters are
+    assumed to only get null on error.
+  *>
+  TYPE_NULLABILITY_NULLABLE_RESULT = 4
+}
+
+<*
+  Retrieve the nullability kind of a pointer type.
+*>
+extern fn CXTypeNullabilityKind type_getNullability(
+  CXType t)
+@cname("clang_Type_getNullability");
+
+<*
+  List the possible error codes for \c clang_Type_getSizeOf,
+  \c clang_Type_getAlignOf, \c clang_Type_getOffsetOf,
+  \c clang_Cursor_getOffsetOf, and \c clang_getOffsetOfBase.
+  A value of this enumeration type can be returned if the target type is not
+  a valid argument to sizeof, alignof or offsetof.
+*>
+constdef CXTypeLayoutError : CInt {
+
+  <*
+    Type is of kind CXType_Invalid.
+  *>
+  TYPE_LAYOUT_ERROR_INVALID = -1,
+
+  <*
+    The type is an incomplete Type.
+  *>
+  TYPE_LAYOUT_ERROR_INCOMPLETE = -2,
+
+  <*
+    The type is a dependent Type.
+  *>
+  TYPE_LAYOUT_ERROR_DEPENDENT = -3,
+
+  <*
+    The type is not a constant size type.
+  *>
+  TYPE_LAYOUT_ERROR_NOT_CONSTANT_SIZE = -4,
+
+  <*
+    The Field name is not valid for this record.
+  *>
+  TYPE_LAYOUT_ERROR_INVALID_FIELD_NAME = -5,
+
+  <*
+    The type is undeduced.
+  *>
+  TYPE_LAYOUT_ERROR_UNDEDUCED = -6
+}
+
+<*
+  Return the alignment of a type in bytes as per C++[expr.alignof]
+  standard.
+  If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
+  If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
+  is returned.
+  If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
+  returned.
+  If the type declaration is not a constant size type,
+  CXTypeLayoutError_NotConstantSize is returned.
+*>
+extern fn CLongLong type_getAlignOf(
+  CXType t)
+@cname("clang_Type_getAlignOf");
+
+<*
+  Return the class type of an member pointer type.
+  If a non-member-pointer type is passed in, an invalid type is returned.
+*>
+extern fn CXType type_getClassType(
+  CXType t)
+@cname("clang_Type_getClassType");
+
+<*
+  Return the size of a type in bytes as per C++[expr.sizeof] standard.
+  If the type declaration is invalid, CXTypeLayoutError_Invalid is returned.
+  If the type declaration is an incomplete type, CXTypeLayoutError_Incomplete
+  is returned.
+  If the type declaration is a dependent type, CXTypeLayoutError_Dependent is
+  returned.
+*>
+extern fn CLongLong type_getSizeOf(
+  CXType t)
+@cname("clang_Type_getSizeOf");
+
+<*
+  Return the offset of a field named S in a record of type T in bits
+  as it would be returned by __offsetof__ as per C++11[18.2p4]
+  If the cursor is not a record field declaration, CXTypeLayoutError_Invalid
+  is returned.
+  If the field's type declaration is an incomplete type,
+  CXTypeLayoutError_Incomplete is returned.
+  If the field's type declaration is a dependent type,
+  CXTypeLayoutError_Dependent is returned.
+  If the field's name S is not found,
+  CXTypeLayoutError_InvalidFieldName is returned.
+*>
+extern fn CLongLong type_getOffsetOf(
+  CXType t,
+  ZString s)
+@cname("clang_Type_getOffsetOf");
+
+<*
+  Return the type that was modified by this attributed type.
+  If the type is not an attributed type, an invalid type is returned.
+*>
+extern fn CXType type_getModifiedType(
+  CXType t)
+@cname("clang_Type_getModifiedType");
+
+<*
+  Gets the type contained by this atomic type.
+  If a non-atomic type is passed in, an invalid type is returned.
+*>
+extern fn CXType type_getValueType(
+  CXType ct)
+@cname("clang_Type_getValueType");
+
+<*
+  Return the offset of the field represented by the Cursor.
+  If the cursor is not a field declaration, -1 is returned.
+  If the cursor semantic parent is not a record field declaration,
+  CXTypeLayoutError_Invalid is returned.
+  If the field's type declaration is an incomplete type,
+  CXTypeLayoutError_Incomplete is returned.
+  If the field's type declaration is a dependent type,
+  CXTypeLayoutError_Dependent is returned.
+  If the field's name S is not found,
+  CXTypeLayoutError_InvalidFieldName is returned.
+*>
+extern fn CLongLong cursor_getOffsetOfField(
+  CXCursor c)
+@cname("clang_Cursor_getOffsetOfField");
+
+<*
+  Determine whether the given cursor represents an anonymous
+  tag or namespace
+*>
+extern fn CUInt cursor_isAnonymous(
+  CXCursor c)
+@cname("clang_Cursor_isAnonymous");
+
+<*
+  Determine whether the given cursor represents an anonymous record
+  declaration.
+*>
+extern fn CUInt cursor_isAnonymousRecordDecl(
+  CXCursor c)
+@cname("clang_Cursor_isAnonymousRecordDecl");
+
+<*
+  Determine whether the given cursor represents an inline namespace
+  declaration.
+*>
+extern fn CUInt cursor_isInlineNamespace(
+  CXCursor c)
+@cname("clang_Cursor_isInlineNamespace");
+
+constdef CXRefQualifierKind : CInt {
+
+  <*
+    No ref-qualifier was provided. *
+  *>
+  REF_QUALIFIER_NONE = 0,
+
+  <*
+    An lvalue ref-qualifier was provided (\c &). *
+  *>
+  REF_QUALIFIER_L_VALUE = 1,
+
+  <*
+    An rvalue ref-qualifier was provided (\c &&). *
+  *>
+  REF_QUALIFIER_R_VALUE = 2
+}
+
+<*
+  Returns the number of template arguments for given template
+  specialization, or -1 if type \c T is not a template specialization.
+*>
+extern fn CInt type_getNumTemplateArguments(
+  CXType t)
+@cname("clang_Type_getNumTemplateArguments");
+
+<*
+  Returns the type template argument of a template class specialization
+  at given index.
+  This function only returns template type arguments and does not handle
+  template template arguments or variadic packs.
+*>
+extern fn CXType type_getTemplateArgumentAsType(
+  CXType t,
+  CUInt i)
+@cname("clang_Type_getTemplateArgumentAsType");
+
+<*
+  Retrieve the ref-qualifier kind of a function or method.
+  The ref-qualifier is returned for C++ functions or methods. For other types
+  or non-C++ declarations, CXRefQualifier_None is returned.
+*>
+extern fn CXRefQualifierKind type_getCXXRefQualifier(
+  CXType t)
+@cname("clang_Type_getCXXRefQualifier");
+
+<*
+  Returns 1 if the base class specified by the cursor with kind
+  CX_CXXBaseSpecifier is virtual.
+*>
+extern fn CUInt isVirtualBase(
+  CXCursor)
+@cname("clang_isVirtualBase");
+
+<*
+  Returns the offset in bits of a CX_CXXBaseSpecifier relative to the parent
+  class.
+  Returns a small negative number if the offset cannot be computed. See
+  CXTypeLayoutError for error codes.
+*>
+extern fn CLongLong getOffsetOfBase(
+  CXCursor parent,
+  CXCursor base)
+@cname("clang_getOffsetOfBase");
+
+<*
+  Represents the C++ access control level to a base class for a
+  cursor with kind CX_CXXBaseSpecifier.
+*>
+constdef CX_CXXAccessSpecifier : CInt {
+  _CXX_INVALID_ACCESS_SPECIFIER = 0,
+  _CXX_PUBLIC = 1,
+  _CXX_PROTECTED = 2,
+  _CXX_PRIVATE = 3
+}
+
+<*
+  Returns the access control level for the referenced object.
+  If the cursor refers to a C++ declaration, its access control level within
+  its parent scope is returned. Otherwise, if the cursor refers to a base
+  specifier or access specifier, the specifier itself is returned.
+*>
+extern fn CX_CXXAccessSpecifier getCXXAccessSpecifier(
+  CXCursor)
+@cname("clang_getCXXAccessSpecifier");
+
+<*
+  Represents the storage classes as declared in the source. CX_SC_Invalid
+  was added for the case that the passed cursor in not a declaration.
+*>
+constdef CX_StorageClass : CInt {
+  _SC_INVALID = 0,
+  _SC_NONE = 1,
+  _SC_EXTERN = 2,
+  _SC_STATIC = 3,
+  _SC_PRIVATE_EXTERN = 4,
+  _SC_OPEN_CL_WORK_GROUP_LOCAL = 5,
+  _SC_AUTO = 6,
+  _SC_REGISTER = 7
+}
+
+<*
+  Represents a specific kind of binary operator which can appear at a cursor.
+*>
+constdef CX_BinaryOperatorKind : CInt {
+  _BO_INVALID = 0,
+  _BO_PTR_MEM_D = 1,
+  _BO_PTR_MEM_I = 2,
+  _BO_MUL = 3,
+  _BO_DIV = 4,
+  _BO_REM = 5,
+  _BO_ADD = 6,
+  _BO_SUB = 7,
+  _BO_SHL = 8,
+  _BO_SHR = 9,
+  _BO_CMP = 10,
+  _BO_LT = 11,
+  _BO_GT = 12,
+  _BO_LE = 13,
+  _BO_GE = 14,
+  _BO_EQ = 15,
+  _BO_NE = 16,
+  _BO_AND = 17,
+  _BO_XOR = 18,
+  _BO_OR = 19,
+  _BO_L_AND = 20,
+  _BO_L_OR = 21,
+  _BO_ASSIGN = 22,
+  _BO_MUL_ASSIGN = 23,
+  _BO_DIV_ASSIGN = 24,
+  _BO_REM_ASSIGN = 25,
+  _BO_ADD_ASSIGN = 26,
+  _BO_SUB_ASSIGN = 27,
+  _BO_SHL_ASSIGN = 28,
+  _BO_SHR_ASSIGN = 29,
+  _BO_AND_ASSIGN = 30,
+  _BO_XOR_ASSIGN = 31,
+  _BO_OR_ASSIGN = 32,
+  _BO_COMMA = 33,
+  _BO_LAST = 33
+}
+
+<*
+  \brief Returns the operator code for the binary operator.
+  @deprecated "use clang_getCursorBinaryOperatorKind instead."
+*>
+extern fn CX_BinaryOperatorKind cursor_getBinaryOpcode(
+  CXCursor c)
+@cname("clang_Cursor_getBinaryOpcode");
+
+<*
+  \brief Returns a string containing the spelling of the binary operator.
+  @deprecated "use clang_getBinaryOperatorKindSpelling instead"
+*>
+extern fn CXString cursor_getBinaryOpcodeStr(
+  CX_BinaryOperatorKind op)
+@cname("clang_Cursor_getBinaryOpcodeStr");
+
+<*
+  Returns the storage class for a function or variable declaration.
+  If the passed in Cursor is not a function or variable declaration,
+  CX_SC_Invalid is returned else the storage class.
+*>
+extern fn CX_StorageClass cursor_getStorageClass(
+  CXCursor)
+@cname("clang_Cursor_getStorageClass");
+
+<*
+  Determine the number of overloaded declarations referenced by a
+  \c CXCursor_OverloadedDeclRef cursor.
+  \param cursor The cursor whose overloaded declarations are being queried.
+  \returns The number of overloaded declarations referenced by \c cursor. If it
+  is not a \c CXCursor_OverloadedDeclRef cursor, returns 0.
+*>
+extern fn CUInt getNumOverloadedDecls(
+  CXCursor cursor)
+@cname("clang_getNumOverloadedDecls");
+
+<*
+  Retrieve a cursor for one of the overloaded declarations referenced
+  by a \c CXCursor_OverloadedDeclRef cursor.
+  \param cursor The cursor whose overloaded declarations are being queried.
+  \param index The zero-based index into the set of overloaded declarations in
+  the cursor.
+  \returns A cursor representing the declaration referenced by the given
+  \c cursor at the specified \c index. If the cursor does not have an
+  associated set of overloaded declarations, or if the index is out of bounds,
+  returns \c clang_getNullCursor();
+*>
+extern fn CXCursor getOverloadedDecl(
+  CXCursor cursor,
+  CUInt index)
+@cname("clang_getOverloadedDecl");
+
+<*
+  For cursors representing an iboutletcollection attribute,
+  this function returns the collection element type.
+*>
+extern fn CXType getIBOutletCollectionType(
+  CXCursor)
+@cname("clang_getIBOutletCollectionType");
+
+<*
+  Describes how the traversal of the children of a particular
+  cursor should proceed after visiting a particular child cursor.
+  A value of this enumeration type should be returned by each
+  \c CXCursorVisitor to indicate how clang_visitChildren() proceed.
+*>
+constdef CXChildVisitResult : CInt {
+
+  <*
+    Terminates the cursor traversal.
+  *>
+  CHILD_VISIT_BREAK = 0,
+
+  <*
+    Continues the cursor traversal with the next sibling of
+    the cursor just visited, without visiting its children.
+  *>
+  CHILD_VISIT_CONTINUE = 1,
+
+  <*
+    Recursively traverse the children of this cursor, using
+    the same visitor and client data.
+  *>
+  CHILD_VISIT_RECURSE = 2
+}
+
 alias CXCursorVisitor = fn CXChildVisitResult(
-  CXCursor cursor, 
-  CXCursor parent, 
+  CXCursor cursor,
+  CXCursor parent,
   CXClientData client_data);
 
-/**
- * Visit the children of a particular cursor.
- *
- * This function visits all the direct children of the given cursor,
- * invoking the given \p visitor function with the cursors of each
- * visited child. The traversal may be recursive, if the visitor returns
- * \c CXChildVisit_Recurse. The traversal may also be ended prematurely, if
- * the visitor returns \c CXChildVisit_Break.
- *
- * \param parent the cursor whose child may be visited. All kinds of
- * cursors can be visited, including invalid cursors (which, by
- * definition, have no children).
- *
- * \param visitor the visitor function that will be invoked for each
- * child of \p parent.
- *
- * \param client_data pointer data supplied by the client, which will
- * be passed to the visitor each time it is invoked.
- *
- * \returns a non-zero value if the traversal was terminated
- * prematurely by the visitor returning \c CXChildVisit_Break.
- */
-fn CUInt visitChildren(
-  CXCursor parent, 
-  CXCursorVisitor visitor, 
-  CXClientData client_data) 
-@extern("clang_visitChildren");
-
-/**
- * Visitor invoked for each cursor found by a traversal.
- *
- * This visitor block will be invoked for each cursor found by
- * clang_visitChildrenWithBlock(). Its first argument is the cursor being
- * visited, its second argument is the parent visitor for that cursor.
- *
- * The visitor should return one of the \c CXChildVisitResult values
- * to direct clang_visitChildrenWithBlock().
- */
-typedef CXCursorVisitorBlock = void*;
-
-/**
- * Visits the children of a cursor using the specified block.  Behaves
- * identically to clang_visitChildren() in all other respects.
- */
-fn CUInt visitChildrenWithBlock(
-  CXCursor parent, 
-  CXCursorVisitorBlock block) 
-@extern("clang_visitChildrenWithBlock");
-
-/**
- * Retrieve a Unified Symbol Resolution (USR) for the entity referenced
- * by the given cursor.
- *
- * A Unified Symbol Resolution (USR) is a string that identifies a particular
- * entity (function, class, variable, etc.) within a program. USRs can be
- * compared across translation units to determine, e.g., when references in
- * one translation refer to an entity defined in another translation unit.
- */
-fn CXString getCursorUSR(
-  CXCursor c) 
-@extern("clang_getCursorUSR");
-
-/**
- * Construct a USR for a specified Objective-C class.
- */
-fn CXString constructUSR_ObjCClass(
-  ZString class_name) 
-@extern("clang_constructUSR_ObjCClass");
-
-/**
- * Construct a USR for a specified Objective-C category.
- */
-fn CXString constructUSR_ObjCCategory(
-  ZString class_name, 
-  ZString category_name) 
-@extern("clang_constructUSR_ObjCCategory");
-
-/**
- * Construct a USR for a specified Objective-C protocol.
- */
-fn CXString constructUSR_ObjCProtocol(
-  ZString protocol_name) 
-@extern("clang_constructUSR_ObjCProtocol");
-
-/**
- * Construct a USR for a specified Objective-C instance variable and
- *   the USR for its containing class.
- */
-fn CXString constructUSR_ObjCIvar(
-  ZString name, 
-  CXString classUSR) 
-@extern("clang_constructUSR_ObjCIvar");
-
-/**
- * Construct a USR for a specified Objective-C method and
- *   the USR for its containing class.
- */
-fn CXString constructUSR_ObjCMethod(
-  ZString name, 
-  CUInt is_instance_method, 
-  CXString classUSR) 
-@extern("clang_constructUSR_ObjCMethod");
-
-/**
- * Construct a USR for a specified Objective-C property and the USR
- *  for its containing class.
- */
-fn CXString constructUSR_ObjCProperty(
-  ZString property, 
-  CXString classUSR) 
-@extern("clang_constructUSR_ObjCProperty");
-
-/**
- * Retrieve a name for the entity referenced by this cursor.
- */
-fn CXString getCursorSpelling(
-  CXCursor cursor) 
-@extern("clang_getCursorSpelling");
-
-/**
- * Retrieve a range for a piece that forms the cursors spelling name.
- * Most of the times there is only one range for the complete spelling but for
- * Objective-C methods and Objective-C message expressions, there are multiple
- * pieces for each selector identifier.
- *
- * \param pieceIndex the index of the spelling name piece. If this is greater
- * than the actual number of pieces, it will return a NULL (invalid) range.
- *
- * \param options Reserved.
- */
-fn CXSourceRange getSpellingNameRange_Cursor(
-  CXCursor cursor, 
-  CUInt piece_index, 
-  CUInt options) 
-@extern("clang_Cursor_getSpellingNameRange");
-
-/**
- * Opaque pointer representing a policy that controls pretty printing
- * for \c clang_getCursorPrettyPrinted.
- */
-typedef CXPrintingPolicy = inline void*;
-
-/**
- * Properties for the printing policy.
- *
- * See \c clang::PrintingPolicy for more information.
- */
-typedef CXPrintingPolicyProperty = inline CInt;
-
-const CXPrintingPolicyProperty PRINTING_POLICY_INDENTATION = 0;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_SPECIFIERS = 1;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_TAG_KEYWORD = 2;
-const CXPrintingPolicyProperty PRINTING_POLICY_INCLUDE_TAG_DEFINITION = 3;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_SCOPE = 4;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_UNWRITTEN_SCOPE = 5;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_INITIALIZERS = 6;
-const CXPrintingPolicyProperty PRINTING_POLICY_CONSTANT_ARRAY_SIZE_AS_WRITTEN = 7;
-const CXPrintingPolicyProperty PRINTING_POLICY_ANONYMOUS_TAG_LOCATIONS = 8;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_STRONG_LIFETIME = 9;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_LIFETIME_QUALIFIERS = 10;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_TEMPLATE_ARGS_IN_CXX_CONSTRUCTORS = 11;
-const CXPrintingPolicyProperty PRINTING_POLICY_BOOL = 12;
-const CXPrintingPolicyProperty PRINTING_POLICY_RESTRICT = 13;
-const CXPrintingPolicyProperty PRINTING_POLICY_ALIGNOF = 14;
-const CXPrintingPolicyProperty PRINTING_POLICY_UNDERSCORE_ALIGNOF = 15;
-const CXPrintingPolicyProperty PRINTING_POLICY_USE_VOID_FOR_ZERO_PARAMS = 16;
-const CXPrintingPolicyProperty PRINTING_POLICY_TERSE_OUTPUT = 17;
-const CXPrintingPolicyProperty PRINTING_POLICY_POLISH_FOR_DECLARATION = 18;
-const CXPrintingPolicyProperty PRINTING_POLICY_HALF = 19;
-const CXPrintingPolicyProperty PRINTING_POLICY_MS_WCHAR = 20;
-const CXPrintingPolicyProperty PRINTING_POLICY_INCLUDE_NEW_LINES = 21;
-const CXPrintingPolicyProperty PRINTING_POLICY_MSVC_FORMATTING = 22;
-const CXPrintingPolicyProperty PRINTING_POLICY_CONSTANTS_AS_WRITTEN = 23;
-const CXPrintingPolicyProperty PRINTING_POLICY_SUPPRESS_IMPLICIT_BASE = 24;
-const CXPrintingPolicyProperty PRINTING_POLICY_FULLY_QUALIFIED_NAME = 25;
-
-const CXPrintingPolicyProperty PRINTING_POLICY_LAST_PROPERTY = PRINTING_POLICY_FULLY_QUALIFIED_NAME;
-
-/**
- * Get a property value for the given printing policy.
- */
-fn CUInt getProperty_PrintingPolicy(
-  CXPrintingPolicy policy, 
-  CXPrintingPolicyProperty property) 
-@extern("clang_PrintingPolicy_getProperty");
-
-/**
- * Set a property value for the given printing policy.
- */
-fn void setProperty_PrintingPolicy(
-  CXPrintingPolicy policy, 
-  CXPrintingPolicyProperty property, 
-  CUInt value) 
-@extern("clang_PrintingPolicy_setProperty");
-
-/**
- * Retrieve the default policy for the cursor.
- *
- * The policy should be released after use with \c
- * clang_PrintingPolicy_dispose.
- */
-fn CXPrintingPolicy getCursorPrintingPolicy(
-  CXCursor cursor) 
-@extern("clang_getCursorPrintingPolicy");
-
-/**
- * Release a printing policy.
- */
-fn void dispose_PrintingPolicy(
-  CXPrintingPolicy policy) 
-@extern("clang_PrintingPolicy_dispose");
-
-/**
- * Pretty prCInt declarations.
- *
- * \param Cursor The cursor representing a declaration.
- *
- * \param Policy The policy to control the entities being printed. If
- * NULL, a default policy is used.
- *
- * \returns The pretty printed declaration or the empty string for
- * other cursors.
- */
-fn CXString getCursorPrettyPrinted(
-  CXCursor cursor, 
-  CXPrintingPolicy policy) 
-@extern("clang_getCursorPrettyPrinted");
-
-/**
- * Retrieve the display name for the entity referenced by this cursor.
- *
- * The display name contains extra information that helps identify the cursor,
- * such as the parameters of a function or template or the arguments of a
- * class template specialization.
- */
-fn CXString getCursorDisplayName(
-  CXCursor cursor) 
-@extern("clang_getCursorDisplayName");
-
-/** For a cursor that is a reference, retrieve a cursor representing the
- * entity that it references.
- *
- * Reference cursors refer to other entities in the AST. For example, an
- * Objective-C superclass reference cursor refers to an Objective-C class.
- * This function produces the cursor for the Objective-C class from the
- * cursor for the superclass reference. If the input cursor is a declaration or
- * definition, it returns that declaration or definition unchanged.
- * Otherwise, returns the NULL cursor.
- */
-fn CXCursor getCursorReferenced(
-  CXCursor cursor) 
-@extern("clang_getCursorReferenced");
-
-/**
- *  For a cursor that is either a reference to or a declaration
- *  of some entity, retrieve a cursor that describes the definition of
- *  that entity.
- *
- *  Some entities can be declared multiple times within a translation
- *  unit, but only one of those declarations can also be a
- *  definition. For example, given:
- *
- *  \code
- *  CInt f(CInt, CInt);
- *  CInt g(CInt x, CInt y) { return f(x, y); }
- *  CInt f(CInt a, CInt b) { return a + b; }
- *  CInt f(CInt, CInt);
- *  \endcode
- *
- *  there are three declarations of the function "f", but only the
- *  second one is a definition. The clang_getCursorDefinition()
- *  function will take any cursor pointing to a declaration of "f"
- *  (the first or fourth lines of the example) or a cursor referenced
- *  that uses "f" (the call to "f' inside "g") and will return a
- *  declaration cursor pointing to the definition (the second "f"
- *  declaration).
- *
- *  If given a cursor for which there is no corresponding definition,
- *  e.g., because there is no definition of that entity within this
- *  translation unit, returns a NULL cursor.
- */
-fn CXCursor getCursorDefinition(
-  CXCursor cursor) 
-@extern("clang_getCursorDefinition");
-
-/**
- * Determine whether the declaration pointed to by this cursor
- * is also a definition of that entity.
- */
-fn CUInt isCursorDefinition(
-  CXCursor cursor) 
-@extern("clang_isCursorDefinition");
-
-/**
- * Retrieve the canonical cursor corresponding to the given cursor.
- *
- * In the C family of languages, many kinds of entities can be declared several
- * times within a single translation unit. For example, a structure type can
- * be forward-declared (possibly multiple times) and later defined:
- *
- * \code
- * struct X;
- * struct X;
- * struct X {
- *   CInt member;
- * };
- * \endcode
- *
- * The declarations and the definition of \c X are represented by three
- * different cursors, all of which are declarations of the same underlying
- * entity. One of these cursor is considered the "canonical" cursor, which
- * is effectively the representative for the underlying entity. One can
- * determine if two cursors are declarations of the same underlying entity by
- * comparing their canonical cursors.
- *
- * \returns The canonical cursor for the entity referred to by the given cursor.
- */
-fn CXCursor getCanonicalCursor(
-  CXCursor cursor) 
-@extern("clang_getCanonicalCursor");
-
-/**
- * If the cursor points to a selector identifier in an Objective-C
- * method or message expression, this returns the selector index.
- *
- * After getting a cursor with #clang_getCursor, this can be called to
- * determine if the location points to a selector identifier.
- *
- * \returns The selector index if the cursor is an Objective-C method or message
- * expression and the cursor is pointing to a selector identifier, or -1
- * otherwise.
- */
-fn CInt getObjCSelectorIndex_Cursor(
-  CXCursor cursor) 
-@extern("clang_Cursor_getObjCSelectorIndex");
-
-/**
- * Given a cursor pointing to a C++ method call or an Objective-C
- * message, returns non-zero if the method/message is "dynamic", meaning:
- *
- * For a C++ method: the call is virtual.
- * For an Objective-C message: the receiver is an object instance, not 'super'
- * or a specific class.
- *
- * If the method/message is "static" or the cursor does not poCInt to a
- * method/message, it will return zero.
- */
-fn CInt isDynamicCall_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isDynamicCall");
-
-/**
- * Given a cursor pointing to an Objective-C message or property
- * reference, or C++ method call, returns the CXType of the receiver.
- */
-fn CXType getReceiverType_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getReceiverType");
-
-/**
- * Property attributes for a \c CXCursor_ObjCPropertyDecl.
- */
-typedef CXObjCPropertyAttrKind = inline CInt;
-
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_NOATTR = 0x00;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_READONLY = 0x01;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_GETTER = 0x02;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_ASSIGN = 0x04;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_READWRITE = 0x08;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_RETAIN = 0x10;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_COPY = 0x20;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_NONATOMIC = 0x40;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_SETTER = 0x80;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_ATOMIC = 0x100;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_WEAK = 0x200;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_STRONG = 0x400;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_UNSAFE_UNRETAINED = 0x800;
-const CXObjCPropertyAttrKind OBJC_PROPERTY_ATTR_CLASS = 0x1000;
-
-/**
- * Given a cursor that represents a property declaration, return the
- * associated property attributes. The bits are formed from
- * \c CXObjCPropertyAttrKind.
- *
- * \param reserved Reserved for future use, pass 0.
- */
-fn CUInt getObjCPropertyAttributes_Cursor(
-  CXCursor c, 
-  CUInt reserved) 
-@extern("clang_Cursor_getObjCPropertyAttributes");
-
-/**
- * Given a cursor that represents a property declaration, return the
- * name of the method that implements the getter.
- */
-fn CXString getObjCPropertyGetterName_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getObjCPropertyGetterName");
-
-/**
- * Given a cursor that represents a property declaration, return the
- * name of the method that implements the setter, if any.
- */
-fn CXString getObjCPropertySetterName_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getObjCPropertySetterName");
-
-/**
- * 'Qualifiers' written next to the return and parameter types in
- * Objective-C method declarations.
- */
-typedef CXObjCDeclQualifierKind = inline CInt;
-
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_NONE = 0x0;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_IN = 0x1;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_INOUT = 0x2;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_OUT = 0x4;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_BYCOPY = 0x8;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_BYREF = 0x10;
-const CXObjCPropertyAttrKind OBJC_DECL_QUALIFIER_ONEWAY = 0x20;
-
-/**
- * Given a cursor that represents an Objective-C method or parameter
- * declaration, return the associated Objective-C qualifiers for the return
- * type or the parameter respectively. The bits are formed from
- * CXObjCDeclQualifierKind.
- */
-fn CUInt getObjCDeclQualifiers_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getObjCDeclQualifiers");
-
-/**
- * Given a cursor that represents an Objective-C method or property
- * declaration, return non-zero if the declaration was affected by "\@optional".
- * Returns zero if the cursor is not such a declaration or it is "\@required".
- */
-fn CUInt isObjCOptional_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isObjCOptional");
-
-/**
- * Returns non-zero if the given cursor is a variadic function or method.
- */
-fn CUInt isVariadic_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_isVariadic");
-
-/**
- * Returns non-zero if the given cursor points to a symbol marked with
- * external_source_symbol attribute.
- *
- * \param language If non-NULL, and the attribute is present, will be set to
- * the 'language' string from the attribute.
- *
- * \param definedIn If non-NULL, and the attribute is present, will be set to
- * the 'definedIn' string from the attribute.
- *
- * \param isGenerated If non-NULL, and the attribute is present, will be set to
- * non-zero if the 'generated_declaration' is set in the attribute.
- */
-fn CUInt isExternalSymbol_Cursor(
-  CXCursor c, 
-  CXString* language, 
-  CXString* definedIn, 
-  CUInt* isGenerated) 
-@extern("clang_Cursor_isExternalSymbol");
-
-/**
- * Given a cursor that represents a declaration, return the associated
- * comment's source range.  The range may include multiple consecutive comments
- * with whitespace in between.
- */
-fn CXSourceRange getCommentRange_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getCommentRange");
-
-/**
- * Given a cursor that represents a declaration, return the associated
- * comment text, including comment markers.
- */
-fn CXString getRawCommentText_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getRawCommentText");
-
-/**
- * Given a cursor that represents a documentable entity (e.g.,
- * declaration), return the associated \paragraph; otherwise return the
- * first paragraph.
- */
-fn CXString getBriefCommentText_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getBriefCommentText");
-
-/**
- * Retrieve the CXString representing the mangled name of the cursor.
- */
-fn CXString getMangling_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getMangling");
-
-/**
- * Retrieve the CXStrings representing the mangled symbols of the C++
- * constructor or destructor at the cursor.
- */
-fn CXStringSet* getCXXManglings_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getCXXManglings");
-
-/**
- * Retrieve the CXStrings representing the mangled symbols of the ObjC
- * class interface or implementation at the cursor.
- */
-fn CXStringSet* getObjCManglings_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getObjCManglings");
-
-typedef CXModule = inline void*;
-
-/**
- * Given a CXCursor_ModuleImportDecl cursor, return the associated module.
- */
-fn CXModule getModule_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_getModule");
-
-/**
- * Given a CXFile header file, return the module that contains it, if one
- * exists.
- */
-fn CXModule getModuleForFile(
-  CXTranslationUnit tu, 
-  CXFile file) 
-@extern("clang_getModuleForFile");
-
-/**
- * \param Module a module object.
- *
- * \returns the module file where the provided module object came from.
- */
-fn CXFile getASTFile_Module(
-  CXModule mod) 
-@extern("clang_Module_getASTFile");
-
-/**
- * \param Module a module object.
- *
- * \returns the parent of a sub-module or NULL if the given module is top-level,
- * e.g. for 'std.vector' it will return the 'std' module.
- */
-fn CXModule getParent_Module(
-  CXModule mod) 
-@extern("clang_Module_getParent");
-
-/**
- * \param Module a module object.
- *
- * \returns the name of the module, e.g. for the 'std.vector' sub-module it
- * will return "vector".
- */
-fn CXString getName_Module(
-  CXModule mod) 
-@extern("clang_Module_getName");
-
-/**
- * \param Module a module object.
- *
- * \returns the full name of the module, e.g. "std.vector".
- */
-fn CXString getFullName_Module(
-  CXModule mod) 
-@extern("clang_Module_getFullName");
-
-/**
- * \param Module a module object.
- *
- * \returns non-zero if the module is a system one.
- */
-fn CInt isSystem_Module(
-  CXModule mod) 
-@extern("clang_Module_isSystem");
-
-/**
- * \param Module a module object.
- *
- * \returns the number of top level headers associated with this module.
- */
-fn CUInt getNumTopLevelHeaders_Module(
-  CXModule mod, 
-  CXTranslationUnit tu)
-@extern("clang_Module_getNumTopLevelHeaders");
-
-/**
- * \param Module a module object.
- *
- * \param Index top level header index (zero-based).
- *
- * \returns the specified top level header associated with the module.
- */
-fn CXFile getTopLevelHeader_Module(
-  CXModule mod, 
-  CXTranslationUnit tu, 
-  CUInt index) 
-@extern("clang_Module_getTopLevelHeader");
-
-/**
- * Determine if a C++ constructor is a converting constructor.
- */
-fn CUInt isConvertingConstructor_CXXConstructor(
-  CXCursor c) 
-@extern("clang_CXXConstructor_isConvertingConstructor");
-
-/**
- * Determine if a C++ constructor is a copy constructor.
- */
-fn CUInt isCopyConstructor_CXXConstructor(
-  CXCursor c) 
-@extern("clang_CXXConstructor_isCopyConstructor");
-
-/**
- * Determine if a C++ constructor is the default constructor.
- */
-fn CUInt isDefaultConstructor_CXXConstructor(
-  CXCursor c) 
-@extern("clang_CXXConstructor_isDefaultConstructor");
-
-/**
- * Determine if a C++ constructor is a move constructor.
- */
-fn CUInt isMoveConstructor_CXXConstructor(
-  CXCursor c) 
-@extern("clang_CXXConstructor_isMoveConstructor");
-
-/**
- * Determine if a C++ field is declared 'mutable'.
- */
-fn CUInt isMutable_CXXField(
-  CXCursor c) 
-@extern("clang_CXXField_isMutable");
-
-/**
- * Determine if a C++ method is declared '= default'.
- */
-fn CUInt isDefaulted_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isDefaulted");
-
-/**
- * Determine if a C++ method is declared '= delete'.
- */
-fn CUInt isDeleted_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isDeleted");
-
-/**
- * Determine if a C++ member function or member function template is
- * pure virtual.
- */
-fn CUInt isPureVirtual_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isPureVirtual");
-
-/**
- * Determine if a C++ member function or member function template is
- * declared 'static'.
- */
-fn CUInt isStatic_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isStatic");
-
-/**
- * Determine if a C++ member function or member function template is
- * explicitly declared 'virtual' or if it overrides a virtual method from
- * one of the base classes.
- */
-fn CUInt isVirtual_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isVirtual");
-
-/**
- * Determine if a C++ member function is a copy-assignment operator,
- * returning 1 if such is the case and 0 otherwise.
- *
- * > A copy-assignment operator `X::operator=` is a non-static,
- * > non-template member function of _class_ `X` with exactly one
- * > parameter of type `X`, `X&`, `const X&`, `volatile X&` or `const
- * > volatile X&`.
- *
- * That is, for example, the `operator=` in:
- *
- *    class Foo {
- *        bool operator=(const volatile Foo&);
- *    };
- *
- * Is a copy-assignment operator, while the `operator=` in:
- *
- *    class Bar {
- *        bool operator=(const CInt&);
- *    };
- *
- * Is not.
- */
-fn CUInt isCopyAssignmentOperator_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isCopyAssignmentOperator");
-
-/**
- * Determine if a C++ member function is a move-assignment operator,
- * returning 1 if such is the case and 0 otherwise.
- *
- * > A move-assignment operator `X::operator=` is a non-static,
- * > non-template member function of _class_ `X` with exactly one
- * > parameter of type `X&&`, `const X&&`, `volatile X&&` or `const
- * > volatile X&&`.
- *
- * That is, for example, the `operator=` in:
- *
- *    class Foo {
- *        bool operator=(const volatile Foo&&);
- *    };
- *
- * Is a move-assignment operator, while the `operator=` in:
- *
- *    class Bar {
- *        bool operator=(const CInt&&);
- *    };
- *
- * Is not.
- */
-fn CUInt isMoveAssignmentOperator_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isMoveAssignmentOperator");
-
-/**
- * Determines if a C++ constructor or conversion function was declared
- * explicit, returning 1 if such is the case and 0 otherwise.
- *
- * Constructors or conversion functions are declared explicit through
- * the use of the explicit specifier.
- *
- * For example, the following constructor and conversion function are
- * not explicit as they lack the explicit specifier:
- *
- *     class Foo {
- *         Foo();
- *         operator CInt();
- *     };
- *
- * While the following constructor and conversion function are
- * explicit as they are declared with the explicit specifier.
- *
- *     class Foo {
- *         explicit Foo();
- *         explicit operator CInt();
- *     };
- *
- * This function will return 0 when given a cursor pointing to one of
- * the former declarations and it will return 1 for a cursor pointing
- * to the latter declarations.
- *
- * The explicit specifier allows the user to specify a
- * conditional compile-time expression whose value decides
- * whether the marked element is explicit or not.
- *
- * For example:
- *
- *     constexpr bool foo(CInt i) { return i % 2 == 0; }
- *
- *     class Foo {
- *          explicit(foo(1)) Foo();
- *          explicit(foo(2)) operator CInt();
- *     }
- *
- * This function will return 0 for the constructor and 1 for
- * the conversion function.
- */
-fn CUInt isExplicit_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isExplicit");
-
-/**
- * Determine if a C++ record is abstract, i.e. whether a class or struct
- * has a pure virtual member function.
- */
-fn CUInt isAbstract_CXXRecord(
-  CXCursor c) 
-@extern("clang_CXXRecord_isAbstract");
-
-/**
- * Determine if an enum declaration refers to a scoped enum.
- */
-fn CUInt isScopedEnumDecl(
+<*
+  Visit the children of a particular cursor.
+  This function visits all the direct children of the given cursor,
+  invoking the given \p visitor function with the cursors of each
+  visited child. The traversal may be recursive, if the visitor returns
+  \c CXChildVisit_Recurse. The traversal may also be ended prematurely, if
+  the visitor returns \c CXChildVisit_Break.
+  \param parent the cursor whose child may be visited. All kinds of
+  cursors can be visited, including invalid cursors (which, by
+  definition, have no children).
+  \param visitor the visitor function that will be invoked for each
+  child of \p parent.
+  \param client_data pointer data supplied by the client, which will
+  be passed to the visitor each time it is invoked.
+  \returns a non-zero value if the traversal was terminated
+  prematurely by the visitor returning \c CXChildVisit_Break.
+*>
+extern fn CUInt visitChildren(
+  CXCursor parent,
+  CXCursorVisitor visitor,
+  CXClientData client_data)
+@cname("clang_visitChildren");
+
+alias CXCursorVisitorBlock = void*;
+
+<*
+  Visits the children of a cursor using the specified block.  Behaves
+  identically to clang_visitChildren() in all other respects.
+*>
+extern fn CUInt visitChildrenWithBlock(
+  CXCursor parent,
+  CXCursorVisitorBlock block)
+@cname("clang_visitChildrenWithBlock");
+
+<*
+  Retrieve a Unified Symbol Resolution (USR) for the entity referenced
+  by the given cursor.
+  A Unified Symbol Resolution (USR) is a string that identifies a particular
+  entity (function, class, variable, etc.) within a program. USRs can be
+  compared across translation units to determine, e.g., when references in
+  one translation refer to an entity defined in another translation unit.
+*>
+extern fn CXString getCursorUSR(
+  CXCursor)
+@cname("clang_getCursorUSR");
+
+<*
+  Construct a USR for a specified Objective-C class.
+*>
+extern fn CXString constructUSR_ObjCClass(
+  ZString class_name)
+@cname("clang_constructUSR_ObjCClass");
+
+<*
+  Construct a USR for a specified Objective-C category.
+*>
+extern fn CXString constructUSR_ObjCCategory(
+  ZString class_name,
+  ZString category_name)
+@cname("clang_constructUSR_ObjCCategory");
+
+<*
+  Construct a USR for a specified Objective-C protocol.
+*>
+extern fn CXString constructUSR_ObjCProtocol(
+  ZString protocol_name)
+@cname("clang_constructUSR_ObjCProtocol");
+
+<*
+  Construct a USR for a specified Objective-C instance variable and
+  the USR for its containing class.
+*>
+extern fn CXString constructUSR_ObjCIvar(
+  ZString name,
+  CXString class_usr)
+@cname("clang_constructUSR_ObjCIvar");
+
+<*
+  Construct a USR for a specified Objective-C method and
+  the USR for its containing class.
+*>
+extern fn CXString constructUSR_ObjCMethod(
+  ZString name,
+  CUInt is_instance_method,
+  CXString class_usr)
+@cname("clang_constructUSR_ObjCMethod");
+
+<*
+  Construct a USR for a specified Objective-C property and the USR
+  for its containing class.
+*>
+extern fn CXString constructUSR_ObjCProperty(
+  ZString property,
+  CXString class_usr)
+@cname("clang_constructUSR_ObjCProperty");
+
+<*
+  Retrieve a name for the entity referenced by this cursor.
+*>
+extern fn CXString getCursorSpelling(
+  CXCursor)
+@cname("clang_getCursorSpelling");
+
+<*
+  Retrieve a range for a piece that forms the cursors spelling name.
+  Most of the times there is only one range for the complete spelling but for
+  Objective-C methods and Objective-C message expressions, there are multiple
+  pieces for each selector identifier.
+  \param pieceIndex the index of the spelling name piece. If this is greater
+  than the actual number of pieces, it will return a NULL (invalid) range.
+  \param options Reserved.
+*>
+extern fn CXSourceRange cursor_getSpellingNameRange(
+  CXCursor,
+  CUInt piece_index,
+  CUInt options)
+@cname("clang_Cursor_getSpellingNameRange");
+
+alias CXPrintingPolicy = void*;
+
+<*
+  Properties for the printing policy.
+  See \c clang::PrintingPolicy for more information.
+*>
+constdef CXPrintingPolicyProperty : CInt {
+  PRINTING_POLICY_INDENTATION = 0,
+  PRINTING_POLICY_SUPPRESS_SPECIFIERS = 1,
+  PRINTING_POLICY_SUPPRESS_TAG_KEYWORD = 2,
+  PRINTING_POLICY_INCLUDE_TAG_DEFINITION = 3,
+  PRINTING_POLICY_SUPPRESS_SCOPE = 4,
+  PRINTING_POLICY_SUPPRESS_UNWRITTEN_SCOPE = 5,
+  PRINTING_POLICY_SUPPRESS_INITIALIZERS = 6,
+  PRINTING_POLICY_CONSTANT_ARRAY_SIZE_AS_WRITTEN = 7,
+  PRINTING_POLICY_ANONYMOUS_TAG_LOCATIONS = 8,
+  PRINTING_POLICY_SUPPRESS_STRONG_LIFETIME = 9,
+  PRINTING_POLICY_SUPPRESS_LIFETIME_QUALIFIERS = 10,
+  PRINTING_POLICY_SUPPRESS_TEMPLATE_ARGS_IN_CXX_CONSTRUCTORS = 11,
+  PRINTING_POLICY_BOOL = 12,
+  PRINTING_POLICY_RESTRICT = 13,
+  PRINTING_POLICY_ALIGNOF = 14,
+  PRINTING_POLICY_UNDERSCORE_ALIGNOF = 15,
+  PRINTING_POLICY_USE_VOID_FOR_ZERO_PARAMS = 16,
+  PRINTING_POLICY_TERSE_OUTPUT = 17,
+  PRINTING_POLICY_POLISH_FOR_DECLARATION = 18,
+  PRINTING_POLICY_HALF = 19,
+  PRINTING_POLICY_MSW_CHAR = 20,
+  PRINTING_POLICY_INCLUDE_NEWLINES = 21,
+  PRINTING_POLICY_MSVC_FORMATTING = 22,
+  PRINTING_POLICY_CONSTANTS_AS_WRITTEN = 23,
+  PRINTING_POLICY_SUPPRESS_IMPLICIT_BASE = 24,
+  PRINTING_POLICY_FULLY_QUALIFIED_NAME = 25,
+  PRINTING_POLICY_LAST_PROPERTY = 25
+}
+
+<*
+  Get a property value for the given printing policy.
+*>
+extern fn CUInt printingPolicy_getProperty(
+  CXPrintingPolicy policy,
+  CXPrintingPolicyProperty property)
+@cname("clang_PrintingPolicy_getProperty");
+
+<*
+  Set a property value for the given printing policy.
+*>
+extern fn void printingPolicy_setProperty(
+  CXPrintingPolicy policy,
+  CXPrintingPolicyProperty property,
+  CUInt value)
+@cname("clang_PrintingPolicy_setProperty");
+
+<*
+  Retrieve the default policy for the cursor.
+  The policy should be released after use with \c
+  clang_PrintingPolicy_dispose.
+*>
+extern fn CXPrintingPolicy getCursorPrintingPolicy(
+  CXCursor)
+@cname("clang_getCursorPrintingPolicy");
+
+<*
+  Release a printing policy.
+*>
+extern fn void printingPolicy_dispose(
+  CXPrintingPolicy policy)
+@cname("clang_PrintingPolicy_dispose");
+
+<*
+  Pretty print declarations.
+  \param Cursor The cursor representing a declaration.
+  \param Policy The policy to control the entities being printed. If
+  NULL, a default policy is used.
+  \returns The pretty printed declaration or the empty string for
+  other cursors.
+*>
+extern fn CXString getCursorPrettyPrinted(
+  CXCursor cursor,
+  CXPrintingPolicy policy)
+@cname("clang_getCursorPrettyPrinted");
+
+<*
+  Pretty-print the underlying type using a custom printing policy.
+  If the type is invalid, an empty string is returned.
+*>
+extern fn CXString getTypePrettyPrinted(
+  CXType ct,
+  CXPrintingPolicy cx_policy)
+@cname("clang_getTypePrettyPrinted");
+
+<*
+  Get the fully qualified name for a type.
+  This includes full qualification of all template parameters.
+  Policy - Further refine the type formatting
+  WithGlobalNsPrefix - If non-zero, function will prepend a '::' to qualified
+  names
+*>
+extern fn CXString getFullyQualifiedName(
+  CXType ct,
+  CXPrintingPolicy policy,
+  CUInt with_global_ns_prefix)
+@cname("clang_getFullyQualifiedName");
+
+<*
+  Retrieve the display name for the entity referenced by this cursor.
+  The display name contains extra information that helps identify the cursor,
+  such as the parameters of a function or template or the arguments of a
+  class template specialization.
+*>
+extern fn CXString getCursorDisplayName(
+  CXCursor)
+@cname("clang_getCursorDisplayName");
+
+<*
+  For a cursor that is a reference, retrieve a cursor representing the
+  entity that it references.
+  Reference cursors refer to other entities in the AST. For example, an
+  Objective-C superclass reference cursor refers to an Objective-C class.
+  This function produces the cursor for the Objective-C class from the
+  cursor for the superclass reference. If the input cursor is a declaration or
+  definition, it returns that declaration or definition unchanged.
+  Otherwise, returns the NULL cursor.
+*>
+extern fn CXCursor getCursorReferenced(
+  CXCursor)
+@cname("clang_getCursorReferenced");
+
+<*
+  For a cursor that is either a reference to or a declaration
+  of some entity, retrieve a cursor that describes the definition of
+  that entity.
+  Some entities can be declared multiple times within a translation
+  unit, but only one of those declarations can also be a
+  definition. For example, given:
+  \code
+  int f(int, int);
+  int g(int x, int y) { return f(x, y); }
+  int f(int a, int b) { return a + b; }
+  int f(int, int);
+  \endcode
+  there are three declarations of the function "f", but only the
+  second one is a definition. The clang_getCursorDefinition()
+  function will take any cursor pointing to a declaration of "f"
+  (the first or fourth lines of the example) or a cursor referenced
+  that uses "f" (the call to "f' inside "g") and will return a
+  declaration cursor pointing to the definition (the second "f"
+  declaration).
+  If given a cursor for which there is no corresponding definition,
+  e.g., because there is no definition of that entity within this
+  translation unit, returns a NULL cursor.
+*>
+extern fn CXCursor getCursorDefinition(
+  CXCursor)
+@cname("clang_getCursorDefinition");
+
+<*
+  Determine whether the declaration pointed to by this cursor
+  is also a definition of that entity.
+*>
+extern fn CUInt isCursorDefinition(
+  CXCursor)
+@cname("clang_isCursorDefinition");
+
+<*
+  Retrieve the canonical cursor corresponding to the given cursor.
+  In the C family of languages, many kinds of entities can be declared several
+  times within a single translation unit. For example, a structure type can
+  be forward-declared (possibly multiple times) and later defined:
+  \code
+  struct X;
+  struct X;
+  struct X {
+  int member;
+  };
+  \endcode
+  The declarations and the definition of \c X are represented by three
+  different cursors, all of which are declarations of the same underlying
+  entity. One of these cursor is considered the "canonical" cursor, which
+  is effectively the representative for the underlying entity. One can
+  determine if two cursors are declarations of the same underlying entity by
+  comparing their canonical cursors.
+  \returns The canonical cursor for the entity referred to by the given cursor.
+*>
+extern fn CXCursor getCanonicalCursor(
+  CXCursor)
+@cname("clang_getCanonicalCursor");
+
+<*
+  If the cursor points to a selector identifier in an Objective-C
+  method or message expression, this returns the selector index.
+  After getting a cursor with #clang_getCursor, this can be called to
+  determine if the location points to a selector identifier.
+  \returns The selector index if the cursor is an Objective-C method or message
+  expression and the cursor is pointing to a selector identifier, or -1
+  otherwise.
+*>
+extern fn CInt cursor_getObjCSelectorIndex(
+  CXCursor)
+@cname("clang_Cursor_getObjCSelectorIndex");
+
+<*
+  Given a cursor pointing to a C++ method call or an Objective-C
+  message, returns non-zero if the method/message is "dynamic", meaning:
+  For a C++ method: the call is virtual.
+  For an Objective-C message: the receiver is an object instance, not 'super'
+  or a specific class.
+  If the method/message is "static" or the cursor does not point to a
+  method/message, it will return zero.
+*>
+extern fn CInt cursor_isDynamicCall(
   CXCursor c)
-@extern("clang_EnumDecl_isScoped");
+@cname("clang_Cursor_isDynamicCall");
 
-/**
- * Determine if a C++ member function or member function template is
- * declared 'const'.
- */
-fn CUInt isConst_CXXMethod(
-  CXCursor c) 
-@extern("clang_CXXMethod_isConst");
+<*
+  Given a cursor pointing to an Objective-C message or property
+  reference, or C++ method call, returns the CXType of the receiver.
+*>
+extern fn CXType cursor_getReceiverType(
+  CXCursor c)
+@cname("clang_Cursor_getReceiverType");
 
-/**
- * Given a cursor that represents a template, determine
- * the cursor kind of the specializations would be generated by instantiating
- * the template.
- *
- * This routine can be used to determine what flavor of function template,
- * class template, or class template partial specialization is stored in the
- * cursor. For example, it can describe whether a class template cursor is
- * declared with "struct", "class" or "union".
- *
- * \param C The cursor to query. This cursor should represent a template
- * declaration.
- *
- * \returns The cursor kind of the specializations that would be generated
- * by instantiating the template \p C. If \p C is not a template, returns
- * \c CXCursor_NoDeclFound.
- */
-fn CXCursorKind getTemplateCursorKind(
-  CXCursor c) 
-@extern("clang_getTemplateCursorKind");
+<*
+  Property attributes for a \c CXCursor_ObjCPropertyDecl.
+*>
+constdef CXObjCPropertyAttrKind : CInt {
+  OBJ_C_PROPERTY_ATTR_NOATTR = 0,
+  OBJ_C_PROPERTY_ATTR_READONLY = 1,
+  OBJ_C_PROPERTY_ATTR_GETTER = 2,
+  OBJ_C_PROPERTY_ATTR_ASSIGN = 4,
+  OBJ_C_PROPERTY_ATTR_READWRITE = 8,
+  OBJ_C_PROPERTY_ATTR_RETAIN = 16,
+  OBJ_C_PROPERTY_ATTR_COPY = 32,
+  OBJ_C_PROPERTY_ATTR_NONATOMIC = 64,
+  OBJ_C_PROPERTY_ATTR_SETTER = 128,
+  OBJ_C_PROPERTY_ATTR_ATOMIC = 256,
+  OBJ_C_PROPERTY_ATTR_WEAK = 512,
+  OBJ_C_PROPERTY_ATTR_STRONG = 1024,
+  OBJ_C_PROPERTY_ATTR_UNSAFE_UNRETAINED = 2048,
+  OBJ_C_PROPERTY_ATTR_CLASS = 4096
+}
 
-/**
- * Given a cursor that may represent a specialization or instantiation
- * of a template, retrieve the cursor that represents the template that it
- * specializes or from which it was instantiated.
- *
- * This routine determines the template involved both for explicit
- * specializations of templates and for implicit instantiations of the template,
- * both of which are referred to as "specializations". For a class template
- * specialization (e.g., \c std::vector<bool>), this routine will return
- * either the primary template (\c std::vector) or, if the specialization was
- * instantiated from a class template partial specialization, the class template
- * partial specialization. For a class template partial specialization and a
- * function template specialization (including instantiations), this
- * this routine will return the specialized template.
- *
- * For members of a class template (e.g., member functions, member classes, or
- * static data members), returns the specialized or instantiated member.
- * Although not strictly "templates" in the C++ language, members of class
- * templates have the same notions of specializations and instantiations that
- * templates do, so this routine treats them similarly.
- *
- * \param C A cursor that may be a specialization of a template or a member
- * of a template.
- *
- * \returns If the given cursor is a specialization or instantiation of a
- * template or a member thereof, the template or member that it specializes or
- * from which it was instantiated. Otherwise, returns a NULL cursor.
- */
-fn CXCursor getSpecializedCursorTemplate(
-  CXCursor c) 
-@extern("clang_getSpecializedCursorTemplate");
+<*
+  Given a cursor that represents a property declaration, return the
+  associated property attributes. The bits are formed from
+  \c CXObjCPropertyAttrKind.
+  \param reserved Reserved for future use, pass 0.
+*>
+extern fn CUInt cursor_getObjCPropertyAttributes(
+  CXCursor c,
+  CUInt reserved)
+@cname("clang_Cursor_getObjCPropertyAttributes");
 
-/**
- * Given a cursor that references something else, return the source range
- * covering that reference.
- *
- * \param C A cursor pointing to a member reference, a declaration reference, or
- * an operator call.
- * \param NameFlags A bitset with three independent flags:
- * CXNameRange_WantQualifier, CXNameRange_WantTemplateArgs, and
- * CXNameRange_WantSinglePiece.
- * \param PieceIndex For contiguous names or when passing the flag
- * CXNameRange_WantSinglePiece, only one piece with index 0 is
- * available. When the CXNameRange_WantSinglePiece flag is not passed for a
- * non-contiguous names, this index can be used to retrieve the individual
- * pieces of the name. See also CXNameRange_WantSinglePiece.
- *
- * \returns The piece of the name pointed to by the given cursor. If there is no
- * name, or if the PieceIndex is out-of-range, a null-cursor will be returned.
- */
-fn CXSourceRange getCursorReferenceNameRange(
-  CXCursor c, 
-  CUInt name_flags, 
-  CUInt piece_index) 
-@extern("clang_getCursorReferenceNameRange");
+<*
+  Given a cursor that represents a property declaration, return the
+  name of the method that implements the getter.
+*>
+extern fn CXString cursor_getObjCPropertyGetterName(
+  CXCursor c)
+@cname("clang_Cursor_getObjCPropertyGetterName");
 
-typedef CXNameRefFlags = inline CInt;
+<*
+  Given a cursor that represents a property declaration, return the
+  name of the method that implements the setter, if any.
+*>
+extern fn CXString cursor_getObjCPropertySetterName(
+  CXCursor c)
+@cname("clang_Cursor_getObjCPropertySetterName");
 
-/**
- * Include the nested-name-specifier, e.g. Foo:: in x.Foo::y, in the
- * range.
- */
-const CXNameRefFlags NAME_RANGE_WANT_QUALIFIER = 0x1;
+<*
+  'Qualifiers' written next to the return and parameter types in
+  Objective-C method declarations.
+*>
+constdef CXObjCDeclQualifierKind : CInt {
+  OBJ_C_DECL_QUALIFIER_NONE = 0,
+  OBJ_C_DECL_QUALIFIER_IN = 1,
+  OBJ_C_DECL_QUALIFIER_INOUT = 2,
+  OBJ_C_DECL_QUALIFIER_OUT = 4,
+  OBJ_C_DECL_QUALIFIER_BYCOPY = 8,
+  OBJ_C_DECL_QUALIFIER_BYREF = 16,
+  OBJ_C_DECL_QUALIFIER_ONEWAY = 32
+}
 
-/**
- * Include the explicit template arguments, e.g. \<CInt> in x.f<CInt>,
- * in the range.
- */
-const CXNameRefFlags NAME_RANGE_WANT_TEMPLATE_ARGS = 0x2;
+<*
+  Given a cursor that represents an Objective-C method or parameter
+  declaration, return the associated Objective-C qualifiers for the return
+  type or the parameter respectively. The bits are formed from
+  CXObjCDeclQualifierKind.
+*>
+extern fn CUInt cursor_getObjCDeclQualifiers(
+  CXCursor c)
+@cname("clang_Cursor_getObjCDeclQualifiers");
 
-/**
- * If the name is non-contiguous, return the full spanning range.
- *
- * Non-contiguous names occur in Objective-C when a selector with two or more
- * parameters is used, or in C++ when using an operator:
- * \code
- * [object doSomething:here withValue:there]; // Objective-C
- * return some_vector[1]; // C++
- * \endcode
- */
-const CXNameRefFlags NAME_RANGE_WANT_SINGLE_PIECE = 0x4;
+<*
+  Given a cursor that represents an Objective-C method or property
+  declaration, return non-zero if the declaration was affected by "\@optional".
+  Returns zero if the cursor is not such a declaration or it is "\@required".
+*>
+extern fn CUInt cursor_isObjCOptional(
+  CXCursor c)
+@cname("clang_Cursor_isObjCOptional");
 
-/**
- * Describes a kind of token.
- */
-typedef CXTokenKind = inline CInt;
+<*
+  Returns non-zero if the given cursor is a variadic function or method.
+*>
+extern fn CUInt cursor_isVariadic(
+  CXCursor c)
+@cname("clang_Cursor_isVariadic");
 
-/**
- * A token that contains some kind of punctuation.
- */
-const CXTokenKind TOKEN_PUNCTUATION = 0;
+<*
+  Returns non-zero if the given cursor points to a symbol marked with
+  external_source_symbol attribute.
+  \param language If non-NULL, and the attribute is present, will be set to
+  the 'language' string from the attribute.
+  \param definedIn If non-NULL, and the attribute is present, will be set to
+  the 'definedIn' string from the attribute.
+  \param isGenerated If non-NULL, and the attribute is present, will be set to
+  non-zero if the 'generated_declaration' is set in the attribute.
+*>
+extern fn CUInt cursor_isExternalSymbol(
+  CXCursor c,
+  CXString* language,
+  CXString* defined_in,
+  CUInt* is_generated)
+@cname("clang_Cursor_isExternalSymbol");
 
-/**
- * A language keyword.
- */
-const CXTokenKind TOKEN_KEYWORD = 1;
+<*
+  Given a cursor that represents a declaration, return the associated
+  comment's source range.  The range may include multiple consecutive comments
+  with whitespace in between.
+*>
+extern fn CXSourceRange cursor_getCommentRange(
+  CXCursor c)
+@cname("clang_Cursor_getCommentRange");
 
-/**
- * An identifier (that is not a keyword).
- */
-const CXTokenKind TOKEN_IDENTIFIER = 2;
+<*
+  Given a cursor that represents a declaration, return the associated
+  comment text, including comment markers.
+*>
+extern fn CXString cursor_getRawCommentText(
+  CXCursor c)
+@cname("clang_Cursor_getRawCommentText");
 
-/**
- * A numeric, string, or character literal.
- */
-const CXTokenKind TOKEN_LITERAL = 3;
+<*
+  Given a cursor that represents a documentable entity (e.g.,
+  declaration), return the associated \paragraph; otherwise return the
+  first paragraph.
+*>
+extern fn CXString cursor_getBriefCommentText(
+  CXCursor c)
+@cname("clang_Cursor_getBriefCommentText");
 
-/**
- * A comment.
- */
-const CXTokenKind TOKEN_COMMENT = 4;
+<*
+  Retrieve the CXString representing the mangled name of the cursor.
+*>
+extern fn CXString cursor_getMangling(
+  CXCursor)
+@cname("clang_Cursor_getMangling");
 
+<*
+  Retrieve the CXStrings representing the mangled symbols of the C++
+  constructor or destructor at the cursor.
+*>
+extern fn CXStringSet* cursor_getCXXManglings(
+  CXCursor)
+@cname("clang_Cursor_getCXXManglings");
 
-/**
- * Describes a single preprocessing token.
- */
+<*
+  Retrieve the CXStrings representing the mangled symbols of the ObjC
+  class interface or implementation at the cursor.
+*>
+extern fn CXStringSet* cursor_getObjCManglings(
+  CXCursor)
+@cname("clang_Cursor_getObjCManglings");
+
+<*
+  Given a CXCursor_GCCAsmStmt cursor, return the assembly template string.
+  As per LLVM IR Assembly Template language, template placeholders for
+  inputs and outputs are either of the form $N where N is a decimal number
+  as an index into the input-output specification,
+  or ${N:M} where N is a decimal number also as an index into the
+  input-output specification and M is the template argument modifier.
+  The index N in both cases points into the the total inputs and outputs,
+  or more specifically, into the list of outputs followed by the inputs,
+  starting from index 0 as the first available template argument.
+  This function also returns a valid empty string if the cursor does not point
+  at a GCC inline assembly block.
+  Users are responsible for releasing the allocation of returned string via
+  \c clang_disposeString.
+*>
+extern fn CXString cursor_getGCCAssemblyTemplate(
+  CXCursor)
+@cname("clang_Cursor_getGCCAssemblyTemplate");
+
+<*
+  Given a CXCursor_GCCAsmStmt cursor, check if the assembly block has goto
+  labels.
+  This function also returns 0 if the cursor does not point at a GCC inline
+  assembly block.
+*>
+extern fn CUInt cursor_isGCCAssemblyHasGoto(
+  CXCursor)
+@cname("clang_Cursor_isGCCAssemblyHasGoto");
+
+<*
+  Given a CXCursor_GCCAsmStmt cursor, count the number of outputs.
+  This function also returns 0 if the cursor does not point at a GCC inline
+  assembly block.
+*>
+extern fn CUInt cursor_getGCCAssemblyNumOutputs(
+  CXCursor)
+@cname("clang_Cursor_getGCCAssemblyNumOutputs");
+
+<*
+  Given a CXCursor_GCCAsmStmt cursor, count the number of inputs.
+  This function also returns 0 if the cursor does not point at a GCC inline
+  assembly block.
+*>
+extern fn CUInt cursor_getGCCAssemblyNumInputs(
+  CXCursor)
+@cname("clang_Cursor_getGCCAssemblyNumInputs");
+
+<*
+  Given a CXCursor_GCCAsmStmt cursor, get the constraint and expression cursor
+  to the Index-th input.
+  This function returns 1 when the cursor points at a GCC inline assembly
+  statement, `Index` is within bounds and both the `Constraint` and `Expr` are
+  not NULL.
+  Otherwise, this function returns 0 but leaves `Constraint` and `Expr`
+  intact.
+  Users are responsible for releasing the allocation of `Constraint` via
+  \c clang_disposeString.
+*>
+extern fn CUInt cursor_getGCCAssemblyInput(
+  CXCursor cursor,
+  CUInt index,
+  CXString* constraint,
+  CXCursor* expr)
+@cname("clang_Cursor_getGCCAssemblyInput");
+
+<*
+  Given a CXCursor_GCCAsmStmt cursor, get the constraint and expression cursor
+  to the Index-th output.
+  This function returns 1 when the cursor points at a GCC inline assembly
+  statement, `Index` is within bounds and both the `Constraint` and `Expr` are
+  not NULL.
+  Otherwise, this function returns 0 but leaves `Constraint` and `Expr`
+  intact.
+  Users are responsible for releasing the allocation of `Constraint` via
+  \c clang_disposeString.
+*>
+extern fn CUInt cursor_getGCCAssemblyOutput(
+  CXCursor cursor,
+  CUInt index,
+  CXString* constraint,
+  CXCursor* expr)
+@cname("clang_Cursor_getGCCAssemblyOutput");
+
+<*
+  Given a CXCursor_GCCAsmStmt cursor, count the clobbers in it.
+  This function also returns 0 if the cursor does not point at a GCC inline
+  assembly block.
+*>
+extern fn CUInt cursor_getGCCAssemblyNumClobbers(
+  CXCursor cursor)
+@cname("clang_Cursor_getGCCAssemblyNumClobbers");
+
+<*
+  Given a CXCursor_GCCAsmStmt cursor, get the Index-th clobber of it.
+  This function returns a valid empty string if the cursor does not point
+  at a GCC inline assembly block or `Index` is out of bounds.
+  Users are responsible for releasing the allocation of returned string via
+  \c clang_disposeString.
+*>
+extern fn CXString cursor_getGCCAssemblyClobber(
+  CXCursor cursor,
+  CUInt index)
+@cname("clang_Cursor_getGCCAssemblyClobber");
+
+<*
+  Given a CXCursor_GCCAsmStmt cursor, check if the inline assembly is
+  `volatile`.
+  This function returns 0 if the cursor does not point at a GCC inline
+  assembly block.
+*>
+extern fn CUInt cursor_isGCCAssemblyVolatile(
+  CXCursor cursor)
+@cname("clang_Cursor_isGCCAssemblyVolatile");
+
+alias CXModule = void*;
+
+<*
+  Given a CXCursor_ModuleImportDecl cursor, return the associated module.
+*>
+extern fn CXModule cursor_getModule(
+  CXCursor c)
+@cname("clang_Cursor_getModule");
+
+<*
+  Given a CXFile header file, return the module that contains it, if one
+  exists.
+*>
+extern fn CXModule getModuleForFile(
+  CXTranslationUnit,
+  CXFile)
+@cname("clang_getModuleForFile");
+
+<*
+  \param Module a module object.
+  \returns the module file where the provided module object came from.
+*>
+extern fn CXFile module_getASTFile(
+  CXModule mod)
+@cname("clang_Module_getASTFile");
+
+<*
+  \param Module a module object.
+  \returns the parent of a sub-module or NULL if the given module is top-level,
+  e.g. for 'std.vector' it will return the 'std' module.
+*>
+extern fn CXModule module_getParent(
+  CXModule mod)
+@cname("clang_Module_getParent");
+
+<*
+  \param Module a module object.
+  \returns the name of the module, e.g. for the 'std.vector' sub-module it
+  will return "vector".
+*>
+extern fn CXString module_getName(
+  CXModule mod)
+@cname("clang_Module_getName");
+
+<*
+  \param Module a module object.
+  \returns the full name of the module, e.g. "std.vector".
+*>
+extern fn CXString module_getFullName(
+  CXModule mod)
+@cname("clang_Module_getFullName");
+
+<*
+  \param Module a module object.
+  \returns non-zero if the module is a system one.
+*>
+extern fn CInt module_isSystem(
+  CXModule mod)
+@cname("clang_Module_isSystem");
+
+<*
+  \param Module a module object.
+  \returns the number of top level headers associated with this module.
+*>
+extern fn CUInt module_getNumTopLevelHeaders(
+  CXTranslationUnit,
+  CXModule mod)
+@cname("clang_Module_getNumTopLevelHeaders");
+
+<*
+  \param Module a module object.
+  \param Index top level header index (zero-based).
+  \returns the specified top level header associated with the module.
+*>
+extern fn CXFile module_getTopLevelHeader(
+  CXTranslationUnit,
+  CXModule mod,
+  CUInt index)
+@cname("clang_Module_getTopLevelHeader");
+
+<*
+  Determine if a C++ constructor is a converting constructor.
+*>
+extern fn CUInt cXXConstructor_isConvertingConstructor(
+  CXCursor c)
+@cname("clang_CXXConstructor_isConvertingConstructor");
+
+<*
+  Determine if a C++ constructor is a copy constructor.
+*>
+extern fn CUInt cXXConstructor_isCopyConstructor(
+  CXCursor c)
+@cname("clang_CXXConstructor_isCopyConstructor");
+
+<*
+  Determine if a C++ constructor is the default constructor.
+*>
+extern fn CUInt cXXConstructor_isDefaultConstructor(
+  CXCursor c)
+@cname("clang_CXXConstructor_isDefaultConstructor");
+
+<*
+  Determine if a C++ constructor is a move constructor.
+*>
+extern fn CUInt cXXConstructor_isMoveConstructor(
+  CXCursor c)
+@cname("clang_CXXConstructor_isMoveConstructor");
+
+<*
+  Determine if a C++ field is declared 'mutable'.
+*>
+extern fn CUInt cXXField_isMutable(
+  CXCursor c)
+@cname("clang_CXXField_isMutable");
+
+<*
+  Determine if a C++ method is declared '= default'.
+*>
+extern fn CUInt cXXMethod_isDefaulted(
+  CXCursor c)
+@cname("clang_CXXMethod_isDefaulted");
+
+<*
+  Determine if a C++ method is declared '= delete'.
+*>
+extern fn CUInt cXXMethod_isDeleted(
+  CXCursor c)
+@cname("clang_CXXMethod_isDeleted");
+
+<*
+  Determine if a C++ member function or member function template is
+  pure virtual.
+*>
+extern fn CUInt cXXMethod_isPureVirtual(
+  CXCursor c)
+@cname("clang_CXXMethod_isPureVirtual");
+
+<*
+  Determine if a C++ member function or member function template is
+  declared 'static'.
+*>
+extern fn CUInt cXXMethod_isStatic(
+  CXCursor c)
+@cname("clang_CXXMethod_isStatic");
+
+<*
+  Determine if a C++ member function or member function template is
+  explicitly declared 'virtual' or if it overrides a virtual method from
+  one of the base classes.
+*>
+extern fn CUInt cXXMethod_isVirtual(
+  CXCursor c)
+@cname("clang_CXXMethod_isVirtual");
+
+<*
+  Determine if a C++ member function is a copy-assignment operator,
+  returning 1 if such is the case and 0 otherwise.
+  > A copy-assignment operator `X::operator=` is a non-static,
+  > non-template member function of _class_ `X` with exactly one
+  > parameter of type `X`, `X&`, `const X&`, `volatile X&` or `const
+  > volatile X&`.
+  That is, for example, the `operator=` in:
+  class Foo {
+  bool operator=(const volatile Foo&);
+  };
+  Is a copy-assignment operator, while the `operator=` in:
+  class Bar {
+  bool operator=(const int&);
+  };
+  Is not.
+*>
+extern fn CUInt cXXMethod_isCopyAssignmentOperator(
+  CXCursor c)
+@cname("clang_CXXMethod_isCopyAssignmentOperator");
+
+<*
+  Determine if a C++ member function is a move-assignment operator,
+  returning 1 if such is the case and 0 otherwise.
+  > A move-assignment operator `X::operator=` is a non-static,
+  > non-template member function of _class_ `X` with exactly one
+  > parameter of type `X&&`, `const X&&`, `volatile X&&` or `const
+  > volatile X&&`.
+  That is, for example, the `operator=` in:
+  class Foo {
+  bool operator=(const volatile Foo&&);
+  };
+  Is a move-assignment operator, while the `operator=` in:
+  class Bar {
+  bool operator=(const int&&);
+  };
+  Is not.
+*>
+extern fn CUInt cXXMethod_isMoveAssignmentOperator(
+  CXCursor c)
+@cname("clang_CXXMethod_isMoveAssignmentOperator");
+
+<*
+  Determines if a C++ constructor or conversion function was declared
+  explicit, returning 1 if such is the case and 0 otherwise.
+  Constructors or conversion functions are declared explicit through
+  the use of the explicit specifier.
+  For example, the following constructor and conversion function are
+  not explicit as they lack the explicit specifier:
+  class Foo {
+  Foo();
+  operator int();
+  };
+  While the following constructor and conversion function are
+  explicit as they are declared with the explicit specifier.
+  class Foo {
+  explicit Foo();
+  explicit operator int();
+  };
+  This function will return 0 when given a cursor pointing to one of
+  the former declarations and it will return 1 for a cursor pointing
+  to the latter declarations.
+  The explicit specifier allows the user to specify a
+  conditional compile-time expression whose value decides
+  whether the marked element is explicit or not.
+  For example:
+  constexpr bool foo(int i) { return i % 2 == 0; }
+  class Foo {
+  explicit(foo(1)) Foo();
+  explicit(foo(2)) operator int();
+  }
+  This function will return 0 for the constructor and 1 for
+  the conversion function.
+*>
+extern fn CUInt cXXMethod_isExplicit(
+  CXCursor c)
+@cname("clang_CXXMethod_isExplicit");
+
+<*
+  Determine if a C++ record is abstract, i.e. whether a class or struct
+  has a pure virtual member function.
+*>
+extern fn CUInt cXXRecord_isAbstract(
+  CXCursor c)
+@cname("clang_CXXRecord_isAbstract");
+
+<*
+  Determine if an enum declaration refers to a scoped enum.
+*>
+extern fn CUInt enumDecl_isScoped(
+  CXCursor c)
+@cname("clang_EnumDecl_isScoped");
+
+<*
+  Determine if a C++ member function or member function template is
+  declared 'const'.
+*>
+extern fn CUInt cXXMethod_isConst(
+  CXCursor c)
+@cname("clang_CXXMethod_isConst");
+
+<*
+  Given a cursor that represents a template, determine
+  the cursor kind of the specializations would be generated by instantiating
+  the template.
+  This routine can be used to determine what flavor of function template,
+  class template, or class template partial specialization is stored in the
+  cursor. For example, it can describe whether a class template cursor is
+  declared with "struct", "class" or "union".
+  \param C The cursor to query. This cursor should represent a template
+  declaration.
+  \returns The cursor kind of the specializations that would be generated
+  by instantiating the template \p C. If \p C is not a template, returns
+  \c CXCursor_NoDeclFound.
+*>
+extern fn CXCursorKind getTemplateCursorKind(
+  CXCursor c)
+@cname("clang_getTemplateCursorKind");
+
+<*
+  Given a cursor that may represent a specialization or instantiation
+  of a template, retrieve the cursor that represents the template that it
+  specializes or from which it was instantiated.
+  This routine determines the template involved both for explicit
+  specializations of templates and for implicit instantiations of the template,
+  both of which are referred to as "specializations". For a class template
+  specialization (e.g., \c std::vector<bool>), this routine will return
+  either the primary template (\c std::vector) or, if the specialization was
+  instantiated from a class template partial specialization, the class template
+  partial specialization. For a class template partial specialization and a
+  function template specialization (including instantiations), this
+  this routine will return the specialized template.
+  For members of a class template (e.g., member functions, member classes, or
+  static data members), returns the specialized or instantiated member.
+  Although not strictly "templates" in the C++ language, members of class
+  templates have the same notions of specializations and instantiations that
+  templates do, so this routine treats them similarly.
+  \param C A cursor that may be a specialization of a template or a member
+  of a template.
+  \returns If the given cursor is a specialization or instantiation of a
+  template or a member thereof, the template or member that it specializes or
+  from which it was instantiated. Otherwise, returns a NULL cursor.
+*>
+extern fn CXCursor getSpecializedCursorTemplate(
+  CXCursor c)
+@cname("clang_getSpecializedCursorTemplate");
+
+<*
+  Given a cursor that references something else, return the source range
+  covering that reference.
+  \param C A cursor pointing to a member reference, a declaration reference, or
+  an operator call.
+  \param NameFlags A bitset with three independent flags:
+  CXNameRange_WantQualifier, CXNameRange_WantTemplateArgs, and
+  CXNameRange_WantSinglePiece.
+  \param PieceIndex For contiguous names or when passing the flag
+  CXNameRange_WantSinglePiece, only one piece with index 0 is
+  available. When the CXNameRange_WantSinglePiece flag is not passed for a
+  non-contiguous names, this index can be used to retrieve the individual
+  pieces of the name. See also CXNameRange_WantSinglePiece.
+  \returns The piece of the name pointed to by the given cursor. If there is no
+  name, or if the PieceIndex is out-of-range, a null-cursor will be returned.
+*>
+extern fn CXSourceRange getCursorReferenceNameRange(
+  CXCursor c,
+  CUInt name_flags,
+  CUInt piece_index)
+@cname("clang_getCursorReferenceNameRange");
+
+constdef CXNameRefFlags : CInt {
+
+  <*
+    Include the nested-name-specifier, e.g. Foo:: in x.Foo::y, in the
+    range.
+  *>
+  NAME_RANGE_WANT_QUALIFIER = 1,
+
+  <*
+    Include the explicit template arguments, e.g. \<int> in x.f<int>,
+    in the range.
+  *>
+  NAME_RANGE_WANT_TEMPLATE_ARGS = 2,
+
+  <*
+    If the name is non-contiguous, return the full spanning range.
+    Non-contiguous names occur in Objective-C when a selector with two or more
+    parameters is used, or in C++ when using an operator:
+    \code
+    [object doSomething:here withValue:there]; // Objective-C
+    return some_vector[1]; // C++
+    \endcode
+  *>
+  NAME_RANGE_WANT_SINGLE_PIECE = 4
+}
+
+<*
+  Describes a kind of token.
+*>
+constdef CXTokenKind : CInt {
+
+  <*
+    A token that contains some kind of punctuation.
+  *>
+  TOKEN_PUNCTUATION = 0,
+
+  <*
+    A language keyword.
+  *>
+  TOKEN_KEYWORD = 1,
+
+  <*
+    An identifier (that is not a keyword).
+  *>
+  TOKEN_IDENTIFIER = 2,
+
+  <*
+    A numeric, string, or character literal.
+  *>
+  TOKEN_LITERAL = 3,
+
+  <*
+    A comment.
+  *>
+  TOKEN_COMMENT = 4
+}
+
+<*
+  Describes a single preprocessing token.
+*>
 struct CXToken {
   CUInt[4] int_data;
   void* ptr_data;
 }
 
-/**
- * Get the raw lexical token starting with the given location.
- *
- * \param TU the translation unit whose text is being tokenized.
- *
- * \param Location the source location with which the token starts.
- *
- * \returns The token starting with the given location or NULL if no such token
- * exist. The returned pointer must be freed with clang_disposeTokens before the
- * translation unit is destroyed.
- */
-fn CXToken* getToken(
-  CXTranslationUnit tu, 
-  CXSourceLocation location) 
-@extern("clang_getToken");
-
-/**
- * Determine the kind of the given token.
- */
-fn CXTokenKind getTokenKind(
-  CXToken token) 
-@extern("clang_getTokenKind");
-
-/**
- * Determine the spelling of the given token.
- *
- * The spelling of a token is the textual representation of that token, e.g.,
- * the text of an identifier or keyword.
- */
-fn CXString getTokenSpelling(
-  CXTranslationUnit tu, 
-  CXToken token) 
-@extern("clang_getTokenSpelling");
-
-/**
- * Retrieve the source location of the given token.
- */
-fn CXSourceLocation getTokenLocation(
-  CXTranslationUnit tu, 
-  CXToken token) 
-@extern("clang_getTokenLocation");
-
-/**
- * Retrieve a source range that covers the given token.
- */
-fn CXSourceRange getTokenExtent(
+<*
+  Get the raw lexical token starting with the given location.
+  \param TU the translation unit whose text is being tokenized.
+  \param Location the source location with which the token starts.
+  \returns The token starting with the given location or NULL if no such token
+  exist. The returned pointer must be freed with clang_disposeTokens before the
+  translation unit is destroyed.
+*>
+extern fn CXToken* getToken(
   CXTranslationUnit tu,
-  CXToken token)
-@extern("clang_getTokenExtent");
+  CXSourceLocation location)
+@cname("clang_getToken");
 
-/**
- * Tokenize the source code described by the given range into raw
- * lexical tokens.
- *
- * \param TU the translation unit whose text is being tokenized.
- *
- * \param Range the source range in which text should be tokenized. All of the
- * tokens produced by tokenization will fall within this source range,
- *
- * \param Tokens this pointer will be set to poCInt to the array of tokens
- * that occur within the given source range. The returned pointer must be
- * freed with clang_disposeTokens() before the translation unit is destroyed.
- *
- * \param NumTokens will be set to the number of tokens in the \c *Tokens
- * array.
- *
- */
-fn void tokenize(
-  CXTranslationUnit tu, 
-  CXSourceRange range, 
-  CXToken** tokens, 
-  CUInt* num_tokens) 
-@extern("clang_tokenize");
+<*
+  Determine the kind of the given token.
+*>
+extern fn CXTokenKind getTokenKind(
+  CXToken)
+@cname("clang_getTokenKind");
 
-/**
- * Annotate the given set of tokens by providing cursors for each token
- * that can be mapped to a specific entity within the abstract syntax tree.
- *
- * This token-annotation routine is equivalent to invoking
- * clang_getCursor() for the source locations of each of the
- * tokens. The cursors provided are filtered, so that only those
- * cursors that have a direct correspondence to the token are
- * accepted. For example, given a function call \c f(x),
- * clang_getCursor() would provide the following cursors:
- *
- *   * when the cursor is over the 'f', a DeclRefExpr cursor referring to 'f'.
- *   * when the cursor is over the '(' or the ')', a CallExpr referring to 'f'.
- *   * when the cursor is over the 'x', a DeclRefExpr cursor referring to 'x'.
- *
- * Only the first and last of these cursors will occur within the
- * annotate, since the tokens "f" and "x' directly refer to a function
- * and a variable, respectively, but the parentheses are just a small
- * part of the full syntax of the function call expression, which is
- * not provided as an annotation.
- *
- * \param TU the translation unit that owns the given tokens.
- *
- * \param Tokens the set of tokens to annotate.
- *
- * \param NumTokens the number of tokens in \p Tokens.
- *
- * \param Cursors an array of \p NumTokens cursors, whose contents will be
- * replaced with the cursors corresponding to each token.
- */
-fn void annotateTokens(
-  CXTranslationUnit tu, 
-  CXToken* tokens, 
-  CUInt num_tokens, 
-  CXCursor* cursors) 
-@extern("clang_annotateTokens");
+<*
+  Determine the spelling of the given token.
+  The spelling of a token is the textual representation of that token, e.g.,
+  the text of an identifier or keyword.
+*>
+extern fn CXString getTokenSpelling(
+  CXTranslationUnit,
+  CXToken)
+@cname("clang_getTokenSpelling");
 
-/**
- * Free the given set of tokens.
- */
-fn void disposeTokens(
-  CXTranslationUnit tu, 
-  CXToken* tokens, 
-  CUInt num_tokens) 
-@extern("clang_disposeTokens");
+<*
+  Retrieve the source location of the given token.
+*>
+extern fn CXSourceLocation getTokenLocation(
+  CXTranslationUnit,
+  CXToken)
+@cname("clang_getTokenLocation");
 
-/* for debug/testing */
-fn CXString getCursorKindSpelling(
-  CXCursorKind kind) 
-@extern("clang_getCursorKindSpelling");
+<*
+  Retrieve a source range that covers the given token.
+*>
+extern fn CXSourceRange getTokenExtent(
+  CXTranslationUnit,
+  CXToken)
+@cname("clang_getTokenExtent");
 
-fn void getDefinitionSpellingAndExtent(
-  CXCursor cursor, 
-  ZString* startBuf, 
-  ZString* endBuf, 
-  CUInt* startLine, 
-  CUInt* startColumn, 
-  CUInt* endLine, 
-  CUInt* endColumn) 
-@extern("clang_getDefinitionSpellingAndExtent");
+<*
+  Tokenize the source code described by the given range into raw
+  lexical tokens.
+  \param TU the translation unit whose text is being tokenized.
+  \param Range the source range in which text should be tokenized. All of the
+  tokens produced by tokenization will fall within this source range,
+  \param Tokens this pointer will be set to point to the array of tokens
+  that occur within the given source range. The returned pointer must be
+  freed with clang_disposeTokens() before the translation unit is destroyed.
+  \param NumTokens will be set to the number of tokens in the \c *Tokens
+  array.
+*>
+extern fn void tokenize(
+  CXTranslationUnit tu,
+  CXSourceRange range,
+  CXToken** tokens,
+  CUInt* num_tokens)
+@cname("clang_tokenize");
 
-fn void enableStackTraces() 
-@extern("clang_enableStackTraces");
+<*
+  Annotate the given set of tokens by providing cursors for each token
+  that can be mapped to a specific entity within the abstract syntax tree.
+  This token-annotation routine is equivalent to invoking
+  clang_getCursor() for the source locations of each of the
+  tokens. The cursors provided are filtered, so that only those
+  cursors that have a direct correspondence to the token are
+  accepted. For example, given a function call \c f(x),
+  clang_getCursor() would provide the following cursors:
+  * when the cursor is over the 'f', a DeclRefExpr cursor referring to 'f'.
+  * when the cursor is over the '(' or the ')', a CallExpr referring to 'f'.
+  * when the cursor is over the 'x', a DeclRefExpr cursor referring to 'x'.
+  Only the first and last of these cursors will occur within the
+  annotate, since the tokens "f" and "x' directly refer to a function
+  and a variable, respectively, but the parentheses are just a small
+  part of the full syntax of the function call expression, which is
+  not provided as an annotation.
+  \param TU the translation unit that owns the given tokens.
+  \param Tokens the set of tokens to annotate.
+  \param NumTokens the number of tokens in \p Tokens.
+  \param Cursors an array of \p NumTokens cursors, whose contents will be
+  replaced with the cursors corresponding to each token.
+*>
+extern fn void annotateTokens(
+  CXTranslationUnit tu,
+  CXToken* tokens,
+  CUInt num_tokens,
+  CXCursor* cursors)
+@cname("clang_annotateTokens");
 
-alias VoidPtrCallback @private = fn void(void*);
+<*
+  Free the given set of tokens.
+*>
+extern fn void disposeTokens(
+  CXTranslationUnit tu,
+  CXToken* tokens,
+  CUInt num_tokens)
+@cname("clang_disposeTokens");
 
-fn void executeOnThread(
-  VoidPtrCallback func, 
-  void* user_data, 
-  CUInt stack_size) 
-@extern("clang_executeOnThread");
+<*
+  \defgroup CINDEX_DEBUG Debugging facilities
+  These routines are used for testing and debugging, only, and should not
+  be relied upon.
+  @{
+*>
+extern fn CXString getCursorKindSpelling(
+  CXCursorKind kind)
+@cname("clang_getCursorKindSpelling");
 
-/**
- * A semantic string that describes a code-completion result.
- *
- * A semantic string that describes the formatting of a code-completion
- * result as a single "template" of text that should be inserted into the
- * source buffer when a particular code-completion result is selected.
- * Each semantic string is made up of some number of "chunks", each of which
- * contains some text along with a description of what that text means, e.g.,
- * the name of the entity being referenced, whether the text chunk is part of
- * the template, or whether it is a "placeholder" that the user should replace
- * with actual code,of a specific kind. See \c CXCompletionChunkKind for a
- * description of the different kinds of chunks.
- */
-typedef CXCompletionString = inline void*;
+extern fn void getDefinitionSpellingAndExtent(
+  CXCursor,
+  ZString* start_buf,
+  ZString* end_buf,
+  CUInt* start_line,
+  CUInt* start_column,
+  CUInt* end_line,
+  CUInt* end_column)
+@cname("clang_getDefinitionSpellingAndExtent");
 
-/**
- * A single result of code completion.
- */
+extern fn void enableStackTraces()
+@cname("clang_enableStackTraces");
+
+alias UnnamedPFN1 @private = fn void(
+  void*);
+
+extern fn void executeOnThread(
+  UnnamedPFN1 func,
+  void* user_data,
+  CUInt stack_size)
+@cname("clang_executeOnThread");
+
+alias CXCompletionString = void*;
+
+<*
+  A single result of code completion.
+*>
 struct CXCompletionResult {
-  /*
-   * The kind of entity that this completion refers to.
-   *
-   * The cursor kind will be a macro, keyword, or a declaration (one of the
-   * *Decl cursor kinds), describing the entity that the completion is
-   * referring to.
-   *
-   * \todo In the future, we would like to provide a full cursor, to allow
-   * the client to extract additional information from declaration.
-   */
   CXCursorKind cursor_kind;
-
-  /*
-   * The code-completion string that describes how to insert this
-   * code-completion result into the editing buffer.
-   */
   CXCompletionString completion_string;
 }
 
-/**
- * Describes a single piece of text within a code-completion string.
- *
- * Each "chunk" within a code-completion string (\c CXCompletionString) is
- * either a piece of text with a specific "kind" that describes how that text
- * should be interpreted by the client or is another completion string.
- */
-typedef CXCompletionChunkKind = inline CInt;
+<*
+  Describes a single piece of text within a code-completion string.
+  Each "chunk" within a code-completion string (\c CXCompletionString) is
+  either a piece of text with a specific "kind" that describes how that text
+  should be interpreted by the client or is another completion string.
+*>
+constdef CXCompletionChunkKind : CInt {
 
-/**
- * A code-completion string that describes "optional" text that
- * could be a part of the template (but is not required).
- *
- * The Optional chunk is the only kind of chunk that has a code-completion
- * string for its representation, which is accessible via
- * \c clang_getCompletionChunkCompletionString(). The code-completion string
- * describes an additional part of the template that is completely optional.
- * For example, optional chunks can be used to describe the placeholders for
- * arguments that match up with defaulted function parameters, e.g. given:
- *
- * \code
- * void f(CInt x, float y = 3.14, double z = 2.71828);
- * \endcode
- *
- * The code-completion string for this function would contain:
- *   - a TypedText chunk for "f".
- *   - a LeftParen chunk for "(".
- *   - a Placeholder chunk for "CInt x"
- *   - an Optional chunk containing the remaining defaulted arguments, e.g.,
- *       - a Comma chunk for ","
- *       - a Placeholder chunk for "float y"
- *       - an Optional chunk containing the last defaulted argument:
- *           - a Comma chunk for ","
- *           - a Placeholder chunk for "double z"
- *   - a RightParen chunk for ")"
- *
- * There are many ways to handle Optional chunks. Two simple approaches are:
- *   - Completely ignore optional chunks, in which case the template for the
- *     function "f" would only include the first parameter ("CInt x").
- *   - Fully expand all optional chunks, in which case the template for the
- *     function "f" would have all of the parameters.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_OPTIONAL = 0;
-/**
- * Text that a user would be expected to type to get this
- * code-completion result.
- *
- * There will be exactly one "typed text" chunk in a semantic string, which
- * will typically provide the spelling of a keyword or the name of a
- * declaration that could be used at the current code point. Clients are
- * expected to filter the code-completion results based on the text in this
- * chunk.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_TYPED_TEXT = 1;
-/**
- * Text that should be inserted as part of a code-completion result.
- *
- * A "text" chunk represents text that is part of the template to be
- * inserted into user code should this particular code-completion result
- * be selected.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_TEXT = 2;
-/**
- * Placeholder text that should be replaced by the user.
- *
- * A "placeholder" chunk marks a place where the user should insert text
- * into the code-completion template. For example, placeholders might mark
- * the function parameters for a function declaration, to indicate that the
- * user should provide arguments for each of those parameters. The actual
- * text in a placeholder is a suggestion for the text to display before
- * the user replaces the placeholder with real code.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_PLACEHOLDER = 3;
-/**
- * Informative text that should be displayed but never inserted as
- * part of the template.
- *
- * An "informative" chunk contains annotations that can be displayed to
- * help the user decide whether a particular code-completion result is the
- * right option, but which is not part of the actual template to be inserted
- * by code completion.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_INFORMATIVE = 4;
-/**
- * Text that describes the current parameter when code-completion is
- * referring to function call, message send, or template specialization.
- *
- * A "current parameter" chunk occurs when code-completion is providing
- * information about a parameter corresponding to the argument at the
- * code-completion point. For example, given a function
- *
- * \code
- * CInt add(CInt x, CInt y);
- * \endcode
- *
- * and the source code \c add(, where the code-completion poCInt is after the
- * "(", the code-completion string will contain a "current parameter" chunk
- * for "CInt x", indicating that the current argument will initialize that
- * parameter. After typing further, to \c add(17, (where the code-completion
- * poCInt is after the ","), the code-completion string will contain a
- * "current parameter" chunk to "CInt y".
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_CURRENT_PARAMETER = 5;
-/**
- * A left parenthesis ('('), used to initiate a function call or
- * signal the beginning of a function parameter list.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_LEFT_PAREN = 6;
-/**
- * A right parenthesis (')'), used to finish a function call or
- * signal the end of a function parameter list.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RIGHT_PAREN = 7;
-/**
- * A left bracket ('[').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_LEFT_BRACKE = 8;
-/**
- * A right bracket (']').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RIGHT_BRACKET = 9;
-/**
- * A left brace ('{').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_LEFT_BRACE = 10;
-/**
- * A right brace ('}').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RIGHT_BRACE = 11;
-/**
- * A left angle bracket ('<').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_LEFT_ANGLE = 12;
-/**
- * A right angle bracket ('>').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RIGHT_ANGLE = 13;
-/**
- * A comma separator (',').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_COMMA = 14;
-/**
- * Text that specifies the result type of a given result.
- *
- * This special kind of informative chunk is not meant to be inserted into
- * the text buffer. Rather, it is meant to illustrate the type that an
- * expression using the given completion string would have.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_RESULT_TYPE = 15;
-/**
- * A colon (':').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_COLON = 16;
-/**
- * A semicolon (';').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_SEMI_COLON = 17;
-/**
- * An '=' sign.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_EQUAL = 18;
-/**
- * Horizontal space (' ').
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_HORIZONTAL_SPACE = 19;
-/**
- * Vertical space ('\\n'), after which it is generally a good idea to
- * perform indentation.
- */
-const CXCompletionChunkKind COMPLETION_CHUNK_VERTICAL_SPACE = 20;
+  <*
+    A code-completion string that describes "optional" text that
+    could be a part of the template (but is not required).
+    The Optional chunk is the only kind of chunk that has a code-completion
+    string for its representation, which is accessible via
+    \c clang_getCompletionChunkCompletionString(). The code-completion string
+    describes an additional part of the template that is completely optional.
+    For example, optional chunks can be used to describe the placeholders for
+    arguments that match up with defaulted function parameters, e.g. given:
+    \code
+    void f(int x, float y = 3.14, double z = 2.71828);
+    \endcode
+    The code-completion string for this function would contain:
+    - a TypedText chunk for "f".
+    - a LeftParen chunk for "(".
+    - a Placeholder chunk for "int x"
+    - an Optional chunk containing the remaining defaulted arguments, e.g.,
+    - a Comma chunk for ","
+    - a Placeholder chunk for "float y"
+    - an Optional chunk containing the last defaulted argument:
+    - a Comma chunk for ","
+    - a Placeholder chunk for "double z"
+    - a RightParen chunk for ")"
+    There are many ways to handle Optional chunks. Two simple approaches are:
+    - Completely ignore optional chunks, in which case the template for the
+    function "f" would only include the first parameter ("int x").
+    - Fully expand all optional chunks, in which case the template for the
+    function "f" would have all of the parameters.
+  *>
+  COMPLETION_CHUNK_OPTIONAL = 0,
 
-/**
- * Determine the kind of a particular chunk within a completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \param chunk_number the 0-based index of the chunk in the completion string.
- *
- * \returns the kind of the chunk at the index \c chunk_number.
- */
-fn CXCompletionChunkKind getCompletionChunkKind(
-  CXCompletionString completion_string, 
-  CUInt chunk_number) 
-@extern("clang_getCompletionChunkKind");
+  <*
+    Text that a user would be expected to type to get this
+    code-completion result.
+    There will be exactly one "typed text" chunk in a semantic string, which
+    will typically provide the spelling of a keyword or the name of a
+    declaration that could be used at the current code point. Clients are
+    expected to filter the code-completion results based on the text in this
+    chunk.
+  *>
+  COMPLETION_CHUNK_TYPED_TEXT = 1,
 
-/**
- * Retrieve the text associated with a particular chunk within a
- * completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \param chunk_number the 0-based index of the chunk in the completion string.
- *
- * \returns the text associated with the chunk at index \c chunk_number.
- */
-fn CXString getCompletionChunkText(
-  CXCompletionString completion_string, 
-  CUInt chunk_number) 
-@extern("clang_getCompletionChunkText");
+  <*
+    Text that should be inserted as part of a code-completion result.
+    A "text" chunk represents text that is part of the template to be
+    inserted into user code should this particular code-completion result
+    be selected.
+  *>
+  COMPLETION_CHUNK_TEXT = 2,
 
-/**
- * Retrieve the completion string associated with a particular chunk
- * within a completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \param chunk_number the 0-based index of the chunk in the completion string.
- *
- * \returns the completion string associated with the chunk at index
- * \c chunk_number.
- */
-fn CXCompletionString getCompletionChunkCompletionString(
-  CXCompletionString completion_string, 
-  CUInt chunk_number) 
-@extern("clang_getCompletionChunkCompletionString");
+  <*
+    Placeholder text that should be replaced by the user.
+    A "placeholder" chunk marks a place where the user should insert text
+    into the code-completion template. For example, placeholders might mark
+    the function parameters for a function declaration, to indicate that the
+    user should provide arguments for each of those parameters. The actual
+    text in a placeholder is a suggestion for the text to display before
+    the user replaces the placeholder with real code.
+  *>
+  COMPLETION_CHUNK_PLACEHOLDER = 3,
 
-/**
- * Retrieve the number of chunks in the given code-completion string.
- */
-fn CUInt getNumCompletionChunks(
-  CXCompletionString completion_string) 
-@extern("clang_getNumCompletionChunks");
+  <*
+    Informative text that should be displayed but never inserted as
+    part of the template.
+    An "informative" chunk contains annotations that can be displayed to
+    help the user decide whether a particular code-completion result is the
+    right option, but which is not part of the actual template to be inserted
+    by code completion.
+  *>
+  COMPLETION_CHUNK_INFORMATIVE = 4,
 
-/**
- * Determine the priority of this code completion.
- *
- * The priority of a code completion indicates how likely it is that this
- * particular completion is the completion that the user will select. The
- * priority is selected by various internal heuristics.
- *
- * \param completion_string The completion string to query.
- *
- * \returns The priority of this completion string. Smaller values indicate
- * higher-priority (more likely) completions.
- */
-fn CUInt getCompletionPriority(
-  CXCompletionString completion_string) 
-@extern("clang_getCompletionPriority");
+  <*
+    Text that describes the current parameter when code-completion is
+    referring to function call, message send, or template specialization.
+    A "current parameter" chunk occurs when code-completion is providing
+    information about a parameter corresponding to the argument at the
+    code-completion point. For example, given a function
+    \code
+    int add(int x, int y);
+    \endcode
+    and the source code \c add(, where the code-completion point is after the
+    "(", the code-completion string will contain a "current parameter" chunk
+    for "int x", indicating that the current argument will initialize that
+    parameter. After typing further, to \c add(17, (where the code-completion
+    point is after the ","), the code-completion string will contain a
+    "current parameter" chunk to "int y".
+  *>
+  COMPLETION_CHUNK_CURRENT_PARAMETER = 5,
 
-/**
- * Determine the availability of the entity that this code-completion
- * string refers to.
- *
- * \param completion_string The completion string to query.
- *
- * \returns The availability of the completion string.
- */
-fn CXAvailabilityKind getCompletionAvailability(
-  CXCompletionString completion_string) 
-@extern("clang_getCompletionAvailability");
+  <*
+    A left parenthesis ('('), used to initiate a function call or
+    signal the beginning of a function parameter list.
+  *>
+  COMPLETION_CHUNK_LEFT_PAREN = 6,
 
-/**
- * Retrieve the number of annotations associated with the given
- * completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \returns the number of annotations associated with the given completion
- * string.
- */
-fn CUInt getCompletionNumAnnotations(
-  CXCompletionString completion_string) 
-@extern("clang_getCompletionNumAnnotations");
+  <*
+    A right parenthesis (')'), used to finish a function call or
+    signal the end of a function parameter list.
+  *>
+  COMPLETION_CHUNK_RIGHT_PAREN = 7,
 
-/**
- * Retrieve the annotation associated with the given completion string.
- *
- * \param completion_string the completion string to query.
- *
- * \param annotation_number the 0-based index of the annotation of the
- * completion string.
- *
- * \returns annotation string associated with the completion at index
- * \c annotation_number, or a NULL string if that annotation is not available.
- */
-fn CXString getCompletionAnnotation(
-  CXCompletionString completion_string, 
-  CUInt annotation_number) 
-@extern("clang_getCompletionAnnotation");
+  <*
+    A left bracket ('[').
+  *>
+  COMPLETION_CHUNK_LEFT_BRACKET = 8,
 
-/**
- * Retrieve the parent context of the given completion string.
- *
- * The parent context of a completion string is the semantic parent of
- * the declaration (if any) that the code completion represents. For example,
- * a code completion for an Objective-C method would have the method's class
- * or protocol as its context.
- *
- * \param completion_string The code completion string whose parent is
- * being queried.
- *
- * \param kind DEPRECATED: always set to CXCursor_NotImplemented if non-NULL.
- *
- * \returns The name of the completion parent, e.g., "NSObject" if
- * the completion string represents a method in the NSObject class.
- */
-fn CXString getCompletionParent(
-  CXCompletionString completion_string, 
-  CXCursorKind* kind) 
-@extern("clang_getCompletionParent");
+  <*
+    A right bracket (']').
+  *>
+  COMPLETION_CHUNK_RIGHT_BRACKET = 9,
 
-/**
- * Retrieve the brief documentation comment attached to the declaration
- * that corresponds to the given completion string.
- */
-fn CXString getCompletionBriefComment(
-  CXCompletionString completion_string) 
-@extern("clang_getCompletionBriefComment");
+  <*
+    A left brace ('{').
+  *>
+  COMPLETION_CHUNK_LEFT_BRACE = 10,
 
-/**
- * Retrieve a completion string for an arbitrary declaration or macro
- * definition cursor.
- *
- * \param cursor The cursor to query.
- *
- * \returns A non-context-sensitive completion string for declaration and macro
- * definition cursors, or NULL for other kinds of cursors.
- */
-fn CXCompletionString getCursorCompletionString(
-  CXCursor cursor) 
-@extern("clang_getCursorCompletionString");
+  <*
+    A right brace ('}').
+  *>
+  COMPLETION_CHUNK_RIGHT_BRACE = 11,
 
-/**
- * Contains the results of code-completion.
- *
- * This data structure contains the results of code completion, as
- * produced by \c clang_codeCompleteAt(). Its contents must be freed by
- * \c clang_disposeCodeCompleteResults.
- */
+  <*
+    A left angle bracket ('<').
+  *>
+  COMPLETION_CHUNK_LEFT_ANGLE = 12,
+
+  <*
+    A right angle bracket ('>').
+  *>
+  COMPLETION_CHUNK_RIGHT_ANGLE = 13,
+
+  <*
+    A comma separator (',').
+  *>
+  COMPLETION_CHUNK_COMMA = 14,
+
+  <*
+    Text that specifies the result type of a given result.
+    This special kind of informative chunk is not meant to be inserted into
+    the text buffer. Rather, it is meant to illustrate the type that an
+    expression using the given completion string would have.
+  *>
+  COMPLETION_CHUNK_RESULT_TYPE = 15,
+
+  <*
+    A colon (':').
+  *>
+  COMPLETION_CHUNK_COLON = 16,
+
+  <*
+    A semicolon (';').
+  *>
+  COMPLETION_CHUNK_SEMI_COLON = 17,
+
+  <*
+    An '=' sign.
+  *>
+  COMPLETION_CHUNK_EQUAL = 18,
+
+  <*
+    Horizontal space (' ').
+  *>
+  COMPLETION_CHUNK_HORIZONTAL_SPACE = 19,
+
+  <*
+    Vertical space ('\\n'), after which it is generally a good idea to
+    perform indentation.
+  *>
+  COMPLETION_CHUNK_VERTICAL_SPACE = 20
+}
+
+<*
+  Determine the kind of a particular chunk within a completion string.
+  \param completion_string the completion string to query.
+  \param chunk_number the 0-based index of the chunk in the completion string.
+  \returns the kind of the chunk at the index \c chunk_number.
+*>
+extern fn CXCompletionChunkKind getCompletionChunkKind(
+  CXCompletionString completion_string,
+  CUInt chunk_number)
+@cname("clang_getCompletionChunkKind");
+
+<*
+  Retrieve the text associated with a particular chunk within a
+  completion string.
+  \param completion_string the completion string to query.
+  \param chunk_number the 0-based index of the chunk in the completion string.
+  \returns the text associated with the chunk at index \c chunk_number.
+*>
+extern fn CXString getCompletionChunkText(
+  CXCompletionString completion_string,
+  CUInt chunk_number)
+@cname("clang_getCompletionChunkText");
+
+<*
+  Retrieve the completion string associated with a particular chunk
+  within a completion string.
+  \param completion_string the completion string to query.
+  \param chunk_number the 0-based index of the chunk in the completion string.
+  \returns the completion string associated with the chunk at index
+  \c chunk_number.
+*>
+extern fn CXCompletionString getCompletionChunkCompletionString(
+  CXCompletionString completion_string,
+  CUInt chunk_number)
+@cname("clang_getCompletionChunkCompletionString");
+
+<*
+  Retrieve the number of chunks in the given code-completion string.
+*>
+extern fn CUInt getNumCompletionChunks(
+  CXCompletionString completion_string)
+@cname("clang_getNumCompletionChunks");
+
+<*
+  Determine the priority of this code completion.
+  The priority of a code completion indicates how likely it is that this
+  particular completion is the completion that the user will select. The
+  priority is selected by various internal heuristics.
+  \param completion_string The completion string to query.
+  \returns The priority of this completion string. Smaller values indicate
+  higher-priority (more likely) completions.
+*>
+extern fn CUInt getCompletionPriority(
+  CXCompletionString completion_string)
+@cname("clang_getCompletionPriority");
+
+<*
+  Determine the availability of the entity that this code-completion
+  string refers to.
+  \param completion_string The completion string to query.
+  \returns The availability of the completion string.
+*>
+extern fn CXAvailabilityKind getCompletionAvailability(
+  CXCompletionString completion_string)
+@cname("clang_getCompletionAvailability");
+
+<*
+  Retrieve the number of annotations associated with the given
+  completion string.
+  \param completion_string the completion string to query.
+  \returns the number of annotations associated with the given completion
+  string.
+*>
+extern fn CUInt getCompletionNumAnnotations(
+  CXCompletionString completion_string)
+@cname("clang_getCompletionNumAnnotations");
+
+<*
+  Retrieve the annotation associated with the given completion string.
+  \param completion_string the completion string to query.
+  \param annotation_number the 0-based index of the annotation of the
+  completion string.
+  \returns annotation string associated with the completion at index
+  \c annotation_number, or a NULL string if that annotation is not available.
+*>
+extern fn CXString getCompletionAnnotation(
+  CXCompletionString completion_string,
+  CUInt annotation_number)
+@cname("clang_getCompletionAnnotation");
+
+<*
+  Retrieve the parent context of the given completion string.
+  The parent context of a completion string is the semantic parent of
+  the declaration (if any) that the code completion represents. For example,
+  a code completion for an Objective-C method would have the method's class
+  or protocol as its context.
+  \param completion_string The code completion string whose parent is
+  being queried.
+  \param kind DEPRECATED: always set to CXCursor_NotImplemented if non-NULL.
+  \returns The name of the completion parent, e.g., "NSObject" if
+  the completion string represents a method in the NSObject class.
+*>
+extern fn CXString getCompletionParent(
+  CXCompletionString completion_string,
+  CXCursorKind* kind)
+@cname("clang_getCompletionParent");
+
+<*
+  Retrieve the brief documentation comment attached to the declaration
+  that corresponds to the given completion string.
+*>
+extern fn CXString getCompletionBriefComment(
+  CXCompletionString completion_string)
+@cname("clang_getCompletionBriefComment");
+
+<*
+  Retrieve a completion string for an arbitrary declaration or macro
+  definition cursor.
+  \param cursor The cursor to query.
+  \returns A non-context-sensitive completion string for declaration and macro
+  definition cursors, or NULL for other kinds of cursors.
+*>
+extern fn CXCompletionString getCursorCompletionString(
+  CXCursor cursor)
+@cname("clang_getCursorCompletionString");
+
+<*
+  Contains the results of code-completion.
+  This data structure contains the results of code completion, as
+  produced by \c clang_codeCompleteAt(). Its contents must be freed by
+  \c clang_disposeCodeCompleteResults.
+*>
 struct CXCodeCompleteResults {
-  /*
-   * The code-completion results.
-   */
   CXCompletionResult* results;
-
-  /*
-   * The number of code-completion results stored in the
-   * \c Results array.
-   */
   CUInt num_results;
 }
 
-/**
- * Retrieve the number of fix-its for the given completion index.
- *
- * Calling this makes sense only if CXCodeComplete_IncludeCompletionsWithFixIts
- * option was set.
- *
- * \param results The structure keeping all completion results
- *
- * \param completion_index The index of the completion
- *
- * \return The number of fix-its which must be applied before the completion at
- * completion_index can be applied
- */
-fn CUInt getCompletionNumFixIts(
-  CXCodeCompleteResults* results, 
-  CUInt completion_index) 
-@extern("clang_getCompletionNumFixIts");
+<*
+  Retrieve the number of fix-its for the given completion index.
+  Calling this makes sense only if CXCodeComplete_IncludeCompletionsWithFixIts
+  option was set.
+  \param results The structure keeping all completion results
+  \param completion_index The index of the completion
+  \return The number of fix-its which must be applied before the completion at
+  completion_index can be applied
+*>
+extern fn CUInt getCompletionNumFixIts(
+  CXCodeCompleteResults* results,
+  CUInt completion_index)
+@cname("clang_getCompletionNumFixIts");
 
-/**
- * Fix-its that *must* be applied before inserting the text for the
- * corresponding completion.
- *
- * By default, clang_codeCompleteAt() only returns completions with empty
- * fix-its. Extra completions with non-empty fix-its should be explicitly
- * requested by setting CXCodeComplete_IncludeCompletionsWithFixIts.
- *
- * For the clients to be able to compute position of the cursor after applying
- * fix-its, the following conditions are guaranteed to hold for
- * replacement_range of the stored fix-its:
- *  - Ranges in the fix-its are guaranteed to never contain the completion
- *  poCInt (or identifier under completion point, if any) inside them, except
- *  at the start or at the end of the range.
- *  - If a fix-it range starts or ends with completion poCInt (or starts or
- *  ends after the identifier under completion point), it will contain at
- *  least one character. It allows to unambiguously recompute completion
- *  poCInt after applying the fix-it.
- *
- * The intuition is that provided fix-its change code around the identifier we
- * complete, but are not allowed to touch the identifier itself or the
- * completion point. One example of completions with corrections are the ones
- * replacing '.' with '->' and vice versa:
- *
- * std::unique_ptr<std::vector<CInt>> vec_ptr;
- * In 'vec_ptr.^', one of the completions is 'push_back', it requires
- * replacing '.' with '->'.
- * In 'vec_ptr->^', one of the completions is 'release', it requires
- * replacing '->' with '.'.
- *
- * \param results The structure keeping all completion results
- *
- * \param completion_index The index of the completion
- *
- * \param fixit_index The index of the fix-it for the completion at
- * completion_index
- *
- * \param replacement_range The fix-it range that must be replaced before the
- * completion at completion_index can be applied
- *
- * \returns The fix-it string that must replace the code at replacement_range
- * before the completion at completion_index can be applied
- */
-fn CXString getCompletionFixIt(
-  CXCodeCompleteResults* results, 
-  CUInt completion_index, 
-  CUInt fixit_index, 
-  CXSourceRange* replacement_range) 
-@extern("clang_getCompletionFixIt");
+<*
+  Fix-its that *must* be applied before inserting the text for the
+  corresponding completion.
+  By default, clang_codeCompleteAt() only returns completions with empty
+  fix-its. Extra completions with non-empty fix-its should be explicitly
+  requested by setting CXCodeComplete_IncludeCompletionsWithFixIts.
+  For the clients to be able to compute position of the cursor after applying
+  fix-its, the following conditions are guaranteed to hold for
+  replacement_range of the stored fix-its:
+  - Ranges in the fix-its are guaranteed to never contain the completion
+  point (or identifier under completion point, if any) inside them, except
+  at the start or at the end of the range.
+  - If a fix-it range starts or ends with completion point (or starts or
+  ends after the identifier under completion point), it will contain at
+  least one character. It allows to unambiguously recompute completion
+  point after applying the fix-it.
+  The intuition is that provided fix-its change code around the identifier we
+  complete, but are not allowed to touch the identifier itself or the
+  completion point. One example of completions with corrections are the ones
+  replacing '.' with '->' and vice versa:
+  std::unique_ptr<std::vector<int>> vec_ptr;
+  In 'vec_ptr.^', one of the completions is 'push_back', it requires
+  replacing '.' with '->'.
+  In 'vec_ptr->^', one of the completions is 'release', it requires
+  replacing '->' with '.'.
+  \param results The structure keeping all completion results
+  \param completion_index The index of the completion
+  \param fixit_index The index of the fix-it for the completion at
+  completion_index
+  \param replacement_range The fix-it range that must be replaced before the
+  completion at completion_index can be applied
+  \returns The fix-it string that must replace the code at replacement_range
+  before the completion at completion_index can be applied
+*>
+extern fn CXString getCompletionFixIt(
+  CXCodeCompleteResults* results,
+  CUInt completion_index,
+  CUInt fixit_index,
+  CXSourceRange* replacement_range)
+@cname("clang_getCompletionFixIt");
 
-/**
- * Flags that can be passed to \c clang_codeCompleteAt() to
- * modify its behavior.
- *
- * The enumerators in this enumeration can be bitwise-OR'd together to
- * provide multiple options to \c clang_codeCompleteAt().
- */
-typedef CXCodeComplete_Flags = inline CInt;
+<*
+  Flags that can be passed to \c clang_codeCompleteAt() to
+  modify its behavior.
+  The enumerators in this enumeration can be bitwise-OR'd together to
+  provide multiple options to \c clang_codeCompleteAt().
+*>
+constdef CXCodeComplete_Flags : CInt {
 
-/**
- * Whether to include macros within the set of code
- * completions returned.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_INCLUDE_MACROS = 0x01;
+  <*
+    Whether to include macros within the set of code
+    completions returned.
+  *>
+  CODE_COMPLETE_INCLUDE_MACROS = 1,
 
-/**
- * Whether to include code patterns for language constructs
- * within the set of code completions, e.g., for loops.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_INCLUDE_CODE_PATTERNS = 0x02;
+  <*
+    Whether to include code patterns for language constructs
+    within the set of code completions, e.g., for loops.
+  *>
+  CODE_COMPLETE_INCLUDE_CODE_PATTERNS = 2,
 
-/**
- * Whether to include brief documentation within the set of code
- * completions returned.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_INCLUDE_BRIEF_COMMENTS = 0x04;
+  <*
+    Whether to include brief documentation within the set of code
+    completions returned.
+  *>
+  CODE_COMPLETE_INCLUDE_BRIEF_COMMENTS = 4,
 
-/**
- * Whether to speed up completion by omitting top- or namespace-level entities
- * defined in the preamble. There's no guarantee any particular entity is
- * omitted. This may be useful if the headers are indexed externally.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_SKIP_PREAMBLE = 0x08;
+  <*
+    Whether to speed up completion by omitting top- or namespace-level entities
+    defined in the preamble. There's no guarantee any particular entity is
+    omitted. This may be useful if the headers are indexed externally.
+  *>
+  CODE_COMPLETE_SKIP_PREAMBLE = 8,
 
-/**
- * Whether to include completions with small
- * fix-its, e.g. change '.' to '->' on member access, etc.
- */
-const CXCodeComplete_Flags CODE_COMPLETE_INCLUDE_COMPLETION_SWITH_FIX_ITS = 0x10;
+  <*
+    Whether to include completions with small
+    fix-its, e.g. change '.' to '->' on member access, etc.
+  *>
+  CODE_COMPLETE_INCLUDE_COMPLETIONS_WITH_FIX_ITS = 16
+}
 
-/**
- * Bits that represent the context under which completion is occurring.
- *
- * The enumerators in this enumeration may be bitwise-OR'd together if multiple
- * contexts are occurring simultaneously.
- */
-typedef CXCompletionContext = inline CInt;
+<*
+  Bits that represent the context under which completion is occurring.
+  The enumerators in this enumeration may be bitwise-OR'd together if multiple
+  contexts are occurring simultaneously.
+*>
+constdef CXCompletionContext : CInt {
 
-/**
- * The context for completions is unexposed, as only Clang results
- * should be included. (This is equivalent to having no context bits set.)
- */
-const CXCompletionContext COMPLETION_CONTEXT_UNEXPOSED = 0;
-/**
- * Completions for any possible type should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_ANY_TYPE = 1 << 0;
-/**
- * Completions for any possible value (variables, function calls, etc.)
- * should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_ANY_VALUE = 1 << 1;
-/**
- * Completions for values that resolve to an Objective-C object should
- * be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_OBJECT_VALUE = 1 << 2;
-/**
- * Completions for values that resolve to an Objective-C selector
- * should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_SELECT_OR_VALUE = 1 << 3;
-/**
- * Completions for values that resolve to a C++ class type should be
- * included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_CXX_CLASS_TYPE_VALUE = 1 << 4;
-/**
- * Completions for fields of the member being accessed using the dot
- * operator should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_DOT_MEMBER_ACCESS = 1 << 5;
-/**
- * Completions for fields of the member being accessed using the arrow
- * operator should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_ARROW_MEMBER_ACCESS = 1 << 6;
-/**
- * Completions for properties of the Objective-C object being accessed
- * using the dot operator should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_PROPERTY_ACCESS = 1 << 7;
-/**
- * Completions for enum tags should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_ENUM_TAG = 1 << 8;
-/**
- * Completions for union tags should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_UNION_TAG = 1 << 9;
-/**
- * Completions for struct tags should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_STRUCT_TAG = 1 << 10;
+  <*
+    The context for completions is unexposed, as only Clang results
+    should be included. (This is equivalent to having no context bits set.)
+  *>
+  COMPLETION_CONTEXT_UNEXPOSED = 0,
 
-/**
- * Completions for C++ class names should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_CLASS_TAG = 1 << 11;
-/**
- * Completions for C++ namespaces and namespace aliases should be
- * included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_NAMESPACE = 1 << 12;
-/**
- * Completions for C++ nested name specifiers should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_NESTED_NAME_SPECIFIER = 1 << 13;
-/**
- * Completions for Objective-C interfaces (classes) should be included
- * in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_INTERFACE = 1 << 14;
-/**
- * Completions for Objective-C protocols should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_PROTOCOL = 1 << 15;
-/**
- * Completions for Objective-C categories should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_CATEGORY = 1 << 16;
-/**
- * Completions for Objective-C instance messages should be included
- * in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_INSTANCE_MESSAGE = 1 << 17;
-/**
- * Completions for Objective-C class messages should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_CLASS_MESSAGE = 1 << 18;
-/**
- * Completions for Objective-C selector names should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_OBJC_SELECTOR_NAME = 1 << 19;
-/**
- * Completions for preprocessor macro names should be included in
- * the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_MACRO_NAME = 1 << 20;
-/**
- * Natural language completions should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_NATURAL_LANGUAGE = 1 << 21;
-/**
- * #include file completions should be included in the results.
- */
-const CXCompletionContext COMPLETION_CONTEXT_INCLUDED_FILE = 1 << 22;
-/**
- * The current context is unknown, so set all contexts.
- */
-const CXCompletionContext COMPLETION_CONTEXT_UNKNOWN = ((1 << 23) - 1);
+  <*
+    Completions for any possible type should be included in the results.
+  *>
+  COMPLETION_CONTEXT_ANY_TYPE = 1,
 
-/**
- * Returns a default set of code-completion options that can be
- * passed to\c clang_codeCompleteAt().
- */
-fn CUInt defaultCodeCompleteOptions() 
-@extern("clang_defaultCodeCompleteOptions");
+  <*
+    Completions for any possible value (variables, function calls, etc.)
+    should be included in the results.
+  *>
+  COMPLETION_CONTEXT_ANY_VALUE = 2,
 
-/**
- * Perform code completion at a given location in a translation unit.
- *
- * This function performs code completion at a particular file, line, and
- * column within source code, providing results that suggest potential
- * code snippets based on the context of the completion. The basic model
- * for code completion is that Clang will parse a complete source file,
- * performing syntax checking up to the location where code-completion has
- * been requested. At that point, a special code-completion token is passed
- * to the parser, which recognizes this token and determines, based on the
- * current location in the C/Objective-C/C++ grammar and the state of
- * semantic analysis, what completions to provide. These completions are
- * returned via a new \c CXCodeCompleteResults structure.
- *
- * Code completion itself is meant to be triggered by the client when the
- * user types punctuation characters or whitespace, at which poCInt the
- * code-completion location will coincide with the cursor. For example, if \c p
- * is a pointer, code-completion might be triggered after the "-" and then
- * after the ">" in \c p->. When the code-completion location is after the ">",
- * the completion results will provide, e.g., the members of the struct that
- * "p" points to. The client is responsible for placing the cursor at the
- * beginning of the token currently being typed, then filtering the results
- * based on the contents of the token. For example, when code-completing for
- * the expression \c p->get, the client should provide the location just after
- * the ">" (e.g., pointing at the "g") to this code-completion hook. Then, the
- * client can filter the results based on the current token text ("get"), only
- * showing those results that start with "get". The intent of this interface
- * is to separate the relatively high-latency acquisition of code-completion
- * results from the filtering of results on a per-character basis, which must
- * have a lower latency.
- *
- * \param TU The translation unit in which code-completion should
- * occur. The source files for this translation unit need not be
- * completely up-to-date (and the contents of those source files may
- * be overridden via \p unsaved_files). Cursors referring into the
- * translation unit may be invalidated by this invocation.
- *
- * \param complete_filename The name of the source file where code
- * completion should be performed. This filename may be any file
- * included in the translation unit.
- *
- * \param complete_line The line at which code-completion should occur.
- *
- * \param complete_column The column at which code-completion should occur.
- * Note that the column should poCInt just after the syntactic construct that
- * initiated code completion, and not in the middle of a lexical token.
- *
- * \param unsaved_files the Files that have not yet been saved to disk
- * but may be required for parsing or code completion, including the
- * contents of those files.  The contents and name of these files (as
- * specified by CXUnsavedFile) are copied when necessary, so the
- * client only needs to guarantee their validity until the call to
- * this function returns.
- *
- * \param num_unsaved_files The number of unsaved file entries in \p
- * unsaved_files.
- *
- * \param options Extra options that control the behavior of code
- * completion, expressed as a bitwise OR of the enumerators of the
- * CXCodeComplete_Flags enumeration. The
- * \c clang_defaultCodeCompleteOptions() function returns a default set
- * of code-completion options.
- *
- * \returns If successful, a new \c CXCodeCompleteResults structure
- * containing code-completion results, which should eventually be
- * freed with \c clang_disposeCodeCompleteResults(). If code
- * completion fails, returns NULL.
- */
-fn CXCodeCompleteResults* codeCompleteAt(
-  CXTranslationUnit tu, 
-  ZString complete_filename, 
-  CUInt complete_line, 
-  CUInt complete_column, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CUInt options) 
-@extern("clang_codeCompleteAt");
+  <*
+    Completions for values that resolve to an Objective-C object should
+    be included in the results.
+  *>
+  COMPLETION_CONTEXT_OBJ_C_OBJECT_VALUE = 4,
 
-/**
- * Sort the code-completion results in case-insensitive alphabetical
- * order.
- *
- * \param Results The set of results to sort.
- * \param NumResults The number of results in \p Results.
- */
-fn void sortCodeCompletionResults(
-  CXCompletionResult* results, 
-  CUInt num_results) 
-@extern("clang_sortCodeCompletionResults");
+  <*
+    Completions for values that resolve to an Objective-C selector
+    should be included in the results.
+  *>
+  COMPLETION_CONTEXT_OBJ_C_SELECTOR_VALUE = 8,
 
-/**
- * Free the given set of code-completion results.
- */
-fn void disposeCodeCompleteResults(
-  CXCodeCompleteResults *results) 
-@extern("clang_disposeCodeCompleteResults");
+  <*
+    Completions for values that resolve to a C++ class type should be
+    included in the results.
+  *>
+  COMPLETION_CONTEXT_CXX_CLASS_TYPE_VALUE = 16,
 
-/**
- * Determine the number of diagnostics produced prior to the
- * location where code completion was performed.
- */
-fn CUInt codeCompleteGetNumDiagnostics(
-  CXCodeCompleteResults* results) 
-@extern("clang_codeCompleteGetNumDiagnostics");
+  <*
+    Completions for fields of the member being accessed using the dot
+    operator should be included in the results.
+  *>
+  COMPLETION_CONTEXT_DOT_MEMBER_ACCESS = 32,
 
-/**
- * Retrieve a diagnostic associated with the given code completion.
- *
- * \param Results the code completion results to query.
- * \param Index the zero-based diagnostic number to retrieve.
- *
- * \returns the requested diagnostic. This diagnostic must be freed
- * via a call to \c clang_disposeDiagnostic().
- */
-fn CXDiagnostic codeCompleteGetDiagnostic(
-  CXCodeCompleteResults* results, 
-  CUInt index) 
-@extern("clang_codeCompleteGetDiagnostic");
+  <*
+    Completions for fields of the member being accessed using the arrow
+    operator should be included in the results.
+  *>
+  COMPLETION_CONTEXT_ARROW_MEMBER_ACCESS = 64,
 
-/**
- * Determines what completions are appropriate for the context
- * the given code completion.
- *
- * \param Results the code completion results to query
- *
- * \returns the kinds of completions that are appropriate for use
- * along with the given code completion results.
- */
-fn CULongLong codeCompleteGetContexts(
-  CXCodeCompleteResults* results) 
-@extern("clang_codeCompleteGetContexts");
+  <*
+    Completions for properties of the Objective-C object being accessed
+    using the dot operator should be included in the results.
+  *>
+  COMPLETION_CONTEXT_OBJ_C_PROPERTY_ACCESS = 128,
 
-/**
- * Returns the cursor kind for the container for the current code
- * completion context. The container is only guaranteed to be set for
- * contexts where a container exists (i.e. member accesses or Objective-C
- * message sends); if there is not a container, this function will return
- * CXCursor_InvalidCode.
- *
- * \param Results the code completion results to query
- *
- * \param IsIncomplete on return, this value will be false if Clang has complete
- * information about the container. If Clang does not have complete
- * information, this value will be true.
- *
- * \returns the container kind, or CXCursor_InvalidCode if there is not a
- * container
- */
-fn CXCursorKind codeCompleteGetContainerKind(
-  CXCodeCompleteResults* results, 
-  CUInt* is_incomplete) 
-@extern("clang_codeCompleteGetContainerKind");
+  <*
+    Completions for enum tags should be included in the results.
+  *>
+  COMPLETION_CONTEXT_ENUM_TAG = 256,
 
-/**
- * Returns the USR for the container for the current code completion
- * context. If there is not a container for the current context, this
- * function will return the empty string.
- *
- * \param Results the code completion results to query
- *
- * \returns the USR for the container
- */
-fn CXString codeCompleteGetContainerUSR(
-  CXCodeCompleteResults* results) 
-@extern("clang_codeCompleteGetContainerUSR");
+  <*
+    Completions for union tags should be included in the results.
+  *>
+  COMPLETION_CONTEXT_UNION_TAG = 512,
 
-/**
- * Returns the currently-entered selector for an Objective-C message
- * send, formatted like "initWithFoo:bar:". Only guaranteed to return a
- * non-empty string for CXCompletionContext_ObjCInstanceMessage and
- * CXCompletionContext_ObjCClassMessage.
- *
- * \param Results the code completion results to query
- *
- * \returns the selector (or partial selector) that has been entered thus far
- * for an Objective-C message send.
- */
-fn CXString codeCompleteGetObjCSelector(
-  CXCodeCompleteResults* results) 
-@extern("clang_codeCompleteGetObjCSelector");
+  <*
+    Completions for struct tags should be included in the results.
+  *>
+  COMPLETION_CONTEXT_STRUCT_TAG = 1024,
 
-/**
- * Return a version string, suitable for showing to a user, but not
- *        intended to be parsed (the format is not guaranteed to be stable).
- */
-fn CXString getClangVersion() 
-@extern("clang_getClangVersion");
+  <*
+    Completions for C++ class names should be included in the results.
+  *>
+  COMPLETION_CONTEXT_CLASS_TAG = 2048,
 
-/**
- * Enable/disable crash recovery.
- *
- * \param isEnabled Flag to indicate if crash recovery is enabled.  A non-zero
- *        value enables crash recovery, while 0 disables it.
- */
-fn void toggleCrashRecovery(
-  CUInt is_enabled) 
-@extern("clang_toggleCrashRecovery");
+  <*
+    Completions for C++ namespaces and namespace aliases should be
+    included in the results.
+  *>
+  COMPLETION_CONTEXT_NAMESPACE = 4096,
 
-/**
- * Visitor invoked for each file in a translation unit
- *        (used with clang_getInclusions()).
- *
- * This visitor function will be invoked by clang_getInclusions() for each
- * file included (either at the top-level or by \#include directives) within
- * a translation unit.  The first argument is the file being included, and
- * the second and third arguments provide the inclusion stack.  The
- * array is sorted in order of immediate inclusion.  For example,
- * the first element refers to the location that included 'included_file'.
- */
+  <*
+    Completions for C++ nested name specifiers should be included in
+    the results.
+  *>
+  COMPLETION_CONTEXT_NESTED_NAME_SPECIFIER = 8192,
+
+  <*
+    Completions for Objective-C interfaces (classes) should be included
+    in the results.
+  *>
+  COMPLETION_CONTEXT_OBJ_C_INTERFACE = 16384,
+
+  <*
+    Completions for Objective-C protocols should be included in
+    the results.
+  *>
+  COMPLETION_CONTEXT_OBJ_C_PROTOCOL = 32768,
+
+  <*
+    Completions for Objective-C categories should be included in
+    the results.
+  *>
+  COMPLETION_CONTEXT_OBJ_C_CATEGORY = 65536,
+
+  <*
+    Completions for Objective-C instance messages should be included
+    in the results.
+  *>
+  COMPLETION_CONTEXT_OBJ_C_INSTANCE_MESSAGE = 131072,
+
+  <*
+    Completions for Objective-C class messages should be included in
+    the results.
+  *>
+  COMPLETION_CONTEXT_OBJ_C_CLASS_MESSAGE = 262144,
+
+  <*
+    Completions for Objective-C selector names should be included in
+    the results.
+  *>
+  COMPLETION_CONTEXT_OBJ_C_SELECTOR_NAME = 524288,
+
+  <*
+    Completions for preprocessor macro names should be included in
+    the results.
+  *>
+  COMPLETION_CONTEXT_MACRO_NAME = 1048576,
+
+  <*
+    Natural language completions should be included in the results.
+  *>
+  COMPLETION_CONTEXT_NATURAL_LANGUAGE = 2097152,
+
+  <*
+    #include file completions should be included in the results.
+  *>
+  COMPLETION_CONTEXT_INCLUDED_FILE = 4194304,
+
+  <*
+    The current context is unknown, so set all contexts.
+  *>
+  COMPLETION_CONTEXT_UNKNOWN = 8388607
+}
+
+<*
+  Returns a default set of code-completion options that can be
+  passed to\c clang_codeCompleteAt().
+*>
+extern fn CUInt defaultCodeCompleteOptions()
+@cname("clang_defaultCodeCompleteOptions");
+
+<*
+  Perform code completion at a given location in a translation unit.
+  This function performs code completion at a particular file, line, and
+  column within source code, providing results that suggest potential
+  code snippets based on the context of the completion. The basic model
+  for code completion is that Clang will parse a complete source file,
+  performing syntax checking up to the location where code-completion has
+  been requested. At that point, a special code-completion token is passed
+  to the parser, which recognizes this token and determines, based on the
+  current location in the C/Objective-C/C++ grammar and the state of
+  semantic analysis, what completions to provide. These completions are
+  returned via a new \c CXCodeCompleteResults structure.
+  Code completion itself is meant to be triggered by the client when the
+  user types punctuation characters or whitespace, at which point the
+  code-completion location will coincide with the cursor. For example, if \c p
+  is a pointer, code-completion might be triggered after the "-" and then
+  after the ">" in \c p->. When the code-completion location is after the ">",
+  the completion results will provide, e.g., the members of the struct that
+  "p" points to. The client is responsible for placing the cursor at the
+  beginning of the token currently being typed, then filtering the results
+  based on the contents of the token. For example, when code-completing for
+  the expression \c p->get, the client should provide the location just after
+  the ">" (e.g., pointing at the "g") to this code-completion hook. Then, the
+  client can filter the results based on the current token text ("get"), only
+  showing those results that start with "get". The intent of this interface
+  is to separate the relatively high-latency acquisition of code-completion
+  results from the filtering of results on a per-character basis, which must
+  have a lower latency.
+  \param TU The translation unit in which code-completion should
+  occur. The source files for this translation unit need not be
+  completely up-to-date (and the contents of those source files may
+  be overridden via \p unsaved_files). Cursors referring into the
+  translation unit may be invalidated by this invocation.
+  \param complete_filename The name of the source file where code
+  completion should be performed. This filename may be any file
+  included in the translation unit.
+  \param complete_line The line at which code-completion should occur.
+  \param complete_column The column at which code-completion should occur.
+  Note that the column should point just after the syntactic construct that
+  initiated code completion, and not in the middle of a lexical token.
+  \param unsaved_files the Files that have not yet been saved to disk
+  but may be required for parsing or code completion, including the
+  contents of those files.  The contents and name of these files (as
+  specified by CXUnsavedFile) are copied when necessary, so the
+  client only needs to guarantee their validity until the call to
+  this function returns.
+  \param num_unsaved_files The number of unsaved file entries in \p
+  unsaved_files.
+  \param options Extra options that control the behavior of code
+  completion, expressed as a bitwise OR of the enumerators of the
+  CXCodeComplete_Flags enumeration. The
+  \c clang_defaultCodeCompleteOptions() function returns a default set
+  of code-completion options.
+  \returns If successful, a new \c CXCodeCompleteResults structure
+  containing code-completion results, which should eventually be
+  freed with \c clang_disposeCodeCompleteResults(). If code
+  completion fails, returns NULL.
+*>
+extern fn CXCodeCompleteResults* codeCompleteAt(
+  CXTranslationUnit tu,
+  ZString complete_filename,
+  CUInt complete_line,
+  CUInt complete_column,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CUInt options)
+@cname("clang_codeCompleteAt");
+
+<*
+  Sort the code-completion results in case-insensitive alphabetical
+  order.
+  \param Results The set of results to sort.
+  \param NumResults The number of results in \p Results.
+*>
+extern fn void sortCodeCompletionResults(
+  CXCompletionResult* results,
+  CUInt num_results)
+@cname("clang_sortCodeCompletionResults");
+
+<*
+  Free the given set of code-completion results.
+*>
+extern fn void disposeCodeCompleteResults(
+  CXCodeCompleteResults* results)
+@cname("clang_disposeCodeCompleteResults");
+
+<*
+  Determine the number of diagnostics produced prior to the
+  location where code completion was performed.
+*>
+extern fn CUInt codeCompleteGetNumDiagnostics(
+  CXCodeCompleteResults* results)
+@cname("clang_codeCompleteGetNumDiagnostics");
+
+<*
+  Retrieve a diagnostic associated with the given code completion.
+  \param Results the code completion results to query.
+  \param Index the zero-based diagnostic number to retrieve.
+  \returns the requested diagnostic. This diagnostic must be freed
+  via a call to \c clang_disposeDiagnostic().
+*>
+extern fn CXDiagnostic codeCompleteGetDiagnostic(
+  CXCodeCompleteResults* results,
+  CUInt index)
+@cname("clang_codeCompleteGetDiagnostic");
+
+<*
+  Determines what completions are appropriate for the context
+  the given code completion.
+  \param Results the code completion results to query
+  \returns the kinds of completions that are appropriate for use
+  along with the given code completion results.
+*>
+extern fn CULongLong codeCompleteGetContexts(
+  CXCodeCompleteResults* results)
+@cname("clang_codeCompleteGetContexts");
+
+<*
+  Returns the cursor kind for the container for the current code
+  completion context. The container is only guaranteed to be set for
+  contexts where a container exists (i.e. member accesses or Objective-C
+  message sends); if there is not a container, this function will return
+  CXCursor_InvalidCode.
+  \param Results the code completion results to query
+  \param IsIncomplete on return, this value will be false if Clang has complete
+  information about the container. If Clang does not have complete
+  information, this value will be true.
+  \returns the container kind, or CXCursor_InvalidCode if there is not a
+  container
+*>
+extern fn CXCursorKind codeCompleteGetContainerKind(
+  CXCodeCompleteResults* results,
+  CUInt* is_incomplete)
+@cname("clang_codeCompleteGetContainerKind");
+
+<*
+  Returns the USR for the container for the current code completion
+  context. If there is not a container for the current context, this
+  function will return the empty string.
+  \param Results the code completion results to query
+  \returns the USR for the container
+*>
+extern fn CXString codeCompleteGetContainerUSR(
+  CXCodeCompleteResults* results)
+@cname("clang_codeCompleteGetContainerUSR");
+
+<*
+  Returns the currently-entered selector for an Objective-C message
+  send, formatted like "initWithFoo:bar:". Only guaranteed to return a
+  non-empty string for CXCompletionContext_ObjCInstanceMessage and
+  CXCompletionContext_ObjCClassMessage.
+  \param Results the code completion results to query
+  \returns the selector (or partial selector) that has been entered thus far
+  for an Objective-C message send.
+*>
+extern fn CXString codeCompleteGetObjCSelector(
+  CXCodeCompleteResults* results)
+@cname("clang_codeCompleteGetObjCSelector");
+
+<*
+  Return a version string, suitable for showing to a user, but not
+  intended to be parsed (the format is not guaranteed to be stable).
+*>
+extern fn CXString getClangVersion()
+@cname("clang_getClangVersion");
+
+<*
+  Enable/disable crash recovery.
+  \param isEnabled Flag to indicate if crash recovery is enabled.  A non-zero
+  value enables crash recovery, while 0 disables it.
+*>
+extern fn void toggleCrashRecovery(
+  CUInt is_enabled)
+@cname("clang_toggleCrashRecovery");
+
 alias CXInclusionVisitor = fn void(
   CXFile included_file,
   CXSourceLocation* inclusion_stack,
   CUInt include_len,
   CXClientData client_data);
 
-/**
- * Visit the set of preprocessor inclusions in a translation unit.
- *   The visitor function is called with the provided data for every included
- *   file.  This does not include headers included by the PCH file (unless one
- *   is inspecting the inclusions in the PCH file itself).
- */
-fn void getInclusions(
-  CXTranslationUnit tu, 
-  CXInclusionVisitor visitor, 
-  CXClientData client_data) 
-@extern("clang_getInclusions");
+<*
+  Visit the set of preprocessor inclusions in a translation unit.
+  The visitor function is called with the provided data for every included
+  file.  This does not include headers included by the PCH file (unless one
+  is inspecting the inclusions in the PCH file itself).
+*>
+extern fn void getInclusions(
+  CXTranslationUnit tu,
+  CXInclusionVisitor visitor,
+  CXClientData client_data)
+@cname("clang_getInclusions");
 
-typedef CXEvalResultKind = inline CInt;
-
-const CXEvalResultKind EVAL_INT = 1;
-const CXEvalResultKind EVAL_FLOAT = 2;
-const CXEvalResultKind EVAL_OBJC_STR_LITERAL = 3;
-const CXEvalResultKind EVAL_STR_LITERAL = 4;
-const CXEvalResultKind EVAL_CF_STR = 5;
-const CXEvalResultKind EVAL_OTHER = 6;
-
-const CXEvalResultKind EVAL_UNEXPOSED = 0;
-
-/**
- * Evaluation result of a cursor
- */
-typedef CXEvalResult = inline void*;
-
-/**
- * If cursor is a statement declaration tries to evaluate the
- * statement and if its variable, tries to evaluate its initializer,
- * into its corresponding type.
- * If it's an expression, tries to evaluate the expression.
- */
-fn CXEvalResult evaluate_Cursor(
-  CXCursor c) 
-@extern("clang_Cursor_Evaluate");
-
-/**
- * Returns the kind of the evaluated result.
- */
-fn CXEvalResultKind getKind_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getKind");
-
-/**
- * Returns the evaluation result as integer if the
- * kind is Int.
- */
-fn CInt getAsInt_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsInt");
-
-/**
- * Returns the evaluation result as a CLongLong integer if the
- * kind is Int. This prevents overflows that may happen if the result is
- * returned with clang_EvalResult_getAsInt.
- */
-fn CLongLong getAsLongLong_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsLongLong");
-
-/**
- * Returns a non-zero value if the kind is Int and the evaluation
- * result resulted in an CUInt integer.
- */
-fn CUInt isUnsignedInt_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_isUnsignedInt");
-
-/**
- * Returns the evaluation result as an CUInt integer if
- * the kind is Int and clang_EvalResult_isUnsignedInt is non-zero.
- */
-fn CULongLong getAsUnsigned_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsUnsigned");
-
-/**
- * Returns the evaluation result as double if the
- * kind is double.
- */
-fn double getAsDouble_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsDouble");
-
-/**
- * Returns the evaluation result as a constant string if the
- * kind is other than Int or float. User must not free this pointer,
- * instead call clang_EvalResult_dispose on the CXEvalResult returned
- * by clang_Cursor_Evaluate.
- */
-fn ZString getAsStr_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_getAsStr");
-
-/**
- * Disposes the created Eval memory.
- */
-fn void dispose_EvalResult(
-  CXEvalResult e) 
-@extern("clang_EvalResult_dispose");
-
-/**
- * A remapping of original source files and their translated files.
- */
-typedef CXRemapping = inline void*;
-
-/**
- * Retrieve a remapping.
- *
- * \param path the path that contains metadata about remappings.
- *
- * \returns the requested remapping. This remapping must be freed
- * via a call to \c clang_remap_dispose(). Can return NULL if an error occurred.
- */
-fn CXRemapping getRemappings(
-  ZString path) 
-@extern("clang_getRemappings");
-
-/**
- * Retrieve a remapping.
- *
- * \param filePaths pointer to an array of file paths containing remapping info.
- *
- * \param numFiles number of file paths.
- *
- * \returns the requested remapping. This remapping must be freed
- * via a call to \c clang_remap_dispose(). Can return NULL if an error occurred.
- */
-fn CXRemapping getRemappingsFromFileList(
-  ZString* filePaths, 
-  CUInt numFiles) 
-@extern("clang_getRemappingsFromFileList");
-
-/**
- * Determine the number of remappings.
- */
-fn CUInt remap_getNumFiles(
-  CXRemapping remap) 
-@extern("clang_remap_getNumFiles");
-
-/**
- * Get the original and the associated filename from the remapping.
- *
- * \param original If non-NULL, will be set to the original filename.
- *
- * \param transformed If non-NULL, will be set to the filename that the original
- * is associated with.
- */
-fn void remap_getFilenames(
-  CXRemapping remap, 
-  CUInt index, 
-  CXString* original, 
-  CXString* transformed) 
-@extern("clang_remap_getFilenames");
-
-/**
- * Dispose the remapping.
- */
-fn void remap_dispose(
-  CXRemapping remap) 
-@extern("clang_remap_dispose");
-
-typedef CXVisitorResult = inline CInt;
-
-const CXVisitorResult VISIT_BREAK = 0;
-const CXVisitorResult VISIT_CONTINUE = 1;
-
-alias _CXCursorAndRangeVisitor = fn CXVisitorResult(void *context, CXCursor, CXSourceRange);
-struct CXCursorAndRangeVisitor {
-  void* context;
-  _CXCursorAndRangeVisitor visit;
+constdef CXEvalResultKind : CInt {
+  EVAL_INT = 1,
+  EVAL_FLOAT = 2,
+  EVAL_OBJ_C_STR_LITERAL = 3,
+  EVAL_STR_LITERAL = 4,
+  EVAL_CF_STR = 5,
+  EVAL_OTHER = 6,
+  EVAL_UN_EXPOSED = 0
 }
 
-typedef CXResult = inline CInt;
-/**
- * Function returned successfully.
- */
-const CXResult RESULT_SUCCESS = 0;
-/**
- * One of the parameters was invalid for the function.
- */
-const CXResult RESULT_INVALID = 1;
-/**
- * The function was terminated by a callback (e.g. it returned
- * CXVisit_Break)
- */
-const CXResult RESULT_VISIT_BREAK = 2;
+alias CXEvalResult = void*;
 
-/**
- * Find references of a declaration in a specific file.
- *
- * \param cursor pointing to a declaration or a reference of one.
- *
- * \param file to search for references.
- *
- * \param visitor callback that will receive pairs of CXCursor/CXSourceRange for
- * each reference found.
- * The CXSourceRange will poCInt inside the file; if the reference is inside
- * a macro (and not a macro argument) the CXSourceRange will be invalid.
- *
- * \returns one of the CXResult enumerators.
- */
-fn CXResult findReferencesInFile(
-  CXCursor cursor, 
-  CXFile file, 
-  CXCursorAndRangeVisitor visitor) 
-@extern("clang_findReferencesInFile");
+<*
+  If cursor is a statement declaration tries to evaluate the
+  statement and if its variable, tries to evaluate its initializer,
+  into its corresponding type.
+  If it's an expression, tries to evaluate the expression.
+*>
+extern fn CXEvalResult cursor_Evaluate(
+  CXCursor c)
+@cname("clang_Cursor_Evaluate");
 
-/**
- * Find #import/#include directives in a specific file.
- *
- * \param TU translation unit containing the file to query.
- *
- * \param file to search for #import/#include directives.
- *
- * \param visitor callback that will receive pairs of CXCursor/CXSourceRange for
- * each directive found.
- *
- * \returns one of the CXResult enumerators.
- */
-fn CXResult findIncludesInFile(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  CXCursorAndRangeVisitor visitor) 
-@extern("clang_findIncludesInFile");
+<*
+  Returns the kind of the evaluated result.
+*>
+extern fn CXEvalResultKind evalResult_getKind(
+  CXEvalResult e)
+@cname("clang_EvalResult_getKind");
 
-typedef CXCursorAndRangeVisitorBlock = inline void*;
+<*
+  Returns the evaluation result as integer if the
+  kind is Int.
+*>
+extern fn CInt evalResult_getAsInt(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsInt");
 
-fn CXResult findReferencesInFileWithBlock(
-  CXCursor cursor, 
-  CXFile file, 
-  CXCursorAndRangeVisitorBlock visitor_block) 
-@extern("clang_findReferencesInFileWithBlock");
+<*
+  Returns the evaluation result as a long long integer if the
+  kind is Int. This prevents overflows that may happen if the result is
+  returned with clang_EvalResult_getAsInt.
+*>
+extern fn CLongLong evalResult_getAsLongLong(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsLongLong");
 
-fn CXResult findIncludesInFileWithBlock(
-  CXTranslationUnit tu, 
-  CXFile file, 
-  CXCursorAndRangeVisitorBlock visitor_block) 
-@extern("clang_findIncludesInFileWithBlock");
+<*
+  Returns a non-zero value if the kind is Int and the evaluation
+  result resulted in an unsigned integer.
+*>
+extern fn CUInt evalResult_isUnsignedInt(
+  CXEvalResult e)
+@cname("clang_EvalResult_isUnsignedInt");
 
-/**
- * The client's data object that is associated with a CXFile.
- */
-typedef CXIdxClientFile = inline void*;
+<*
+  Returns the evaluation result as an unsigned integer if
+  the kind is Int and clang_EvalResult_isUnsignedInt is non-zero.
+*>
+extern fn CULongLong evalResult_getAsUnsigned(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsUnsigned");
 
-/**
- * The client's data object that is associated with a semantic entity.
- */
-typedef CXIdxClientEntity = inline void*;
+<*
+  Returns the evaluation result as double if the
+  kind is double.
+*>
+extern fn double evalResult_getAsDouble(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsDouble");
 
-/**
- * The client's data object that is associated with a semantic container
- * of entities.
- */
-typedef CXIdxClientContainer = inline void*;
+<*
+  Returns the evaluation result as a constant string if the
+  kind is other than Int or float. User must not free this pointer,
+  instead call clang_EvalResult_dispose on the CXEvalResult returned
+  by clang_Cursor_Evaluate.
+*>
+extern fn ZString evalResult_getAsStr(
+  CXEvalResult e)
+@cname("clang_EvalResult_getAsStr");
 
-/**
- * The client's data object that is associated with an AST file (PCH
- * or module).
- */
-typedef CXIdxClientASTFile = inline void*;
+<*
+  Disposes the created Eval memory.
+*>
+extern fn void evalResult_dispose(
+  CXEvalResult e)
+@cname("clang_EvalResult_dispose");
 
-/**
- * Source location passed to index callbacks.
- */
+<*
+  \defgroup CINDEX_HIGH Higher level API functions
+  @{
+*>
+constdef CXVisitorResult : CInt {
+  VISIT_BREAK = 0,
+  VISIT_CONTINUE = 1
+}
+
+alias UnnamedPFN2 @private = fn CXVisitorResult(
+  void* context,
+  CXCursor,
+  CXSourceRange);
+
+
+struct CXCursorAndRangeVisitor {
+  void* context;
+  UnnamedPFN2 visit;
+}
+
+constdef CXResult : CInt {
+
+  <*
+    Function returned successfully.
+  *>
+  RESULT_SUCCESS = 0,
+
+  <*
+    One of the parameters was invalid for the function.
+  *>
+  RESULT_INVALID = 1,
+
+  <*
+    The function was terminated by a callback (e.g. it returned
+    CXVisit_Break)
+  *>
+  RESULT_VISIT_BREAK = 2
+}
+
+<*
+  Find references of a declaration in a specific file.
+  \param cursor pointing to a declaration or a reference of one.
+  \param file to search for references.
+  \param visitor callback that will receive pairs of CXCursor/CXSourceRange for
+  each reference found.
+  The CXSourceRange will point inside the file; if the reference is inside
+  a macro (and not a macro argument) the CXSourceRange will be invalid.
+  \returns one of the CXResult enumerators.
+*>
+extern fn CXResult findReferencesInFile(
+  CXCursor cursor,
+  CXFile file,
+  CXCursorAndRangeVisitor visitor)
+@cname("clang_findReferencesInFile");
+
+<*
+  Find #import/#include directives in a specific file.
+  \param TU translation unit containing the file to query.
+  \param file to search for #import/#include directives.
+  \param visitor callback that will receive pairs of CXCursor/CXSourceRange for
+  each directive found.
+  \returns one of the CXResult enumerators.
+*>
+extern fn CXResult findIncludesInFile(
+  CXTranslationUnit tu,
+  CXFile file,
+  CXCursorAndRangeVisitor visitor)
+@cname("clang_findIncludesInFile");
+
+alias CXCursorAndRangeVisitorBlock = void*;
+
+extern fn CXResult findReferencesInFileWithBlock(
+  CXCursor,
+  CXFile,
+  CXCursorAndRangeVisitorBlock)
+@cname("clang_findReferencesInFileWithBlock");
+
+extern fn CXResult findIncludesInFileWithBlock(
+  CXTranslationUnit,
+  CXFile,
+  CXCursorAndRangeVisitorBlock)
+@cname("clang_findIncludesInFileWithBlock");
+
+alias CXIdxClientFile = void*;
+
+alias CXIdxClientEntity = void*;
+
+alias CXIdxClientContainer = void*;
+
+alias CXIdxClientASTFile = void*;
+
+<*
+  Source location passed to index callbacks.
+*>
 struct CXIdxLoc {
   void*[2] ptr_data;
   CUInt int_data;
 }
 
-/**
- * Data for ppIncludedFile callback.
- */
+<*
+  Data for ppIncludedFile callback.
+*>
 struct CXIdxIncludedFileInfo {
-  /*
-   * Location of '#' in the \#include/\#import directive.
-   */
   CXIdxLoc hash_loc;
-  /*
-   * Filename as written in the \#include/\#import directive.
-   */
   ZString filename;
-  /*
-   * The actual file that the \#include/\#import directive resolved to.
-   */
   CXFile file;
   CInt is_import;
   CInt is_angled;
-  /*
-   * Non-zero if the directive was automatically turned into a module
-   * import.
-   */
   CInt is_module_import;
 }
 
-/**
- * Data for IndexerCallbacks#importedASTFile.
- */
+<*
+  Data for IndexerCallbacks#importedASTFile.
+*>
 struct CXIdxImportedASTFileInfo {
-  /*
-   * Top level AST file containing the imported PCH, module or submodule.
-   */
   CXFile file;
-  /*
-   * The imported module or NULL if the AST file is a PCH.
-   */
   CXModule mod;
-  /*
-   * Location where the file is imported. Applicable only for modules.
-   */
   CXIdxLoc loc;
-  /*
-   * Non-zero if an inclusion directive was automatically turned into
-   * a module import. Applicable only for modules.
-   */
   CInt is_implicit;
 }
 
-typedef CXIdxEntityKind = inline CInt;
+constdef CXIdxEntityKind : CInt {
+  IDX_ENTITY_UNEXPOSED = 0,
+  IDX_ENTITY_TYPEDEF = 1,
+  IDX_ENTITY_FUNCTION = 2,
+  IDX_ENTITY_VARIABLE = 3,
+  IDX_ENTITY_FIELD = 4,
+  IDX_ENTITY_ENUM_CONSTANT = 5,
+  IDX_ENTITY_OBJ_C_CLASS = 6,
+  IDX_ENTITY_OBJ_C_PROTOCOL = 7,
+  IDX_ENTITY_OBJ_C_CATEGORY = 8,
+  IDX_ENTITY_OBJ_C_INSTANCE_METHOD = 9,
+  IDX_ENTITY_OBJ_C_CLASS_METHOD = 10,
+  IDX_ENTITY_OBJ_C_PROPERTY = 11,
+  IDX_ENTITY_OBJ_C_IVAR = 12,
+  IDX_ENTITY_ENUM = 13,
+  IDX_ENTITY_STRUCT = 14,
+  IDX_ENTITY_UNION = 15,
+  IDX_ENTITY_CXX_CLASS = 16,
+  IDX_ENTITY_CXX_NAMESPACE = 17,
+  IDX_ENTITY_CXX_NAMESPACE_ALIAS = 18,
+  IDX_ENTITY_CXX_STATIC_VARIABLE = 19,
+  IDX_ENTITY_CXX_STATIC_METHOD = 20,
+  IDX_ENTITY_CXX_INSTANCE_METHOD = 21,
+  IDX_ENTITY_CXX_CONSTRUCTOR = 22,
+  IDX_ENTITY_CXX_DESTRUCTOR = 23,
+  IDX_ENTITY_CXX_CONVERSION_FUNCTION = 24,
+  IDX_ENTITY_CXX_TYPE_ALIAS = 25,
+  IDX_ENTITY_CXX_INTERFACE = 26,
+  IDX_ENTITY_CXX_CONCEPT = 27
+}
 
-const CXIdxEntityKind IDX_ENTITY_UNEXPOSED = 0;
-const CXIdxEntityKind IDX_ENTITY_TYPEDEF = 1;
-const CXIdxEntityKind IDX_ENTITY_FUNCTION = 2;
-const CXIdxEntityKind IDX_ENTITY_VARIABLE = 3;
-const CXIdxEntityKind IDX_ENTITY_FIELD = 4;
-const CXIdxEntityKind IDX_ENTITY_ENUM_CONSTANT = 5;
+constdef CXIdxEntityLanguage : CInt {
+  IDX_ENTITY_LANG_NONE = 0,
+  IDX_ENTITY_LANG_C = 1,
+  IDX_ENTITY_LANG_OBJ_C = 2,
+  IDX_ENTITY_LANG_CXX = 3,
+  IDX_ENTITY_LANG_SWIFT = 4
+}
 
-const CXIdxEntityKind IDX_ENTITY_OBJC_CLASS = 6;
-const CXIdxEntityKind IDX_ENTITY_OBJC_PROTOCOL = 7;
-const CXIdxEntityKind IDX_ENTITY_OBJC_CATEGORY = 8;
+<*
+  Extra C++ template information for an entity. This can apply to:
+  CXIdxEntity_Function
+  CXIdxEntity_CXXClass
+  CXIdxEntity_CXXStaticMethod
+  CXIdxEntity_CXXInstanceMethod
+  CXIdxEntity_CXXConstructor
+  CXIdxEntity_CXXConversionFunction
+  CXIdxEntity_CXXTypeAlias
+*>
+constdef CXIdxEntityCXXTemplateKind : CInt {
+  IDX_ENTITY_NON_TEMPLATE = 0,
+  IDX_ENTITY_TEMPLATE = 1,
+  IDX_ENTITY_TEMPLATE_PARTIAL_SPECIALIZATION = 2,
+  IDX_ENTITY_TEMPLATE_SPECIALIZATION = 3
+}
 
-const CXIdxEntityKind IDX_ENTITY_OBJC_INSTANCE_METHOD = 9;
-const CXIdxEntityKind IDX_ENTITY_OBJC_CLASS_METHOD = 10;
-const CXIdxEntityKind IDX_ENTITY_OBJC_PROPERTY = 11;
-const CXIdxEntityKind IDX_ENTITY_OBJC_IVAR = 12;
+constdef CXIdxAttrKind : CInt {
+  IDX_ATTR_UNEXPOSED = 0,
+  IDX_ATTR_IB_ACTION = 1,
+  IDX_ATTR_IB_OUTLET = 2,
+  IDX_ATTR_IB_OUTLET_COLLECTION = 3
+}
 
-const CXIdxEntityKind IDX_ENTITY_ENUM = 13;
-const CXIdxEntityKind IDX_ENTITY_STRUCT = 14;
-const CXIdxEntityKind IDX_ENTITY_UNION = 15;
-
-const CXIdxEntityKind IDX_ENTITY_CXX_CLASS = 16;
-const CXIdxEntityKind IDX_ENTITY_CXX_NAMESPACE = 17;
-const CXIdxEntityKind IDX_ENTITY_CXX_NAMESPACE_ALIAS = 18;
-const CXIdxEntityKind IDX_ENTITY_CXX_STATIC_VARIABLE = 19;
-const CXIdxEntityKind IDX_ENTITY_CXX_STATIC_METHOD = 20;
-const CXIdxEntityKind IDX_ENTITY_CXX_INSTANCE_METHOD = 21;
-const CXIdxEntityKind IDX_ENTITY_CXX_CONSTRUCTOR = 22;
-const CXIdxEntityKind IDX_ENTITY_CXX_DESTRUCTOR = 23;
-const CXIdxEntityKind IDX_ENTITY_CXX_CONVERSION_FUNCTION = 24;
-const CXIdxEntityKind IDX_ENTITY_CXX_TYPE_ALIAS = 25;
-const CXIdxEntityKind IDX_ENTITY_CXX_INTERFACE = 26;
-const CXIdxEntityKind IDX_ENTITY_CXX_CONCEPT = 27;
-
-typedef CXIdxEntityLanguage = inline CInt;
-
-const CXIdxEntityLanguage IDX_ENTITY_LANG_NONE = 0;
-const CXIdxEntityLanguage IDX_ENTITY_LANG_C = 1;
-const CXIdxEntityLanguage IDX_ENTITY_LANG_OBJC = 2;
-const CXIdxEntityLanguage IDX_ENTITY_LANG_CXX = 3;
-const CXIdxEntityLanguage IDX_ENTITY_LANG_SWIFT = 4;
-
-/**
- * Extra C++ template information for an entity. This can apply to:
- * CXIdxEntity_Function
- * CXIdxEntity_CXXClass
- * CXIdxEntity_CXXStaticMethod
- * CXIdxEntity_CXXInstanceMethod
- * CXIdxEntity_CXXConstructor
- * CXIdxEntity_CXXConversionFunction
- * CXIdxEntity_CXXTypeAlias
- */
-typedef CXIdxEntityCXXTemplateKind = inline CInt;
-
-const CXIdxEntityKind IDX_ENTITY_NON_TEMPLATE = 0;
-const CXIdxEntityKind IDX_ENTITY_TEMPLATE = 1;
-const CXIdxEntityKind IDX_ENTITY_TEMPLATE_PARTIAL_SPECIALIZATION = 2;
-const CXIdxEntityKind IDX_ENTITY_TEMPLATE_SPECIALIZATION = 3;
-
-typedef CXIdxAttrKind = inline CInt;
-
-const CXIdxAttrKind IDX_ATTR_UNEXPOSED = 0;
-const CXIdxAttrKind IDX_ATTR_IB_ACTION = 1;
-const CXIdxAttrKind IDX_ATTR_IB_OUTLET = 2;
-const CXIdxAttrKind IDX_ATTR_IB_OUTLET_COLLECTION = 3;
 
 struct CXIdxAttrInfo {
   CXIdxAttrKind kind;
   CXCursor cursor;
   CXIdxLoc loc;
 }
+
 
 struct CXIdxEntityInfo {
   CXIdxEntityKind kind;
@@ -8231,9 +8133,11 @@ struct CXIdxEntityInfo {
   CUInt num_attributes;
 }
 
+
 struct CXIdxContainerInfo {
   CXCursor cursor;
 }
+
 
 struct CXIdxIBOutletCollectionAttrInfo {
   CXIdxAttrInfo* attr_info;
@@ -8242,43 +8146,39 @@ struct CXIdxIBOutletCollectionAttrInfo {
   CXIdxLoc class_loc;
 }
 
-typedef CXIdxDeclInfoFlags = inline CInt;
-const CXIdxDeclInfoFlags IDX_DECL_FLAG_SKIPPED = 0x1;
+constdef CXIdxDeclInfoFlags : CInt {
+  IDX_DECL_FLAG_SKIPPED = 1
+}
+
 
 struct CXIdxDeclInfo {
   CXIdxEntityInfo* entity_info;
   CXCursor cursor;
   CXIdxLoc loc;
   CXIdxContainerInfo* semantic_container;
-  /*
-   * Generally same as #semanticContainer but can be different in
-   * cases like out-of-line C++ member functions.
-   */
   CXIdxContainerInfo* lexical_container;
   CInt is_redeclaration;
   CInt is_definition;
   CInt is_container;
-  CXIdxContainerInfo* declAsContainer;
-  /*
-   * Whether the declaration exists in code or was created implicitly
-   * by the compiler, e.g. implicit Objective-C methods for properties.
-   */
+  CXIdxContainerInfo* decl_as_container;
   CInt is_implicit;
   CXIdxAttrInfo** attributes;
   CUInt num_attributes;
-
   CUInt flags;
 }
 
-typedef CXIdxObjCContainerKind = inline CInt;
-const CXIdxObjCContainerKind IDX_OBJC_CONTAINER_FORWARD_REF = 0;
-const CXIdxObjCContainerKind IDX_OBJC_CONTAINER_INTERFACE = 1;
-const CXIdxObjCContainerKind IDX_OBJC_CONTAINER_IMPLEMENTATION = 2;
+constdef CXIdxObjCContainerKind : CInt {
+  IDX_OBJ_C_CONTAINER_FORWARD_REF = 0,
+  IDX_OBJ_C_CONTAINER_INTERFACE = 1,
+  IDX_OBJ_C_CONTAINER_IMPLEMENTATION = 2
+}
+
 
 struct CXIdxObjCContainerDeclInfo {
   CXIdxDeclInfo* decl_info;
   CXIdxObjCContainerKind kind;
 }
+
 
 struct CXIdxBaseClassInfo {
   CXIdxEntityInfo* base;
@@ -8286,22 +8186,26 @@ struct CXIdxBaseClassInfo {
   CXIdxLoc loc;
 }
 
+
 struct CXIdxObjCProtocolRefInfo {
   CXIdxEntityInfo* protocol;
   CXCursor cursor;
   CXIdxLoc loc;
 }
 
+
 struct CXIdxObjCProtocolRefListInfo {
   CXIdxObjCProtocolRefInfo** protocols;
   CUInt num_protocols;
 }
 
+
 struct CXIdxObjCInterfaceDeclInfo {
-  CXIdxObjCContainerDeclInfo* containerInfo;
-  CXIdxBaseClassInfo* superInfo;
+  CXIdxObjCContainerDeclInfo* container_info;
+  CXIdxBaseClassInfo* super_info;
   CXIdxObjCProtocolRefListInfo* protocols;
 }
+
 
 struct CXIdxObjCCategoryDeclInfo {
   CXIdxObjCContainerDeclInfo* container_info;
@@ -8311,11 +8215,13 @@ struct CXIdxObjCCategoryDeclInfo {
   CXIdxObjCProtocolRefListInfo* protocols;
 }
 
+
 struct CXIdxObjCPropertyDeclInfo {
   CXIdxDeclInfo* decl_info;
   CXIdxEntityInfo* getter;
   CXIdxEntityInfo* setter;
 }
+
 
 struct CXIdxCXXClassDeclInfo {
   CXIdxDeclInfo* decl_info;
@@ -8323,626 +8229,1464 @@ struct CXIdxCXXClassDeclInfo {
   CUInt num_bases;
 }
 
-/**
- * Data for IndexerCallbacks#indexEntityReference.
- *
- * This may be deprecated in a future version as this duplicates
- * the \c CXSymbolRole_Implicit bit in \c CXSymbolRole.
- */
-typedef CXIdxEntityRefKind = inline CInt;
-/**
- * The entity is referenced directly in user's code.
- */
-const CXIdxEntityRefKind IDX_ENTITY_REF_DIRECT = 1;
-/**
- * An implicit reference, e.g. a reference of an Objective-C method
- * via the dot syntax.
- */
-const CXIdxEntityRefKind IDX_ENTITY_REF_IMPLICIT = 2;
+<*
+  Data for IndexerCallbacks#indexEntityReference.
+  This may be deprecated in a future version as this duplicates
+  the \c CXSymbolRole_Implicit bit in \c CXSymbolRole.
+*>
+constdef CXIdxEntityRefKind : CInt {
 
-/**
- * Roles that are attributed to symbol occurrences.
- *
- * Internal: this currently mirrors low 9 bits of clang::index::SymbolRole with
- * higher bits zeroed. These high bits may be exposed in the future.
- */
-typedef CXSymbolRole = inline CInt;
-const CXSymbolRole SYMBOL_ROLE_NONE = 0;
-const CXSymbolRole SYMBOL_ROLE_DECLARATION = 1 << 0;
-const CXSymbolRole SYMBOL_ROLE_DEFINITION = 1 << 1;
-const CXSymbolRole SYMBOL_ROLE_REFERENCE = 1 << 2;
-const CXSymbolRole SYMBOL_ROLE_READ = 1 << 3;
-const CXSymbolRole SYMBOL_ROLE_WRITE = 1 << 4;
-const CXSymbolRole SYMBOL_ROLE_CALL = 1 << 5;
-const CXSymbolRole SYMBOL_ROLE_DYNAMIC = 1 << 6;
-const CXSymbolRole SYMBOL_ROLE_ADDRESS_OF = 1 << 7;
-const CXSymbolRole SYMBOL_ROLE_IMPLICIT = 1 << 8;
+  <*
+    The entity is referenced directly in user's code.
+  *>
+  IDX_ENTITY_REF_DIRECT = 1,
 
-/**
- * Data for IndexerCallbacks#indexEntityReference.
- */
+  <*
+    An implicit reference, e.g. a reference of an Objective-C method
+    via the dot syntax.
+  *>
+  IDX_ENTITY_REF_IMPLICIT = 2
+}
+
+<*
+  Roles that are attributed to symbol occurrences.
+  Internal: this currently mirrors low 9 bits of clang::index::SymbolRole with
+  higher bits zeroed. These high bits may be exposed in the future.
+*>
+constdef CXSymbolRole : CInt {
+  SYMBOL_ROLE_NONE = 0,
+  SYMBOL_ROLE_DECLARATION = 1,
+  SYMBOL_ROLE_DEFINITION = 2,
+  SYMBOL_ROLE_REFERENCE = 4,
+  SYMBOL_ROLE_READ = 8,
+  SYMBOL_ROLE_WRITE = 16,
+  SYMBOL_ROLE_CALL = 32,
+  SYMBOL_ROLE_DYNAMIC = 64,
+  SYMBOL_ROLE_ADDRESS_OF = 128,
+  SYMBOL_ROLE_IMPLICIT = 256
+}
+
+<*
+  Data for IndexerCallbacks#indexEntityReference.
+*>
 struct CXIdxEntityRefInfo {
   CXIdxEntityRefKind kind;
-  /*
-   * Reference cursor.
-   */
   CXCursor cursor;
   CXIdxLoc loc;
-  /*
-   * The entity that gets referenced.
-   */
   CXIdxEntityInfo* referenced_entity;
-  /*
-   * Immediate "parent" of the reference. For example:
-   *
-   * \code
-   * Foo *var;
-   * \endcode
-   *
-   * The parent of reference of type 'Foo' is the variable 'var'.
-   * For references inside statement bodies of functions/methods,
-   * the parentEntity will be the function/method.
-   */
   CXIdxEntityInfo* parent_entity;
-  /*
-   * Lexical container context of the reference.
-   */
   CXIdxContainerInfo* container;
-  /*
-   * Sets of symbol roles of the reference.
-   */
   CXSymbolRole role;
 }
 
-module clang @private;
-
-alias _IndexerCallbackAbortQuery = fn CInt(
-  CXClientData client_data, 
+alias UnnamedPFN3 @private = fn CInt(
+  CXClientData client_data,
   void* reserved);
 
-alias _IndexerCallbackDiagnostic = fn void(
-  CXClientData client_data, 
-  CXDiagnosticSet ds, 
+alias UnnamedPFN4 @private = fn void(
+  CXClientData client_data,
+  CXDiagnosticSet,
   void* reserved);
 
-alias _IndexerCallbackEnteredMainFile = fn CXIdxClientFile(
-  CXClientData client_data, 
-  CXFile mainFile, 
+alias UnnamedPFN5 @private = fn CXIdxClientFile(
+  CXClientData client_data,
+  CXFile main_file,
   void* reserved);
 
-alias _IndexerCallbackIncludedFile = fn CXIdxClientFile(
-  CXClientData client_data, 
-  CXIdxIncludedFileInfo* file_info);
+alias UnnamedPFN6 @private = fn CXIdxClientFile(
+  CXClientData client_data,
+  CXIdxIncludedFileInfo*);
 
-alias _IndexerCallbackImportedASTFile = fn CXIdxClientASTFile(
-  CXClientData client_data, 
-  CXIdxImportedASTFileInfo* file_info);
+alias UnnamedPFN7 @private = fn CXIdxClientASTFile(
+  CXClientData client_data,
+  CXIdxImportedASTFileInfo*);
 
-alias _IndexerCallbackStartedTU = fn CXIdxClientContainer(
-  CXClientData client_data, 
+alias UnnamedPFN8 @private = fn CXIdxClientContainer(
+  CXClientData client_data,
   void* reserved);
 
-alias _IndexerCallbackIndexDecl = fn void(
-  CXClientData client_data, 
-  CXIdxDeclInfo* decl_info);
+alias UnnamedPFN9 @private = fn void(
+  CXClientData client_data,
+  CXIdxDeclInfo*);
 
-alias _IndexerCallbackIndexEntityRef = fn void(
-  CXClientData client_data, 
-  CXIdxEntityRefInfo* entity_ref_info);
+alias UnnamedPFN10 @private = fn void(
+  CXClientData client_data,
+  CXIdxEntityRefInfo*);
 
-module clang @public;
-
-/**
- * A group of callbacks used by #clang_indexSourceFile and
- * #clang_indexTranslationUnit.
- */
+<*
+  A group of callbacks used by #clang_indexSourceFile and
+  #clang_indexTranslationUnit.
+*>
 struct IndexerCallbacks {
-  /*
-   * Called periodically to check whether indexing should be aborted.
-   * Should return 0 to continue, and non-zero to abort.
-   */
-  _IndexerCallbackAbortQuery abort_query;
-
-  /*
-   * Called at the end of indexing; passes the complete diagnostic set.
-   */
-  _IndexerCallbackDiagnostic diagnostic;
-
-  _IndexerCallbackEnteredMainFile entered_main_file;
-
-  /*
-   * Called when a file gets \#included/\#imported.
-   */
-  _IndexerCallbackIncludedFile pp_included_file;
-
-  /*
-   * Called when a AST file (PCH or module) gets imported.
-   *
-   * AST files will not get indexed (there will not be callbacks to index all
-   * the entities in an AST file). The recommended action is that, if the AST
-   * file is not already indexed, to initiate a new indexing job specific to
-   * the AST file.
-   */
-  _IndexerCallbackImportedASTFile imported_ast_file;
-
-  /*
-   * Called at the beginning of indexing a translation unit.
-   */
-  _IndexerCallbackStartedTU started_translation_unit;
-
-  _IndexerCallbackIndexDecl index_declaration;
-
-  /*
-   * Called to index a reference of an entity.
-   */
-  _IndexerCallbackIndexEntityRef index_entity_reference;
+  UnnamedPFN3 abort_query;
+  UnnamedPFN4 diagnostic;
+  UnnamedPFN5 entered_main_file;
+  UnnamedPFN6 pp_included_file;
+  UnnamedPFN7 imported_ast_file;
+  UnnamedPFN8 started_translation_unit;
+  UnnamedPFN9 index_declaration;
+  UnnamedPFN10 index_entity_reference;
 }
 
-fn CInt index_isEntityObjCContainerKind(
-  CXIdxEntityKind entity_kind) 
-@extern("clang_index_isEntityObjCContainerKind");
+extern fn CInt index_isEntityObjCContainerKind(
+  CXIdxEntityKind)
+@cname("clang_index_isEntityObjCContainerKind");
 
-fn CXIdxObjCContainerDeclInfo* index_getObjCContainerDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCContainerDeclInfo");
+extern fn CXIdxObjCContainerDeclInfo* index_getObjCContainerDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCContainerDeclInfo");
 
-fn CXIdxObjCInterfaceDeclInfo* index_getObjCInterfaceDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCInterfaceDeclInfo");
+extern fn CXIdxObjCInterfaceDeclInfo* index_getObjCInterfaceDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCInterfaceDeclInfo");
 
-fn CXIdxObjCCategoryDeclInfo* index_getObjCCategoryDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCCategoryDeclInfo");
+extern fn CXIdxObjCCategoryDeclInfo* index_getObjCCategoryDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCCategoryDeclInfo");
 
-fn CXIdxObjCProtocolRefListInfo* index_getObjCProtocolRefListInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCProtocolRefListInfo");
+extern fn CXIdxObjCProtocolRefListInfo* index_getObjCProtocolRefListInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCProtocolRefListInfo");
 
-fn CXIdxObjCPropertyDeclInfo* index_getObjCPropertyDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getObjCPropertyDeclInfo");
+extern fn CXIdxObjCPropertyDeclInfo* index_getObjCPropertyDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getObjCPropertyDeclInfo");
 
-fn CXIdxIBOutletCollectionAttrInfo* index_getIBOutletCollectionAttrInfo(
-  CXIdxAttrInfo* attr_info) 
-@extern("clang_index_getIBOutletCollectionAttrInfo");
+extern fn CXIdxIBOutletCollectionAttrInfo* index_getIBOutletCollectionAttrInfo(
+  CXIdxAttrInfo*)
+@cname("clang_index_getIBOutletCollectionAttrInfo");
 
-fn CXIdxCXXClassDeclInfo* index_getCXXClassDeclInfo(
-  CXIdxDeclInfo* decl_info) 
-@extern("clang_index_getCXXClassDeclInfo");
+extern fn CXIdxCXXClassDeclInfo* index_getCXXClassDeclInfo(
+  CXIdxDeclInfo*)
+@cname("clang_index_getCXXClassDeclInfo");
 
-/**
- * For retrieving a custom CXIdxClientContainer attached to a
- * container.
- */
-fn CXIdxClientContainer index_getClientContainer(
-  CXIdxContainerInfo* container_info) 
-@extern("clang_index_getClientContainer");
+<*
+  For retrieving a custom CXIdxClientContainer attached to a
+  container.
+*>
+extern fn CXIdxClientContainer index_getClientContainer(
+  CXIdxContainerInfo*)
+@cname("clang_index_getClientContainer");
 
-/**
- * For setting a custom CXIdxClientContainer attached to a
- * container.
- */
-fn void index_setClientContainer(
-  CXIdxContainerInfo* container_info, 
-  CXIdxClientContainer client_container) 
-@extern("clang_index_setClientContainer");
+<*
+  For setting a custom CXIdxClientContainer attached to a
+  container.
+*>
+extern fn void index_setClientContainer(
+  CXIdxContainerInfo*,
+  CXIdxClientContainer)
+@cname("clang_index_setClientContainer");
 
-/**
- * For retrieving a custom CXIdxClientEntity attached to an entity.
- */
-fn CXIdxClientEntity index_getClientEntity(
-  CXIdxEntityInfo* entity_info) 
-@extern("clang_index_getClientEntity");
+<*
+  For retrieving a custom CXIdxClientEntity attached to an entity.
+*>
+extern fn CXIdxClientEntity index_getClientEntity(
+  CXIdxEntityInfo*)
+@cname("clang_index_getClientEntity");
 
-/**
- * For setting a custom CXIdxClientEntity attached to an entity.
- */
-fn void index_setClientEntity(
-  CXIdxEntityInfo* entity_info, 
-  CXIdxClientEntity client_entity) 
-@extern("clang_index_setClientEntity");
+<*
+  For setting a custom CXIdxClientEntity attached to an entity.
+*>
+extern fn void index_setClientEntity(
+  CXIdxEntityInfo*,
+  CXIdxClientEntity)
+@cname("clang_index_setClientEntity");
 
-/**
- * An indexing action/session, to be applied to one or multiple
- * translation units.
- */
-typedef CXIndexAction = inline void*;
+alias CXIndexAction = void*;
 
-/**
- * An indexing action/session, to be applied to one or multiple
- * translation units.
- *
- * \param CIdx The index object with which the index action will be associated.
- */
-fn CXIndexAction createIndexAction(
-  CXIndex cidx) 
-@extern("clang_IndexAction_create");
+<*
+  An indexing action/session, to be applied to one or multiple
+  translation units.
+  \param CIdx The index object with which the index action will be associated.
+*>
+extern fn CXIndexAction indexAction_create(
+  CXIndex c_idx)
+@cname("clang_IndexAction_create");
 
-/**
- * Destroy the given index action.
- *
- * The index action must not be destroyed until all of the translation units
- * created within that index action have been destroyed.
- */
-fn void dispose_IndexAction(
-  CXIndexAction cidx) 
-@extern("clang_IndexAction_dispose");
+<*
+  Destroy the given index action.
+  The index action must not be destroyed until all of the translation units
+  created within that index action have been destroyed.
+*>
+extern fn void indexAction_dispose(
+  CXIndexAction)
+@cname("clang_IndexAction_dispose");
 
-typedef CXIndexOptFlags = inline CInt;
-/**
- * Used to indicate that no special indexing options are needed.
- */
-const CXIndexOptFlags INDEX_OPT_NONE = 0x0;
+constdef CXIndexOptFlags : CInt {
 
-/**
- * Used to indicate that IndexerCallbacks#indexEntityReference should
- * be invoked for only one reference of an entity per source file that does
- * not also include a declaration/definition of the entity.
- */
-const CXIndexOptFlags INDEX_OPT_SUPPRESS_REDUNDANT_REFS = 0x1;
+  <*
+    Used to indicate that no special indexing options are needed.
+  *>
+  INDEX_OPT_NONE = 0,
 
-/**
- * Function-local symbols should be indexed. If this is not set
- * function-local symbols will be ignored.
- */
-const CXIndexOptFlags INDEX_OPT_INDEX_FUNCTION_LOCAL_SYMBOLS = 0x2;
+  <*
+    Used to indicate that IndexerCallbacks#indexEntityReference should
+    be invoked for only one reference of an entity per source file that does
+    not also include a declaration/definition of the entity.
+  *>
+  INDEX_OPT_SUPPRESS_REDUNDANT_REFS = 1,
 
-/**
- * Implicit function/class template instantiations should be indexed.
- * If this is not set, implicit instantiations will be ignored.
- */
-const CXIndexOptFlags INDEX_OPT_INDEX_IMPLICIT_TEMPLATE_INSTANTIATIONS = 0x4;
+  <*
+    Function-local symbols should be indexed. If this is not set
+    function-local symbols will be ignored.
+  *>
+  INDEX_OPT_INDEX_FUNCTION_LOCAL_SYMBOLS = 2,
 
-/**
- * Suppress all compiler warnings when parsing for indexing.
- */
-const CXIndexOptFlags INDEX_OPT_SUPPRESS_WARNINGS = 0x8;
+  <*
+    Implicit function/class template instantiations should be indexed.
+    If this is not set, implicit instantiations will be ignored.
+  *>
+  INDEX_OPT_INDEX_IMPLICIT_TEMPLATE_INSTANTIATIONS = 4,
 
-/**
- * Skip a function/method body that was already parsed during an
- * indexing session associated with a \c CXIndexAction object.
- * Bodies in system headers are always skipped.
- */
-const CXIndexOptFlags INDEX_OPT_SKIP_PARSED_BODIES_IN_SESSION = 0x10;
+  <*
+    Suppress all compiler warnings when parsing for indexing.
+  *>
+  INDEX_OPT_SUPPRESS_WARNINGS = 8,
 
-/**
- * Index the given source file and the translation unit corresponding
- * to that file via callbacks implemented through #IndexerCallbacks.
- *
- * \param client_data pointer data supplied by the client, which will
- * be passed to the invoked callbacks.
- *
- * \param index_callbacks Pointer to indexing callbacks that the client
- * implements.
- *
- * \param index_callbacks_size Size of #IndexerCallbacks structure that gets
- * passed in index_callbacks.
- *
- * \param index_options A bitmask of options that affects how indexing is
- * performed. This should be a bitwise OR of the CXIndexOpt_XXX flags.
- *
- * \param[out] out_TU pointer to store a \c CXTranslationUnit that can be
- * reused after indexing is finished. Set to \c NULL if you do not require it.
- *
- * \returns 0 on success or if there were errors from which the compiler could
- * recover.  If there is a failure from which there is no recovery, returns
- * a non-zero \c CXErrorCode.
- *
- * The rest of the parameters are the same as #clang_parseTranslationUnit.
- */
-fn CInt indexSourceFile(
-  CXIndexAction index_action, 
-  CXClientData client_data, 
-  IndexerCallbacks* index_callbacks, 
-  CUInt index_callbacks_size, 
-  CUInt index_options, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CXTranslationUnit* out_TU, 
-  CUInt tu_options) 
-@extern("clang_indexSourceFile");
+  <*
+    Skip a function/method body that was already parsed during an
+    indexing session associated with a \c CXIndexAction object.
+    Bodies in system headers are always skipped.
+  *>
+  INDEX_OPT_SKIP_PARSED_BODIES_IN_SESSION = 16
+}
 
-/**
- * Same as clang_indexSourceFile but requires a full command line
- * for \c command_line_args including argv[0]. This is useful if the standard
- * library paths are relative to the binary.
- */
-fn CInt indexSourceFileFullArgv(
-  CXIndexAction index_action, 
-  CXClientData client_data, 
-  IndexerCallbacks* index_callbacks, 
-  CUInt index_callbacks_size, 
-  CUInt index_options, 
-  ZString source_filename, 
-  ZString* command_line_args, 
-  CInt num_command_line_args, 
-  CXUnsavedFile* unsaved_files, 
-  CUInt num_unsaved_files, 
-  CXTranslationUnit* out_TU, 
-  CUInt tu_options) 
-@extern("clang_indexSourceFileFullArgv");
+<*
+  Index the given source file and the translation unit corresponding
+  to that file via callbacks implemented through #IndexerCallbacks.
+  \param client_data pointer data supplied by the client, which will
+  be passed to the invoked callbacks.
+  \param index_callbacks Pointer to indexing callbacks that the client
+  implements.
+  \param index_callbacks_size Size of #IndexerCallbacks structure that gets
+  passed in index_callbacks.
+  \param index_options A bitmask of options that affects how indexing is
+  performed. This should be a bitwise OR of the CXIndexOpt_XXX flags.
+  \param[out] out_TU pointer to store a \c CXTranslationUnit that can be
+  reused after indexing is finished. Set to \c NULL if you do not require it.
+  \returns 0 on success or if there were errors from which the compiler could
+  recover.  If there is a failure from which there is no recovery, returns
+  a non-zero \c CXErrorCode.
+  The rest of the parameters are the same as #clang_parseTranslationUnit.
+*>
+extern fn CInt indexSourceFile(
+  CXIndexAction,
+  CXClientData client_data,
+  IndexerCallbacks* index_callbacks,
+  CUInt index_callbacks_size,
+  CUInt index_options,
+  ZString source_filename,
+  ZString* command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CXTranslationUnit* out_tu,
+  CUInt tu_options)
+@cname("clang_indexSourceFile");
 
-/**
- * Index the given translation unit via callbacks implemented through
- * #IndexerCallbacks.
- *
- * The order of callback invocations is not guaranteed to be the same as
- * when indexing a source file. The high level order will be:
- *
- *   -Preprocessor callbacks invocations
- *   -Declaration/reference callbacks invocations
- *   -Diagnostic callback invocations
- *
- * The parameters are the same as #clang_indexSourceFile.
- *
- * \returns If there is a failure from which there is no recovery, returns
- * non-zero, otherwise returns 0.
- */
-fn CInt indexTranslationUnit(
-  CXIndexAction index_action, 
-  CXClientData client_data, 
-  IndexerCallbacks* index_callbacks, 
-  CUInt index_callbacks_size, 
-  CUInt index_options, 
-  CXTranslationUnit tu) 
-@extern("clang_indexTranslationUnit");
+<*
+  Same as clang_indexSourceFile but requires a full command line
+  for \c command_line_args including argv[0]. This is useful if the standard
+  library paths are relative to the binary.
+*>
+extern fn CInt indexSourceFileFullArgv(
+  CXIndexAction,
+  CXClientData client_data,
+  IndexerCallbacks* index_callbacks,
+  CUInt index_callbacks_size,
+  CUInt index_options,
+  ZString source_filename,
+  ZString* command_line_args,
+  CInt num_command_line_args,
+  CXUnsavedFile* unsaved_files,
+  CUInt num_unsaved_files,
+  CXTranslationUnit* out_tu,
+  CUInt tu_options)
+@cname("clang_indexSourceFileFullArgv");
 
-/**
- * Retrieve the CXIdxFile, file, line, column, and offset represented by
- * the given CXIdxLoc.
- *
- * If the location refers into a macro expansion, retrieves the
- * location of the macro expansion and if it refers into a macro argument
- * retrieves the location of the argument.
- */
-fn void indexLoc_getFileLocation(
-  CXIdxLoc loc, 
-  CXIdxClientFile* indexFile, 
-  CXFile* file, 
-  CUInt* line, 
-  CUInt* column, 
-  CUInt* offset) 
-@extern("clang_indexLoc_getFileLocation");
+<*
+  Index the given translation unit via callbacks implemented through
+  #IndexerCallbacks.
+  The order of callback invocations is not guaranteed to be the same as
+  when indexing a source file. The high level order will be:
+  -Preprocessor callbacks invocations
+  -Declaration/reference callbacks invocations
+  -Diagnostic callback invocations
+  The parameters are the same as #clang_indexSourceFile.
+  \returns If there is a failure from which there is no recovery, returns
+  non-zero, otherwise returns 0.
+*>
+extern fn CInt indexTranslationUnit(
+  CXIndexAction,
+  CXClientData client_data,
+  IndexerCallbacks* index_callbacks,
+  CUInt index_callbacks_size,
+  CUInt index_options,
+  CXTranslationUnit)
+@cname("clang_indexTranslationUnit");
 
-/**
- * Retrieve the CXSourceLocation represented by the given CXIdxLoc.
- */
-fn CXSourceLocation indexLoc_getCXSourceLocation(
-  CXIdxLoc loc) 
-@extern("clang_indexLoc_getCXSourceLocation");
+<*
+  Retrieve the CXIdxFile, file, line, column, and offset represented by
+  the given CXIdxLoc.
+  If the location refers into a macro expansion, retrieves the
+  location of the macro expansion and if it refers into a macro argument
+  retrieves the location of the argument.
+*>
+extern fn void indexLoc_getFileLocation(
+  CXIdxLoc loc,
+  CXIdxClientFile* index_file,
+  CXFile* file,
+  CUInt* line,
+  CUInt* column,
+  CUInt* offset)
+@cname("clang_indexLoc_getFileLocation");
 
-/**
- * Visitor invoked for each field found by a traversal.
- *
- * This visitor function will be invoked for each field found by
- * \c clang_Type_visitFields. Its first argument is the cursor being
- * visited, its second argument is the client data provided to
- * \c clang_Type_visitFields.
- *
- * The visitor should return one of the \c CXVisitorResult values
- * to direct \c clang_Type_visitFields.
- */
+<*
+  Retrieve the CXSourceLocation represented by the given CXIdxLoc.
+*>
+extern fn CXSourceLocation indexLoc_getCXSourceLocation(
+  CXIdxLoc loc)
+@cname("clang_indexLoc_getCXSourceLocation");
+
 alias CXFieldVisitor = fn CXVisitorResult(
-  CXCursor c, 
+  CXCursor c,
   CXClientData client_data);
 
-/**
- * Visit the fields of a particular type.
- *
- * This function visits all the direct fields of the given cursor,
- * invoking the given \p visitor function with the cursors of each
- * visited field. The traversal may be ended prematurely, if
- * the visitor returns \c CXFieldVisit_Break.
- *
- * \param T the record type whose field may be visited.
- *
- * \param visitor the visitor function that will be invoked for each
- * field of \p T.
- *
- * \param client_data pointer data supplied by the client, which will
- * be passed to the visitor each time it is invoked.
- *
- * \returns a non-zero value if the traversal was terminated
- * prematurely by the visitor returning \c CXFieldVisit_Break.
- */
-fn CUInt visitFields_Type(
-  CXType t, 
-  CXFieldVisitor visitor, 
-  CXClientData client_data) 
-@extern("clang_Type_visitFields");
+<*
+  Visit the fields of a particular type.
+  This function visits all the direct fields of the given cursor,
+  invoking the given \p visitor function with the cursors of each
+  visited field. The traversal may be ended prematurely, if
+  the visitor returns \c CXFieldVisit_Break.
+  \param T the record type whose field may be visited.
+  \param visitor the visitor function that will be invoked for each
+  field of \p T.
+  \param client_data pointer data supplied by the client, which will
+  be passed to the visitor each time it is invoked.
+  \returns a non-zero value if the traversal was terminated
+  prematurely by the visitor returning \c CXFieldVisit_Break.
+*>
+extern fn CUInt type_visitFields(
+  CXType t,
+  CXFieldVisitor visitor,
+  CXClientData client_data)
+@cname("clang_Type_visitFields");
 
-/**
- * Describes the kind of binary operators.
- */
-typedef CXBinaryOperatorKind = inline CInt;
+<*
+  Visit the base classes of a type.
+  This function visits all the direct base classes of a the given cursor,
+  invoking the given \p visitor function with the cursors of each
+  visited base. The traversal may be ended prematurely, if
+  the visitor returns \c CXFieldVisit_Break.
+  \param T the record type whose field may be visited.
+  \param visitor the visitor function that will be invoked for each
+  field of \p T.
+  \param client_data pointer data supplied by the client, which will
+  be passed to the visitor each time it is invoked.
+  \returns a non-zero value if the traversal was terminated
+  prematurely by the visitor returning \c CXFieldVisit_Break.
+*>
+extern fn CUInt visitCXXBaseClasses(
+  CXType t,
+  CXFieldVisitor visitor,
+  CXClientData client_data)
+@cname("clang_visitCXXBaseClasses");
 
-/** This value describes cursors which are not binary operators. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_INVALID = 0;
-/** C++ Pointer - to - member operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_PTR_MEM_D = 1;
-/** C++ Pointer - to - member operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_PTR_MEM_I = 2;
-/** Multiplication operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_MUL = 3;
-/** Division operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_DIV = 4;
-/** Remainder operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_REM = 5;
-/** Addition operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_ADD = 6;
-/** Subtraction operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SUB = 7;
-/** Bitwise shift left operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SHL = 8;
-/** Bitwise shift right operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SHR = 9;
-/** C++ three-way comparison (spaceship) operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_CMP = 10;
-/** Less than operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_LT = 11;
-/** Greater than operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_GT = 12;
-/** Less or equal operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_LE = 13;
-/** Greater or equal operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_GE = 14;
-/** Equal operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_EQ = 15;
-/** Not equal operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_NE = 16;
-/** Bitwise AND operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_AND = 17;
-/** Bitwise XOR operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_XOR = 18;
-/** Bitwise OR operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_OR = 19;
-/** Logical AND operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_LAND = 20;
-/** Logical OR operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_LOR = 21;
-/** Assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_ASSIGN = 22;
-/** Multiplication assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_MUL_ASSIGN = 23;
-/** Division assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_DIV_ASSIGN = 24;
-/** Remainder assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_REM_ASSIGN = 25;
-/** Addition assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_ADD_ASSIGN = 26;
-/** Subtraction assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SUB_ASSIGN = 27;
-/** Bitwise shift left assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SHL_ASSIGN = 28;
-/** Bitwise shift right assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_SHR_ASSIGN = 29;
-/** Bitwise AND assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_AND_ASSIGN = 30;
-/** Bitwise XOR assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_XOR_ASSIGN = 31;
-/** Bitwise OR assignment operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_OR_ASSIGN = 32;
-/** Comma operator. 
-  */
-const CXBinaryOperatorKind BINARY_OPERATOR_COMMA = 33;
+<*
+  Visit the class methods of a type.
+  This function visits all the methods of the given cursor,
+  invoking the given \p visitor function with the cursors of each
+  visited method. The traversal may be ended prematurely, if
+  the visitor returns \c CXFieldVisit_Break.
+  \param T The record type whose field may be visited.
+  \param visitor The visitor function that will be invoked for each
+  field of \p T.
+  \param client_data Pointer data supplied by the client, which will
+  be passed to the visitor each time it is invoked.
+  \returns A non-zero value if the traversal was terminated
+  prematurely by the visitor returning \c CXFieldVisit_Break.
+*>
+extern fn CUInt visitCXXMethods(
+  CXType t,
+  CXFieldVisitor visitor,
+  CXClientData client_data)
+@cname("clang_visitCXXMethods");
 
-/**
- * Retrieve the spelling of a given CXBinaryOperatorKind.
- */
-fn CXString getBinaryOperatorKindSpelling(
-  CXBinaryOperatorKind kind) 
-@extern("clang_getBinaryOperatorKindSpelling");
+<*
+  Describes the kind of binary operators.
+*>
+constdef CXBinaryOperatorKind : CInt {
 
-/**
- * Retrieve the binary operator kind of this cursor.
- *
- * If this cursor is not a binary operator then returns Invalid.
- */
-fn CXBinaryOperatorKind getCursorBinaryOperatorKind(
-  CXCursor cursor) 
-@extern("clang_getCursorBinaryOperatorKind");
+  <*
+    This value describes cursors which are not binary operators. *
+  *>
+  BINARY_OPERATOR_INVALID = 0,
 
-/**
- * Describes the kind of unary operators.
- */
-typedef CXUnaryOperatorKind = inline CInt;
+  <*
+    C++ Pointer - to - member operator. *
+  *>
+  BINARY_OPERATOR_PTR_MEM_D = 1,
 
-/** This value describes cursors which are not unary operators. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_INVALID = 0;
-/** Postfix increment operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_POST_INC = 1;
-/** Postfix decrement operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_POST_DEC = 2;
-/** Prefix increment operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_PRE_INC = 3;
-/** Prefix decrement operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_PRE_DEC = 4;
-/** Address of operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_ADDR_OF = 5;
-/** Dereference operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_DEREF = 6;
-/** Plus operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_PLUS = 7;
-/** Minus operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_MINUS = 8;
-/** Not operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_NOT = 9;
-/** LNot operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_LNOT = 10;
-/** "__real expr" operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_REAL = 11;
-/** "__imag expr" operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_IMAG = 12;
-/** __extension__ marker operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_EXTENSION = 13;
-/** C++ co_await operator. 
-  */
-const CXUnaryOperatorKind UNARY_OPERATOR_CO_AWAIT = 14;
+  <*
+    C++ Pointer - to - member operator. *
+  *>
+  BINARY_OPERATOR_PTR_MEM_I = 2,
 
-/**
- * Retrieve the spelling of a given CXUnaryOperatorKind.
- */
-fn CXString getUnaryOperatorKindSpelling(
-  CXUnaryOperatorKind kind) 
-@extern("clang_getUnaryOperatorKindSpelling");
+  <*
+    Multiplication operator. *
+  *>
+  BINARY_OPERATOR_MUL = 3,
 
-/**
- * Retrieve the unary operator kind of this cursor.
- *
- * If this cursor is not a unary operator then returns Invalid.
- */
-fn CXUnaryOperatorKind getCursorUnaryOperatorKind(
-  CXCursor cursor) 
-@extern("clang_getCursorUnaryOperatorKind");
+  <*
+    Division operator. *
+  *>
+  BINARY_OPERATOR_DIV = 4,
 
+  <*
+    Remainder operator. *
+  *>
+  BINARY_OPERATOR_REM = 5,
 
+  <*
+    Addition operator. *
+  *>
+  BINARY_OPERATOR_ADD = 6,
+
+  <*
+    Subtraction operator. *
+  *>
+  BINARY_OPERATOR_SUB = 7,
+
+  <*
+    Bitwise shift left operator. *
+  *>
+  BINARY_OPERATOR_SHL = 8,
+
+  <*
+    Bitwise shift right operator. *
+  *>
+  BINARY_OPERATOR_SHR = 9,
+
+  <*
+    C++ three-way comparison (spaceship) operator. *
+  *>
+  BINARY_OPERATOR_CMP = 10,
+
+  <*
+    Less than operator. *
+  *>
+  BINARY_OPERATOR_LT = 11,
+
+  <*
+    Greater than operator. *
+  *>
+  BINARY_OPERATOR_GT = 12,
+
+  <*
+    Less or equal operator. *
+  *>
+  BINARY_OPERATOR_LE = 13,
+
+  <*
+    Greater or equal operator. *
+  *>
+  BINARY_OPERATOR_GE = 14,
+
+  <*
+    Equal operator. *
+  *>
+  BINARY_OPERATOR_EQ = 15,
+
+  <*
+    Not equal operator. *
+  *>
+  BINARY_OPERATOR_NE = 16,
+
+  <*
+    Bitwise AND operator. *
+  *>
+  BINARY_OPERATOR_AND = 17,
+
+  <*
+    Bitwise XOR operator. *
+  *>
+  BINARY_OPERATOR_XOR = 18,
+
+  <*
+    Bitwise OR operator. *
+  *>
+  BINARY_OPERATOR_OR = 19,
+
+  <*
+    Logical AND operator. *
+  *>
+  BINARY_OPERATOR_L_AND = 20,
+
+  <*
+    Logical OR operator. *
+  *>
+  BINARY_OPERATOR_L_OR = 21,
+
+  <*
+    Assignment operator. *
+  *>
+  BINARY_OPERATOR_ASSIGN = 22,
+
+  <*
+    Multiplication assignment operator. *
+  *>
+  BINARY_OPERATOR_MUL_ASSIGN = 23,
+
+  <*
+    Division assignment operator. *
+  *>
+  BINARY_OPERATOR_DIV_ASSIGN = 24,
+
+  <*
+    Remainder assignment operator. *
+  *>
+  BINARY_OPERATOR_REM_ASSIGN = 25,
+
+  <*
+    Addition assignment operator. *
+  *>
+  BINARY_OPERATOR_ADD_ASSIGN = 26,
+
+  <*
+    Subtraction assignment operator. *
+  *>
+  BINARY_OPERATOR_SUB_ASSIGN = 27,
+
+  <*
+    Bitwise shift left assignment operator. *
+  *>
+  BINARY_OPERATOR_SHL_ASSIGN = 28,
+
+  <*
+    Bitwise shift right assignment operator. *
+  *>
+  BINARY_OPERATOR_SHR_ASSIGN = 29,
+
+  <*
+    Bitwise AND assignment operator. *
+  *>
+  BINARY_OPERATOR_AND_ASSIGN = 30,
+
+  <*
+    Bitwise XOR assignment operator. *
+  *>
+  BINARY_OPERATOR_XOR_ASSIGN = 31,
+
+  <*
+    Bitwise OR assignment operator. *
+  *>
+  BINARY_OPERATOR_OR_ASSIGN = 32,
+
+  <*
+    Comma operator. *
+  *>
+  BINARY_OPERATOR_COMMA = 33,
+
+  <*
+    Comma operator. *
+  *>
+  BINARY_OPERATOR_LAST = 33
+}
+
+<*
+  Retrieve the spelling of a given CXBinaryOperatorKind.
+*>
+extern fn CXString getBinaryOperatorKindSpelling(
+  CXBinaryOperatorKind kind)
+@cname("clang_getBinaryOperatorKindSpelling");
+
+<*
+  Retrieve the binary operator kind of this cursor.
+  If this cursor is not a binary operator then returns Invalid.
+*>
+extern fn CXBinaryOperatorKind getCursorBinaryOperatorKind(
+  CXCursor cursor)
+@cname("clang_getCursorBinaryOperatorKind");
+
+<*
+  Describes the kind of unary operators.
+*>
+constdef CXUnaryOperatorKind : CInt {
+
+  <*
+    This value describes cursors which are not unary operators. *
+  *>
+  UNARY_OPERATOR_INVALID = 0,
+
+  <*
+    Postfix increment operator. *
+  *>
+  UNARY_OPERATOR_POST_INC = 1,
+
+  <*
+    Postfix decrement operator. *
+  *>
+  UNARY_OPERATOR_POST_DEC = 2,
+
+  <*
+    Prefix increment operator. *
+  *>
+  UNARY_OPERATOR_PRE_INC = 3,
+
+  <*
+    Prefix decrement operator. *
+  *>
+  UNARY_OPERATOR_PRE_DEC = 4,
+
+  <*
+    Address of operator. *
+  *>
+  UNARY_OPERATOR_ADDR_OF = 5,
+
+  <*
+    Dereference operator. *
+  *>
+  UNARY_OPERATOR_DEREF = 6,
+
+  <*
+    Plus operator. *
+  *>
+  UNARY_OPERATOR_PLUS = 7,
+
+  <*
+    Minus operator. *
+  *>
+  UNARY_OPERATOR_MINUS = 8,
+
+  <*
+    Not operator. *
+  *>
+  UNARY_OPERATOR_NOT = 9,
+
+  <*
+    LNot operator. *
+  *>
+  UNARY_OPERATOR_L_NOT = 10,
+
+  <*
+    "__real expr" operator. *
+  *>
+  UNARY_OPERATOR_REAL = 11,
+
+  <*
+    "__imag expr" operator. *
+  *>
+  UNARY_OPERATOR_IMAG = 12,
+
+  <*
+    __extension__ marker operator. *
+  *>
+  UNARY_OPERATOR_EXTENSION = 13,
+
+  <*
+    C++ co_await operator. *
+  *>
+  UNARY_OPERATOR_COAWAIT = 14
+}
+
+<*
+  Retrieve the spelling of a given CXUnaryOperatorKind.
+*>
+extern fn CXString getUnaryOperatorKindSpelling(
+  CXUnaryOperatorKind kind)
+@cname("clang_getUnaryOperatorKindSpelling");
+
+<*
+  Retrieve the unary operator kind of this cursor.
+  If this cursor is not a unary operator then returns Invalid.
+*>
+extern fn CXUnaryOperatorKind getCursorUnaryOperatorKind(
+  CXCursor cursor)
+@cname("clang_getCursorUnaryOperatorKind");
+
+alias CXRemapping = void*;
+
+extern fn CXRemapping getRemappings(
+  ZString)
+@cname("clang_getRemappings");
+
+extern fn CXRemapping getRemappingsFromFileList(
+  ZString*,
+  CUInt)
+@cname("clang_getRemappingsFromFileList");
+
+extern fn CUInt remap_getNumFiles(
+  CXRemapping)
+@cname("clang_remap_getNumFiles");
+
+extern fn void remap_getFilenames(
+  CXRemapping,
+  CUInt,
+  CXString*,
+  CXString*)
+@cname("clang_remap_getFilenames");
+
+extern fn void remap_dispose(
+  CXRemapping)
+@cname("clang_remap_dispose");
+
+alias CXCompilationDatabase = void*;
+
+alias CXCompileCommands = void*;
+
+alias CXCompileCommand = void*;
+
+<*
+  Error codes for Compilation Database
+*>
+constdef CXCompilationDatabase_Error : CInt {
+  COMPILATION_DATABASE_NO_ERROR = 0,
+  COMPILATION_DATABASE_CAN_NOT_LOAD_DATABASE = 1
+}
+
+<*
+  Creates a compilation database from the database found in directory
+  buildDir. For example, CMake can output a compile_commands.json which can
+  be used to build the database.
+  It must be freed by \c clang_CompilationDatabase_dispose.
+*>
+extern fn CXCompilationDatabase compilationDatabase_fromDirectory(
+  ZString build_dir,
+  CXCompilationDatabase_Error* error_code)
+@cname("clang_CompilationDatabase_fromDirectory");
+
+<*
+  Free the given compilation database
+*>
+extern fn void compilationDatabase_dispose(
+  CXCompilationDatabase)
+@cname("clang_CompilationDatabase_dispose");
+
+<*
+  Find the compile commands used for a file. The compile commands
+  must be freed by \c clang_CompileCommands_dispose.
+*>
+extern fn CXCompileCommands compilationDatabase_getCompileCommands(
+  CXCompilationDatabase,
+  ZString complete_file_name)
+@cname("clang_CompilationDatabase_getCompileCommands");
+
+<*
+  Get all the compile commands in the given compilation database.
+*>
+extern fn CXCompileCommands compilationDatabase_getAllCompileCommands(
+  CXCompilationDatabase)
+@cname("clang_CompilationDatabase_getAllCompileCommands");
+
+<*
+  Free the given CompileCommands
+*>
+extern fn void compileCommands_dispose(
+  CXCompileCommands)
+@cname("clang_CompileCommands_dispose");
+
+<*
+  Get the number of CompileCommand we have for a file
+*>
+extern fn CUInt compileCommands_getSize(
+  CXCompileCommands)
+@cname("clang_CompileCommands_getSize");
+
+<*
+  Get the I'th CompileCommand for a file
+  Note : 0 <= i < clang_CompileCommands_getSize(CXCompileCommands)
+*>
+extern fn CXCompileCommand compileCommands_getCommand(
+  CXCompileCommands,
+  CUInt i)
+@cname("clang_CompileCommands_getCommand");
+
+<*
+  Get the working directory where the CompileCommand was executed from
+*>
+extern fn CXString compileCommand_getDirectory(
+  CXCompileCommand)
+@cname("clang_CompileCommand_getDirectory");
+
+<*
+  Get the filename associated with the CompileCommand.
+*>
+extern fn CXString compileCommand_getFilename(
+  CXCompileCommand)
+@cname("clang_CompileCommand_getFilename");
+
+<*
+  Get the number of arguments in the compiler invocation.
+*>
+extern fn CUInt compileCommand_getNumArgs(
+  CXCompileCommand)
+@cname("clang_CompileCommand_getNumArgs");
+
+<*
+  Get the I'th argument value in the compiler invocations
+  Invariant :
+  - argument 0 is the compiler executable
+*>
+extern fn CXString compileCommand_getArg(
+  CXCompileCommand,
+  CUInt i)
+@cname("clang_CompileCommand_getArg");
+
+<*
+  Get the number of source mappings for the compiler invocation.
+*>
+extern fn CUInt compileCommand_getNumMappedSources(
+  CXCompileCommand)
+@cname("clang_CompileCommand_getNumMappedSources");
+
+<*
+  Get the I'th mapped source path for the compiler invocation.
+*>
+extern fn CXString compileCommand_getMappedSourcePath(
+  CXCompileCommand,
+  CUInt i)
+@cname("clang_CompileCommand_getMappedSourcePath");
+
+<*
+  Get the I'th mapped source content for the compiler invocation.
+*>
+extern fn CXString compileCommand_getMappedSourceContent(
+  CXCompileCommand,
+  CUInt i)
+@cname("clang_CompileCommand_getMappedSourceContent");
+
+<*
+  A parsed comment.
+*>
+struct CXComment {
+  void* ast_node;
+  CXTranslationUnit translation_unit;
+}
+
+<*
+  Given a cursor that represents a documentable entity (e.g.,
+  declaration), return the associated parsed comment as a
+  \c CXComment_FullComment AST node.
+*>
+extern fn CXComment cursor_getParsedComment(
+  CXCursor c)
+@cname("clang_Cursor_getParsedComment");
+
+<*
+  Describes the type of the comment AST node (\c CXComment).  A comment
+  node can be considered block content (e. g., paragraph), inline content
+  (plain text) or neither (the root AST node).
+*>
+constdef CXCommentKind : CInt {
+
+  <*
+    Null comment.  No AST node is constructed at the requested location
+    because there is no text or a syntax error.
+  *>
+  COMMENT_NULL = 0,
+
+  <*
+    Plain text.  Inline content.
+  *>
+  COMMENT_TEXT = 1,
+
+  <*
+    A command with word-like arguments that is considered inline content.
+    For example: \\c command.
+  *>
+  COMMENT_INLINE_COMMAND = 2,
+
+  <*
+    HTML start tag with attributes (name-value pairs).  Considered
+    inline content.
+    For example:
+    \verbatim
+    <br> <br /> <a href="http://example.org/">
+    \endverbatim
+  *>
+  COMMENT_HTML_START_TAG = 3,
+
+  <*
+    HTML end tag.  Considered inline content.
+    For example:
+    \verbatim
+    </a>
+    \endverbatim
+  *>
+  COMMENT_HTML_END_TAG = 4,
+
+  <*
+    A paragraph, contains inline comment.  The paragraph itself is
+    block content.
+  *>
+  COMMENT_PARAGRAPH = 5,
+
+  <*
+    A command that has zero or more word-like arguments (number of
+    word-like arguments depends on command name) and a paragraph as an
+    argument.  Block command is block content.
+    Paragraph argument is also a child of the block command.
+    For example: \has 0 word-like arguments and a paragraph argument.
+    AST nodes of special kinds that parser knows about (e. g., \\param
+    command) have their own node kinds.
+  *>
+  COMMENT_BLOCK_COMMAND = 6,
+
+  <*
+    A \\param or \\arg command that describes the function parameter
+    (name, passing direction, description).
+    For example: \\param [in] ParamName description.
+  *>
+  COMMENT_PARAM_COMMAND = 7,
+
+  <*
+    A \\tparam command that describes a template parameter (name and
+    description).
+    For example: \\tparam T description.
+  *>
+  COMMENT_T_PARAM_COMMAND = 8,
+
+  <*
+    A verbatim block command (e. g., preformatted code).  Verbatim
+    block has an opening and a closing command and contains multiple lines of
+    text (\c CXComment_VerbatimBlockLine child nodes).
+    For example:
+    \\verbatim
+    aaa
+    \\endverbatim
+  *>
+  COMMENT_VERBATIM_BLOCK_COMMAND = 9,
+
+  <*
+    A line of text that is contained within a
+    CXComment_VerbatimBlockCommand node.
+  *>
+  COMMENT_VERBATIM_BLOCK_LINE = 10,
+
+  <*
+    A verbatim line command.  Verbatim line has an opening command,
+    a single line of text (up to the newline after the opening command) and
+    has no closing command.
+  *>
+  COMMENT_VERBATIM_LINE = 11,
+
+  <*
+    A full comment attached to a declaration, contains block content.
+  *>
+  COMMENT_FULL_COMMENT = 12
+}
+
+<*
+  The most appropriate rendering mode for an inline command, chosen on
+  command semantics in Doxygen.
+*>
+constdef CXCommentInlineCommandRenderKind : CInt {
+
+  <*
+    Command argument should be rendered in a normal font.
+  *>
+  COMMENT_INLINE_COMMAND_RENDER_KIND_NORMAL = 0,
+
+  <*
+    Command argument should be rendered in a bold font.
+  *>
+  COMMENT_INLINE_COMMAND_RENDER_KIND_BOLD = 1,
+
+  <*
+    Command argument should be rendered in a monospaced font.
+  *>
+  COMMENT_INLINE_COMMAND_RENDER_KIND_MONOSPACED = 2,
+
+  <*
+    Command argument should be rendered emphasized (typically italic
+    font).
+  *>
+  COMMENT_INLINE_COMMAND_RENDER_KIND_EMPHASIZED = 3,
+
+  <*
+    Command argument should not be rendered (since it only defines an anchor).
+  *>
+  COMMENT_INLINE_COMMAND_RENDER_KIND_ANCHOR = 4
+}
+
+<*
+  Describes parameter passing direction for \\param or \\arg command.
+*>
+constdef CXCommentParamPassDirection : CInt {
+
+  <*
+    The parameter is an input parameter.
+  *>
+  COMMENT_PARAM_PASS_DIRECTION_IN = 0,
+
+  <*
+    The parameter is an output parameter.
+  *>
+  COMMENT_PARAM_PASS_DIRECTION_OUT = 1,
+
+  <*
+    The parameter is an input and output parameter.
+  *>
+  COMMENT_PARAM_PASS_DIRECTION_IN_OUT = 2
+}
+
+<*
+  \param Comment AST node of any kind.
+  \returns the type of the AST node.
+*>
+extern fn CXCommentKind comment_getKind(
+  CXComment comment)
+@cname("clang_Comment_getKind");
+
+<*
+  \param Comment AST node of any kind.
+  \returns number of children of the AST node.
+*>
+extern fn CUInt comment_getNumChildren(
+  CXComment comment)
+@cname("clang_Comment_getNumChildren");
+
+<*
+  \param Comment AST node of any kind.
+  \param ChildIdx child index (zero-based).
+  \returns the specified child of the AST node.
+*>
+extern fn CXComment comment_getChild(
+  CXComment comment,
+  CUInt child_idx)
+@cname("clang_Comment_getChild");
+
+<*
+  A \c CXComment_Paragraph node is considered whitespace if it contains
+  only \c CXComment_Text nodes that are empty or whitespace.
+  Other AST nodes (except \c CXComment_Paragraph and \c CXComment_Text) are
+  never considered whitespace.
+  \returns non-zero if \c Comment is whitespace.
+*>
+extern fn CUInt comment_isWhitespace(
+  CXComment comment)
+@cname("clang_Comment_isWhitespace");
+
+<*
+  \returns non-zero if \c Comment is inline content and has a newline
+  immediately following it in the comment text.  Newlines between paragraphs
+  do not count.
+*>
+extern fn CUInt inlineContentComment_hasTrailingNewline(
+  CXComment comment)
+@cname("clang_InlineContentComment_hasTrailingNewline");
+
+<*
+  \param Comment a \c CXComment_Text AST node.
+  \returns text contained in the AST node.
+*>
+extern fn CXString textComment_getText(
+  CXComment comment)
+@cname("clang_TextComment_getText");
+
+<*
+  \param Comment a \c CXComment_InlineCommand AST node.
+  \returns name of the inline command.
+*>
+extern fn CXString inlineCommandComment_getCommandName(
+  CXComment comment)
+@cname("clang_InlineCommandComment_getCommandName");
+
+<*
+  \param Comment a \c CXComment_InlineCommand AST node.
+  \returns the most appropriate rendering mode, chosen on command
+  semantics in Doxygen.
+*>
+extern fn CXCommentInlineCommandRenderKind inlineCommandComment_getRenderKind(
+  CXComment comment)
+@cname("clang_InlineCommandComment_getRenderKind");
+
+<*
+  \param Comment a \c CXComment_InlineCommand AST node.
+  \returns number of command arguments.
+*>
+extern fn CUInt inlineCommandComment_getNumArgs(
+  CXComment comment)
+@cname("clang_InlineCommandComment_getNumArgs");
+
+<*
+  \param Comment a \c CXComment_InlineCommand AST node.
+  \param ArgIdx argument index (zero-based).
+  \returns text of the specified argument.
+*>
+extern fn CXString inlineCommandComment_getArgText(
+  CXComment comment,
+  CUInt arg_idx)
+@cname("clang_InlineCommandComment_getArgText");
+
+<*
+  \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
+  node.
+  \returns HTML tag name.
+*>
+extern fn CXString hTMLTagComment_getTagName(
+  CXComment comment)
+@cname("clang_HTMLTagComment_getTagName");
+
+<*
+  \param Comment a \c CXComment_HTMLStartTag AST node.
+  \returns non-zero if tag is self-closing (for example, &lt;br /&gt;).
+*>
+extern fn CUInt hTMLStartTagComment_isSelfClosing(
+  CXComment comment)
+@cname("clang_HTMLStartTagComment_isSelfClosing");
+
+<*
+  \param Comment a \c CXComment_HTMLStartTag AST node.
+  \returns number of attributes (name-value pairs) attached to the start tag.
+*>
+extern fn CUInt hTMLStartTag_getNumAttrs(
+  CXComment comment)
+@cname("clang_HTMLStartTag_getNumAttrs");
+
+<*
+  \param Comment a \c CXComment_HTMLStartTag AST node.
+  \param AttrIdx attribute index (zero-based).
+  \returns name of the specified attribute.
+*>
+extern fn CXString hTMLStartTag_getAttrName(
+  CXComment comment,
+  CUInt attr_idx)
+@cname("clang_HTMLStartTag_getAttrName");
+
+<*
+  \param Comment a \c CXComment_HTMLStartTag AST node.
+  \param AttrIdx attribute index (zero-based).
+  \returns value of the specified attribute.
+*>
+extern fn CXString hTMLStartTag_getAttrValue(
+  CXComment comment,
+  CUInt attr_idx)
+@cname("clang_HTMLStartTag_getAttrValue");
+
+<*
+  \param Comment a \c CXComment_BlockCommand AST node.
+  \returns name of the block command.
+*>
+extern fn CXString blockCommandComment_getCommandName(
+  CXComment comment)
+@cname("clang_BlockCommandComment_getCommandName");
+
+<*
+  \param Comment a \c CXComment_BlockCommand AST node.
+  \returns number of word-like arguments.
+*>
+extern fn CUInt blockCommandComment_getNumArgs(
+  CXComment comment)
+@cname("clang_BlockCommandComment_getNumArgs");
+
+<*
+  \param Comment a \c CXComment_BlockCommand AST node.
+  \param ArgIdx argument index (zero-based).
+  \returns text of the specified word-like argument.
+*>
+extern fn CXString blockCommandComment_getArgText(
+  CXComment comment,
+  CUInt arg_idx)
+@cname("clang_BlockCommandComment_getArgText");
+
+<*
+  \param Comment a \c CXComment_BlockCommand or
+  \c CXComment_VerbatimBlockCommand AST node.
+  \returns paragraph argument of the block command.
+*>
+extern fn CXComment blockCommandComment_getParagraph(
+  CXComment comment)
+@cname("clang_BlockCommandComment_getParagraph");
+
+<*
+  \param Comment a \c CXComment_ParamCommand AST node.
+  \returns parameter name.
+*>
+extern fn CXString paramCommandComment_getParamName(
+  CXComment comment)
+@cname("clang_ParamCommandComment_getParamName");
+
+<*
+  \param Comment a \c CXComment_ParamCommand AST node.
+  \returns non-zero if the parameter that this AST node represents was found
+  in the function prototype and \c clang_ParamCommandComment_getParamIndex
+  function will return a meaningful value.
+*>
+extern fn CUInt paramCommandComment_isParamIndexValid(
+  CXComment comment)
+@cname("clang_ParamCommandComment_isParamIndexValid");
+
+<*
+  \param Comment a \c CXComment_ParamCommand AST node.
+  \returns zero-based parameter index in function prototype.
+*>
+extern fn CUInt paramCommandComment_getParamIndex(
+  CXComment comment)
+@cname("clang_ParamCommandComment_getParamIndex");
+
+<*
+  \param Comment a \c CXComment_ParamCommand AST node.
+  \returns non-zero if parameter passing direction was specified explicitly in
+  the comment.
+*>
+extern fn CUInt paramCommandComment_isDirectionExplicit(
+  CXComment comment)
+@cname("clang_ParamCommandComment_isDirectionExplicit");
+
+<*
+  \param Comment a \c CXComment_ParamCommand AST node.
+  \returns parameter passing direction.
+*>
+extern fn CXCommentParamPassDirection paramCommandComment_getDirection(
+  CXComment comment)
+@cname("clang_ParamCommandComment_getDirection");
+
+<*
+  \param Comment a \c CXComment_TParamCommand AST node.
+  \returns template parameter name.
+*>
+extern fn CXString tParamCommandComment_getParamName(
+  CXComment comment)
+@cname("clang_TParamCommandComment_getParamName");
+
+<*
+  \param Comment a \c CXComment_TParamCommand AST node.
+  \returns non-zero if the parameter that this AST node represents was found
+  in the template parameter list and
+  \c clang_TParamCommandComment_getDepth and
+  \c clang_TParamCommandComment_getIndex functions will return a meaningful
+  value.
+*>
+extern fn CUInt tParamCommandComment_isParamPositionValid(
+  CXComment comment)
+@cname("clang_TParamCommandComment_isParamPositionValid");
+
+<*
+  \param Comment a \c CXComment_TParamCommand AST node.
+  \returns zero-based nesting depth of this parameter in the template parameter list.
+  For example,
+  \verbatim
+  template<typename C, template<typename T> class TT>
+  void test(TT<int> aaa);
+  \endverbatim
+  for C and TT nesting depth is 0,
+  for T nesting depth is 1.
+*>
+extern fn CUInt tParamCommandComment_getDepth(
+  CXComment comment)
+@cname("clang_TParamCommandComment_getDepth");
+
+<*
+  \param Comment a \c CXComment_TParamCommand AST node.
+  \returns zero-based parameter index in the template parameter list at a
+  given nesting depth.
+  For example,
+  \verbatim
+  template<typename C, template<typename T> class TT>
+  void test(TT<int> aaa);
+  \endverbatim
+  for C and TT nesting depth is 0, so we can ask for index at depth 0:
+  at depth 0 C's index is 0, TT's index is 1.
+  For T nesting depth is 1, so we can ask for index at depth 0 and 1:
+  at depth 0 T's index is 1 (same as TT's),
+  at depth 1 T's index is 0.
+*>
+extern fn CUInt tParamCommandComment_getIndex(
+  CXComment comment,
+  CUInt depth)
+@cname("clang_TParamCommandComment_getIndex");
+
+<*
+  \param Comment a \c CXComment_VerbatimBlockLine AST node.
+  \returns text contained in the AST node.
+*>
+extern fn CXString verbatimBlockLineComment_getText(
+  CXComment comment)
+@cname("clang_VerbatimBlockLineComment_getText");
+
+<*
+  \param Comment a \c CXComment_VerbatimLine AST node.
+  \returns text contained in the AST node.
+*>
+extern fn CXString verbatimLineComment_getText(
+  CXComment comment)
+@cname("clang_VerbatimLineComment_getText");
+
+<*
+  Convert an HTML tag AST node to string.
+  \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
+  node.
+  \returns string containing an HTML tag.
+*>
+extern fn CXString hTMLTagComment_getAsString(
+  CXComment comment)
+@cname("clang_HTMLTagComment_getAsString");
+
+<*
+  Convert a given full parsed comment to an HTML fragment.
+  Specific details of HTML layout are subject to change.  Don't try to parse
+  this HTML back into an AST, use other APIs instead.
+  Currently the following CSS classes are used:
+  \li "para-brief" for \paragraph and equivalent commands;
+  \li "para-returns" for \\returns paragraph and equivalent commands;
+  \li "word-returns" for the "Returns" word in \\returns paragraph.
+  Function argument documentation is rendered as a \<dl\> list with arguments
+  sorted in function prototype order.  CSS classes used:
+  \li "param-name-index-NUMBER" for parameter name (\<dt\>);
+  \li "param-descr-index-NUMBER" for parameter description (\<dd\>);
+  \li "param-name-index-invalid" and "param-descr-index-invalid" are used if
+  parameter index is invalid.
+  Template parameter documentation is rendered as a \<dl\> list with
+  parameters sorted in template parameter list order.  CSS classes used:
+  \li "tparam-name-index-NUMBER" for parameter name (\<dt\>);
+  \li "tparam-descr-index-NUMBER" for parameter description (\<dd\>);
+  \li "tparam-name-index-other" and "tparam-descr-index-other" are used for
+  names inside template template parameters;
+  \li "tparam-name-index-invalid" and "tparam-descr-index-invalid" are used if
+  parameter position is invalid.
+  \param Comment a \c CXComment_FullComment AST node.
+  \returns string containing an HTML fragment.
+*>
+extern fn CXString fullComment_getAsHTML(
+  CXComment comment)
+@cname("clang_FullComment_getAsHTML");
+
+<*
+  Convert a given full parsed comment to an XML document.
+  A Relax NG schema for the XML can be found in comment-xml-schema.rng file
+  inside clang source tree.
+  \param Comment a \c CXComment_FullComment AST node.
+  \returns string containing an XML document.
+*>
+extern fn CXString fullComment_getAsXML(
+  CXComment comment)
+@cname("clang_FullComment_getAsXML");
+
+alias CXAPISet = void*;
+
+<*
+  Traverses the translation unit to create a \c CXAPISet.
+  \param tu is the \c CXTranslationUnit to build the \c CXAPISet for.
+  \param out_api is a pointer to the output of this function. It is needs to be
+  disposed of by calling clang_disposeAPISet.
+  \returns Error code indicating success or failure of the APISet creation.
+*>
+extern fn CXErrorCode createAPISet(
+  CXTranslationUnit tu,
+  CXAPISet* out_api)
+@cname("clang_createAPISet");
+
+<*
+  Dispose of an APISet.
+  The provided \c CXAPISet can not be used after this function is called.
+*>
+extern fn void disposeAPISet(
+  CXAPISet api)
+@cname("clang_disposeAPISet");
+
+<*
+  Generate a single symbol symbol graph for the given USR. Returns a null
+  string if the associated symbol can not be found in the provided \c CXAPISet.
+  The output contains the symbol graph as well as some additional information
+  about related symbols.
+  \param usr is a string containing the USR of the symbol to generate the
+  symbol graph for.
+  \param api the \c CXAPISet to look for the symbol in.
+  \returns a string containing the serialized symbol graph representation for
+  the symbol being queried or a null string if it can not be found in the
+  APISet.
+*>
+extern fn CXString getSymbolGraphForUSR(
+  ZString usr,
+  CXAPISet api)
+@cname("clang_getSymbolGraphForUSR");
+
+<*
+  Generate a single symbol symbol graph for the declaration at the given
+  cursor. Returns a null string if the AST node for the cursor isn't a
+  declaration.
+  The output contains the symbol graph as well as some additional information
+  about related symbols.
+  \param cursor the declaration for which to generate the single symbol symbol
+  graph.
+  \returns a string containing the serialized symbol graph representation for
+  the symbol being queried or a null string if it can not be found in the
+  APISet.
+*>
+extern fn CXString getSymbolGraphForCursor(
+  CXCursor cursor)
+@cname("clang_getSymbolGraphForCursor");
+
+<*
+  Installs error handler that prints error message to stderr and calls abort().
+  Replaces currently installed error handler (if any).
+*>
+extern fn void install_aborting_llvm_fatal_error_handler()
+@cname("clang_install_aborting_llvm_fatal_error_handler");
+
+<*
+  Removes currently installed error handler (if any).
+  If no error handler is intalled, the default strategy is to print error
+  message to stderr and call exit(1).
+*>
+extern fn void uninstall_llvm_fatal_error_handler()
+@cname("clang_uninstall_llvm_fatal_error_handler");
+
+alias CXRewriter = void*;
+
+<*
+  Create CXRewriter.
+*>
+extern fn CXRewriter cXRewriter_create(
+  CXTranslationUnit tu)
+@cname("clang_CXRewriter_create");
+
+<*
+  Insert the specified string at the specified location in the original buffer.
+*>
+extern fn void cXRewriter_insertTextBefore(
+  CXRewriter rew,
+  CXSourceLocation loc,
+  ZString insert)
+@cname("clang_CXRewriter_insertTextBefore");
+
+<*
+  Replace the specified range of characters in the input with the specified
+  replacement.
+*>
+extern fn void cXRewriter_replaceText(
+  CXRewriter rew,
+  CXSourceRange to_be_replaced,
+  ZString replacement)
+@cname("clang_CXRewriter_replaceText");
+
+<*
+  Remove the specified range.
+*>
+extern fn void cXRewriter_removeText(
+  CXRewriter rew,
+  CXSourceRange to_be_removed)
+@cname("clang_CXRewriter_removeText");
+
+<*
+  Save all changed files to disk.
+  Returns 1 if any files were not saved successfully, returns 0 otherwise.
+*>
+extern fn CInt cXRewriter_overwriteChangedFiles(
+  CXRewriter rew)
+@cname("clang_CXRewriter_overwriteChangedFiles");
+
+<*
+  Write out rewritten version of the main file to stdout.
+*>
+extern fn void cXRewriter_writeMainFileToStdOut(
+  CXRewriter rew)
+@cname("clang_CXRewriter_writeMainFileToStdOut");
+
+<*
+  Free the given CXRewriter.
+*>
+extern fn void cXRewriter_dispose(
+  CXRewriter rew)
+@cname("clang_CXRewriter_dispose");

--- a/bindgen.c3l/src/data.c3
+++ b/bindgen.c3l/src/data.c3
@@ -113,7 +113,7 @@ struct CBitField
 {
   String  type;
   String  name;
-  usz     width;
+  sz     width;
 }
 
 
@@ -170,8 +170,8 @@ struct C3BitstructField
 {
   String  type;
   String  name;
-  usz     from;
-  usz     to;
+  sz     from;
+  sz     to;
 }
 
 
@@ -215,12 +215,13 @@ struct GlobalVisitData
   TypesTable        types_table;
   OutStream         out;
   CXFile            cxfile;
-  usz               anon_fns_counter;
+  sz               anon_fns_counter;
   WriteState        write_state;
 
   bitstruct : char
   {
-    bool            no_verbose;
+    bool no_verbose;
+    bool use_docs;          
   }
 }
 
@@ -246,7 +247,7 @@ struct FieldsVisitData
   CFields           fields;
   Allocator         allocator;
   GlobalVisitData*  g;
-  usz               current;
+  sz               current;
 }
 
 
@@ -278,6 +279,8 @@ struct ConstVisitData
 struct EnumVisitData
 {
   GlobalVisitData*  g;
+  List{EnumField}   fields;
+  Allocator         allocator;
   String            enum_name;
   bool              is_unsigned;
 }

--- a/bindgen.c3l/src/data.c3
+++ b/bindgen.c3l/src/data.c3
@@ -98,6 +98,12 @@ struct VarDecl
   String name;
 }
 
+struct EnumField 
+{
+  String name;
+  String init;
+  String docs;
+}
 
 <*
  Represents bit fields meaning:

--- a/bindgen.c3l/src/data_methods.c3
+++ b/bindgen.c3l/src/data_methods.c3
@@ -23,8 +23,8 @@ macro void CFields.init(
   &self, 
   Allocator alloc)
 {
-  $foreach $member : CFields.membersof:
-    self.$eval($member.nameof).init(alloc);
+  $foreach $member : CFields::members:
+    self.$eval($member.name).init(alloc);
   $endforeach
 }
 
@@ -35,9 +35,9 @@ macro void CFields.init(
 *>
 macro CFields.@foreach(
   &self; 
-  @body(CFieldKind* kind, usz index))
+  @body(CFieldKind* kind, sz index))
 {
-  usz[CFieldKind.values.len] counters;
+  sz[CFieldKind::values.len] counters;
 
   foreach (i, &k : self.kinds) {
     @body(k, counters[k.ordinal]);
@@ -53,8 +53,8 @@ macro void C3Fields.init(
   &self, 
   Allocator alloc)
 {
-  $foreach $member : C3Fields.membersof:
-    self.$eval($member.nameof).init(alloc);
+  $foreach $member : C3Fields::members:
+    self.$eval($member.name).init(alloc);
   $endforeach
 }
 
@@ -65,9 +65,9 @@ macro void C3Fields.init(
 *>
 macro C3Fields.@foreach(
   &self; 
-  @body(C3FieldKind* kind, usz index))
+  @body(C3FieldKind* kind, sz index))
 {
-  usz[C3FieldKind.values.len] counters;
+  sz[C3FieldKind::values.len] counters;
 
   foreach (i, &k : self.kinds)
   {
@@ -107,12 +107,12 @@ macro void CTypeTokens.free(&self)
 *>
 macro CTypeTokens.@foreach(
   &self; 
-  @body(CTypeTokenKind kind, usz str_index))
+  @body(CTypeTokenKind kind, sz str_index))
 {
-  usz str_counter;
-  usz str_len = self.strs.len();
+  sz str_counter;
+  sz str_len = self.strs.len();
   foreach_r (k : self.kinds) {
-    usz str_index = usz.max;
+    sz str_index = sz::max;
     switch (k) {
       case NAME:
       case SIZED_ARRAY:
@@ -156,23 +156,23 @@ macro void CTypeTokens.push(
  Information about how the specific attribute is printed,
  must be contained in str @tag of the field.
 *>
-fn usz? WriteAttrs.to_format(
+fn sz? WriteAttrs.to_format(
   &self, 
   Formatter* format) 
   @dynamic
 {
-  usz? acc;
+  sz? acc;
 
-  $foreach $f : WriteAttrs.membersof:
-    assert( $f.has_tagof("attr") );
-    String $attr = $f.tagof("attr");
+  $foreach $f : WriteAttrs::members:
+    assert( $f.has_tag("attr") );
+    String $attr = $f.get_tag("attr");
 
-    $switch $f.typeid:
-      $case String:
+    $switch $f.type.kind:
+      $case String::kind:
         if ($f.get(*self) != "") {
           acc += format.printf(" %s(%s)", $attr, $f.get(*self));
         }
-      $case bool:
+      $case bool::kind:
         if ($f.get(*self)) {
           acc += format.printf(" %s", $attr);
         }
@@ -206,11 +206,11 @@ module std::core::array;
 
 <*
  Returns true if predicate returns true at least one time. Returns false otherwise.
- @require $kindof(arr) == SLICE ||| $kindof(arr) == ARRAY       : "Array must be either slice or array"
- @require $kindof(predicate) == FUNC                              : "Predicate must be a function"
- @require $typeof(predicate).returns == bool.typeid                 : "Predicate must return bool"
- @require $typeof(predicate).paramsof.len == 1                      : "Predicate must have one parameter"
- @require $typeof(predicate).paramsof[0].type == $typeof(arr).inner : "Predicate must have parameter of inner array type"
+ @require $Typeof(arr)::kind == SLICE ||| $kindof(arr) == ARRAY       : "Array must be either slice or array"
+ @require $Typeof(predicate)::kind == FUNC                              : "Predicate must be a function"
+ @require $Typeof(predicate)::returns == bool                 : "Predicate must return bool"
+ @require $Typeof(predicate)::params.len == 1                      : "Predicate must have one parameter"
+ @require $Typeof(predicate)::params[0].type == $Typeof(arr)::inner : "Predicate must have parameter of inner array type"
 *>
 macro has(arr, predicate)
 {

--- a/bindgen.c3l/src/err.c3
+++ b/bindgen.c3l/src/err.c3
@@ -11,9 +11,9 @@ import clang, std::io;
 macro void log(
   String str = "", 
   ..., 
-  usz indent = 0) 
+  sz indent = 0) 
 {
-  for (usz i; i < indent; ++i) {
+  for (sz i; i < indent; ++i) {
     io::eprintf("  ");
   }
   io::eprintf("%s[%s]%s : ", Ansi.GREEN, $$FUNC, Ansi.RESET);
@@ -46,7 +46,7 @@ macro void warn(
 {
   if (!no_verbose) {
     io::eprintf("%sWarning%s : ", Ansi.YELLOW, Ansi.RESET);
-    io::eprintfn(str, $vasplat);
+    io::eprintfn(str, ...$vaarg);
   }
 }
 
@@ -62,7 +62,7 @@ macro void info(
 {
   if (!no_verbose) {
     io::eprintf("%sInfo%s : ", Ansi.GREEN, Ansi.RESET);
-    io::eprintfn(str, $vasplat);
+    io::eprintfn(str, ...$vaarg);
   }
 } 
 
@@ -76,7 +76,7 @@ macro void erro(
   ...) 
 {
   io::eprintf("%sError%s : ", Ansi.RED, Ansi.RESET);
-  io::eprintfn(str, $vasplat);
+  io::eprintfn(str, ...$vaarg);
 }
 
 
@@ -92,7 +92,7 @@ macro void diag(
   ...)
 {
   io::eprintf("%sError at %s:%d:%d%s : ", Ansi.RED, file, line, col, Ansi.RESET);
-  io::eprintfn(str, $vasplat);
+  io::eprintfn(str, ...$vaarg);
 }
 
 

--- a/bindgen.c3l/src/misc.c3
+++ b/bindgen.c3l/src/misc.c3
@@ -154,7 +154,7 @@ fn CXSourceRange getTrueCursorExtent(
  their quantity. Does not skip attributes, macro expansions,
  etc.
 *>
-fn usz getTopChildrenNumber(
+fn sz getTopChildrenNumber(
   CXCursor cursor)
 {
 	sz qty;

--- a/bindgen.c3l/src/misc.c3
+++ b/bindgen.c3l/src/misc.c3
@@ -17,14 +17,14 @@ fn String convStr(CXString s) @inline => clang::getCString(s).str_view();
 
 
 fn String getCursorDoc(CXCursor cursor, Allocator alloc, int indent = 0) {
-    CXString raw = clang::cursor_getRawCommentText(cursor);
-    
-    if (raw.data == null) {
-        return ""; 
-    }
+  CXString raw = clang::cursor_getRawCommentText(cursor);
+  
+  if (raw.data == null) {
+      return ""; 
+  }
 
-    defer clang::disposeString(raw);
-    String conv_str = misc::convStr(raw).copy(alloc); 
+  defer clang::disposeString(raw);
+  String conv_str = misc::convStr(raw).copy(alloc); 
 	return cleanupDoc(alloc, conv_str, indent);
 }
 

--- a/bindgen.c3l/src/misc.c3
+++ b/bindgen.c3l/src/misc.c3
@@ -16,16 +16,80 @@ import bgimpl,
 fn String convStr(CXString s) @inline => clang::getCString(s).str_view();
 
 
+fn String getCursorDoc(CXCursor cursor, Allocator alloc, int indent = 0) {
+    CXString raw = clang::cursor_getRawCommentText(cursor);
+    
+    if (raw.data == null) {
+        return ""; 
+    }
+
+    defer clang::disposeString(raw);
+    String conv_str = misc::convStr(raw).copy(alloc); 
+	return cleanupDoc(alloc, conv_str, indent);
+}
+
+fn String cleanupDoc(Allocator alloc, String raw_doc, int indent_level = 0) => @pool() {
+    if (raw_doc.len == 0) return "";
+
+    DString clean;
+    clean.tinit();
+
+	DString indent_builder;
+    indent_builder.tinit();
+    for (int i = 0; i < indent_level; i++) {
+        indent_builder.append("\t");
+    }
+    String indent = indent_builder.str_view();
+    
+    // Split the raw comment into lines
+    String[] lines = raw_doc.split(tmem, "\n");
+    
+	clean.append(indent);
+    clean.append("<*\n");
+    
+    foreach (line : lines) {
+        String trimmed = line.trim();
+        
+        // Remove comment start, end, and leading asterisks
+        if (trimmed.starts_with("/**")) { 
+			trimmed = trimmed[3..]; 
+		}
+        else if (trimmed.starts_with("/*")) {
+			trimmed = trimmed[2..];
+		}
+        if (trimmed.ends_with("*/")) { 
+			trimmed = trimmed[..trimmed.len - 2];
+		}
+        
+        // Strip the leading '*' if it exists (standard Doxygen style)
+        trimmed = trimmed.trim();
+        if (trimmed.starts_with("*")) {
+            trimmed = trimmed[1..].trim();
+        }
+
+        if (trimmed.len > 0) {
+			clean.append(indent);
+            clean.append("\t"); // Indent for style
+            clean.append(trimmed);
+            clean.append("\n");
+        }
+    }
+    
+	clean.append(indent);
+    clean.append("*>");
+    return clean.copy_str(alloc);
+}
+
 <*
  Detects whether the type is a pointer to function or function
  itself
 *>
 fn bool isTypePFN(CXType type) @inline
 {
-  if (type.kind == clang::TYPE_POINTER) {
-    type = clang::getPointeeType(type);
-  }
-  return type.kind == clang::TYPE_FUNCTION_PROTO || type.kind == clang::TYPE_FUNCTION_NO_PROTO;
+	if (type.kind == TYPE_POINTER) {
+		type = clang::getPointeeType(type);
+	}
+	return type.kind == TYPE_FUNCTION_PROTO || type.kind == TYPE_FUNCTION_NO_PROTO;
 }
 
 <*
@@ -39,8 +103,25 @@ fn bool isCursorForwardDeclared(CXCursor cursor) @inline => !clang::isCursorDefi
  Type is incomplete in case when it can't be used directly, without
  a pointer to it
 *>
-fn bool isTypeIncomplete(CXType type) @inline => clang::getSizeOf_Type(type) == clang::TYPE_LAYOUT_ERROR_INCOMPLETE;
+fn bool isTypeIncomplete(CXType type) @inline 
+{
+	// If layout explicitly says it is incomplete, it is incomplete.
+	if ((CInt)clang::type_getSizeOf(type) == (CInt)CXTypeLayoutError.TYPE_LAYOUT_ERROR_INCOMPLETE) {
+		return true;
+	}
 
+	// check if the declaration declaration lacks a definition
+	CXCursor declaration = clang::getTypeDeclaration(type);
+	CXCursorKind kind = clang::getCursorKind(declaration);
+
+	if (kind == CURSOR_STRUCT_DECL || 
+		kind == CURSOR_UNION_DECL || 
+		kind == CURSOR_ENUM_DECL) {
+		return clang::isCursorDefinition(declaration) == 0;
+	}
+
+	return false;
+}
 
 <*
  getTrueCursorExtent returns a source range for the cursor without
@@ -55,7 +136,7 @@ fn bool isTypeIncomplete(CXType type) @inline => clang::getSizeOf_Type(type) == 
 fn CXSourceRange getTrueCursorExtent(
   CXCursor cursor)
 {
-  CXTranslationUnit tu = clang::getTranslationUnit_Cursor(cursor);
+	CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
   CXSourceRange sr = clang::getCursorExtent(cursor);
   CXSourceLocation sl_begin = clang::getRangeStart(sr);    
   CXSourceLocation sl_end = clang::getRangeEnd(sr);
@@ -76,17 +157,17 @@ fn CXSourceRange getTrueCursorExtent(
 fn usz getTopChildrenNumber(
   CXCursor cursor)
 {
-  usz qty;
+	sz qty;
 
-  clang::visitChildren(cursor, 
-    fn (CXCursor cursor, CXCursor parent, CXClientData client_data) {
-      usz* qty = (usz*) client_data;
-      ++*qty;
-      return clang::CHILD_VISIT_CONTINUE;
-    }, (CXClientData) &qty
-  );
+	clang::visitChildren(cursor, 
+		fn (CXCursor cursor, CXCursor parent, CXClientData client_data) {
+		sz* qty = (sz*) client_data;
+		++*qty;
+		return CHILD_VISIT_CONTINUE;
+		}, (CXClientData) &qty
+	);
 
-  return qty;
+	return qty;
 }
 
 
@@ -99,14 +180,14 @@ fn CXType getBaseType(
 {
   CXType base;
 
-  while LOOP: (true) {
-    switch (type.kind) {
-      case clang::TYPE_POINTER: 
-        type = clang::getPointeeType(type);
+	while LOOP: (true) {
+		switch (type.kind) {
+		case TYPE_POINTER: 
+			type = clang::getPointeeType(type);
 
-      case clang::TYPE_CONSTANT_ARRAY:
-      case clang::TYPE_INCOMPLETE_ARRAY:
-        type = clang::getElementType(type);
+		case TYPE_CONSTANT_ARRAY:
+		case TYPE_INCOMPLETE_ARRAY:
+			type = clang::getElementType(type);
 
       default:
         base = type;

--- a/bindgen.c3l/src/misc.c3
+++ b/bindgen.c3l/src/misc.c3
@@ -29,55 +29,55 @@ fn String getCursorDoc(CXCursor cursor, Allocator alloc, int indent = 0) {
 }
 
 fn String cleanupDoc(Allocator alloc, String raw_doc, int indent_level = 0) => @pool() {
-    if (raw_doc.len == 0) return "";
+  if (raw_doc.len == 0) return "";
 
-    DString clean;
-    clean.tinit();
+  DString clean;
+  clean.tinit();
 
 	DString indent_builder;
-    indent_builder.tinit();
-    for (int i = 0; i < indent_level; i++) {
-        indent_builder.append("\t");
-    }
-    String indent = indent_builder.str_view();
-    
-    // Split the raw comment into lines
-    String[] lines = raw_doc.split(tmem, "\n");
+  indent_builder.tinit();
+  for (int i = 0; i < indent_level; i++) {
+      indent_builder.append("  ");
+  }
+  String indent = indent_builder.str_view();
+  
+  // Split the raw comment into lines
+  String[] lines = raw_doc.split(tmem, "\n");
     
 	clean.append(indent);
-    clean.append("<*\n");
+  clean.append("<*\n");
     
-    foreach (line : lines) {
-        String trimmed = line.trim();
-        
-        // Remove comment start, end, and leading asterisks
-        if (trimmed.starts_with("/**")) { 
-			trimmed = trimmed[3..]; 
-		}
-        else if (trimmed.starts_with("/*")) {
-			trimmed = trimmed[2..];
-		}
-        if (trimmed.ends_with("*/")) { 
-			trimmed = trimmed[..trimmed.len - 2];
-		}
-        
-        // Strip the leading '*' if it exists (standard Doxygen style)
-        trimmed = trimmed.trim();
-        if (trimmed.starts_with("*")) {
-            trimmed = trimmed[1..].trim();
-        }
+  foreach (line : lines) {
+    String trimmed = line.trim();
+    
+    // Remove comment start, end, and leading asterisks
+    if (trimmed.starts_with("/**")) { 
+      trimmed = trimmed[3..]; 
+    }
+    else if (trimmed.starts_with("/*")) {
+      trimmed = trimmed[2..];
+    }
+    if (trimmed.ends_with("*/")) { 
+      trimmed = trimmed[..trimmed.len - 2];
+    }
+      
+    // Strip the leading '*' if it exists (standard Doxygen style)
+    trimmed = trimmed.trim();
+    if (trimmed.starts_with("*")) {
+      trimmed = trimmed[1..].trim();
+    }
 
-        if (trimmed.len > 0) {
-			clean.append(indent);
-            clean.append("\t"); // Indent for style
-            clean.append(trimmed);
-            clean.append("\n");
-        }
+    if (trimmed.len > 0) {
+    clean.append(indent);
+      clean.append("  "); // Indent for style
+      clean.append(trimmed);
+      clean.append("\n");
     }
+  }
     
 	clean.append(indent);
-    clean.append("*>");
-    return clean.copy_str(alloc);
+  clean.append("*>");
+  return clean.copy_str(alloc);
 }
 
 <*

--- a/bindgen.c3l/src/tparse.c3
+++ b/bindgen.c3l/src/tparse.c3
@@ -21,7 +21,7 @@ faultdef INVALID_BITFIELDS;
 fn String convertCTypeTokenToC3(
   CTypeTokenKind kind,
   String[] strs,
-  usz str_index)
+  sz str_index)
   @inline
 {
   switch (kind) {
@@ -51,17 +51,17 @@ fn CTypeTokens getTypeTokens(
 
   while LOOP: (true) {
     switch (type.kind) {
-      case clang::TYPE_POINTER: 
+      case TYPE_POINTER: 
         tokens.push(POINTER);
         type = clang::getPointeeType(type);
 
-      case clang::TYPE_CONSTANT_ARRAY:
+      case TYPE_CONSTANT_ARRAY:
         CLongLong size = clang::getArraySize(type);
         String str = string::format(tmem, "[%d]", size);
         tokens.push(SIZED_ARRAY, str);
         type = clang::getElementType(type);
 
-      case clang::TYPE_INCOMPLETE_ARRAY:
+      case TYPE_INCOMPLETE_ARRAY:
         tokens.push(UNSIZED_ARRAY);
         type = clang::getElementType(type);
 
@@ -70,7 +70,7 @@ fn CTypeTokens getTypeTokens(
         defer clang::disposeString(type_spell);
         String type_str = misc::convStr(type_spell);
 
-        type_str = type_str.strip("const ").strip("struct ").strip("enum ").strip("union ");
+        type_str = type_str.strip_prefix("const ").strip_prefix("struct ").strip_prefix("enum ").strip_prefix("union ");
         tokens.push(NAME, type_str.copy(tmem));
         break LOOP;
     }
@@ -98,13 +98,13 @@ fn C3Fields? getC3Fields(
   C3Fields res;
   res.init(alloc);
 
-  // usz.max means we're not in segment
-  usz bit_widths_acc;
-  usz bit_segment_start = usz.max;
+  // sz.max means we're not in segment
+  sz bit_widths_acc;
+  sz bit_segment_start = sz::max;
   List{C3BitstructField} bit_fields;
   bit_fields.init(alloc);
 
-  cfs.@foreach(; CFieldKind* kind, usz index) {
+  cfs.@foreach(; CFieldKind* kind, sz index) {
     switch (*kind) {
       // TODO: do it without pushes with plain copy 
       // as res.norm practically equals to cfs.norm
@@ -115,7 +115,7 @@ fn C3Fields? getC3Fields(
 
       case BIT:
         CBitField cfield = cfs.bit[index];
-        if (bit_segment_start == usz.max) bit_segment_start = index;
+        if (bit_segment_start == sz::max) bit_segment_start = index;
         bit_fields.push({
           .type = cfield.type, 
           .name = cfield.name, 
@@ -142,7 +142,7 @@ fn C3Fields? getC3Fields(
       }
 
     // Finish bit range and reset things if needed
-    if ((*kind != BIT || index == cfs.bit.len() - 1) && bit_segment_start != usz.max) {
+    if ((*kind != BIT || index == cfs.bit.len() - 1) && bit_segment_start != sz::max) {
       res.kinds.push(BITSTRUCT);
       switch (bit_widths_acc) {
         case 1..8:
@@ -176,7 +176,7 @@ fn C3Fields? getC3Fields(
 
       bit_fields = {};
       bit_fields.init(alloc);
-      bit_segment_start = usz.max;
+      bit_segment_start = sz::max;
     }
   };
 
@@ -193,11 +193,11 @@ fn CFieldKind getCFieldKind(
   CFieldKind kind;
 
   switch (clang::getCursorKind(cursor)) {
-    case clang::CURSOR_STRUCT_DECL: 
+    case CURSOR_STRUCT_DECL: 
       kind = STRUCT;
-    case clang::CURSOR_UNION_DECL: 
+    case CURSOR_UNION_DECL: 
       kind = UNION;
-    case clang::CURSOR_ENUM_DECL:
+    case CURSOR_ENUM_DECL:
       kind = ENUM;
     default: 
       if (clang::getFieldDeclBitWidth(cursor) == -1) {

--- a/bindgen.c3l/src/trans.c3
+++ b/bindgen.c3l/src/trans.c3
@@ -161,7 +161,7 @@ fn String? tokensUnderCursor(
   defer clang::disposeString(cursor_spell);
   String cursor_str = misc::convStr(cursor_spell);
 
-  CXTranslationUnit tu = clang::getTranslationUnit_Cursor(cursor);
+  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
   CXSourceRange sr = misc::getTrueCursorExtent(cursor);
 
   CXToken* tokens_ptr; uint tokens_len;
@@ -173,7 +173,7 @@ fn String? tokensUnderCursor(
   // Token number to start iterating from. 
   // It's needed as sometimes cursor name can be also tokenized, 
   // e.g. when tokenizing a macro, first token is it's name.
-  usz start_from = kind == clang::CURSOR_MACRO_DEFINITION ? 1 : 0;
+  sz start_from = kind == CURSOR_MACRO_DEFINITION ? 1 : 0;
   if (tokens_len <= start_from) return trans::EMPTY_MACRO_VAL~;
 
   DString res;
@@ -195,32 +195,32 @@ fn String? tokensUnderCursor(
       // Assume that identifier is one of:
       // 1. Constant (macro)
       // 2. Functional macro
-      case clang::TOKEN_IDENTIFIER:
-        usz i = token - tokens_ptr;
-        if (i < tokens_len - 1) {
-          CXString token_spell_2 = clang::getTokenSpelling(tu, tokens_ptr[i + 1]);
-          defer clang::disposeString(token_spell_2);
-          String token_str_2 = misc::convStr(token_spell_2);
-          if (token_str_2 == "(") {
-            is_func_macro = true;
-            is_in_func_macro = true;
-          }
-        }
+    case TOKEN_IDENTIFIER:
+      sz i = token - tokens_ptr;
+      if (i < (sz)tokens_len - 1) {
+      CXString token_spell_2 = clang::getTokenSpelling(tu, tokens_ptr[i + 1]);
+      defer clang::disposeString(token_spell_2);
+      String token_str_2 = misc::convStr(token_spell_2);
+      if (token_str_2 == "(") {
+        is_func_macro = true;
+        is_in_func_macro = true;
+      }
+      }
 
-        if (is_func_macro) {
-          res.append("@");
-          res.append(trans::apply(token_str, tfns.func_macro)!);
-        } else {
-          res.append(trans::apply(token_str, tfns.constant, tmem))!;
-        }
+      if (is_func_macro) {
+      res.append("@");
+      res.append(trans::apply(token_str, tfns.func_macro)!);
+      } else {
+      res.append(trans::apply(token_str, tfns.constant, tmem))!;
+      }
 
-      case clang::TOKEN_LITERAL:
-        res.append(trans::literal(tmem, token_str));
+    case TOKEN_LITERAL:
+      res.append(trans::literal(tmem, token_str));
 
-      case clang::TOKEN_KEYWORD:
-      case clang::TOKEN_PUNCTUATION:
-      case clang::TOKEN_COMMENT:
-        res.append(token_str);
+    case TOKEN_KEYWORD:
+    case TOKEN_PUNCTUATION:
+    case TOKEN_COMMENT:
+      res.append(token_str);
     }
   };
 
@@ -281,7 +281,7 @@ fn String? basicType(
     case "void":          return "void";
     case "_Bool":         return "bool";
     case "ptrdiff_t":     return "isz";
-    case "size_t":        return "usz";
+    case "size_t":        return "sz";
 
     case "char":          return "CChar";
     case "short":         return "CShort";

--- a/bindgen.c3l/src/trans.c3
+++ b/bindgen.c3l/src/trans.c3
@@ -82,7 +82,7 @@ fn String? ctype(
   // is that clang::getCanonicalType() practically
   // erases the difference between alias and type itself,
   // so we apply it under the following conditions
-  if (clang::isAnonymous_Cursor(clang::getTypeDeclaration(base_type))) {
+  if (clang::cursor_isAnonymous(clang::getTypeDeclaration(base_type))) {
     base_type = clang::getCanonicalType(base_type);
   }
 
@@ -91,7 +91,7 @@ fn String? ctype(
 
   // We will never check NAME for previous kind
   CTypeTokenKind prev_kind = NAME;
-  tokens.@foreach(;CTypeTokenKind kind, usz str_index) {
+  tokens.@foreach(;CTypeTokenKind kind, sz str_index) {
     String str = tparse::convertCTypeTokenToC3(kind, tokens.strs.array_view(), str_index);
 
     switch (kind) {

--- a/bindgen.c3l/src/translators.c3
+++ b/bindgen.c3l/src/translators.c3
@@ -21,9 +21,9 @@ import bgimpl,
 
 <*
  Global variable or const declaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_VAR_DECL
+ @require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
 *>
-fn usz? varDecl(
+fn sz? varDecl(
   GlobalVisitData* vd,
   CXCursor cursor)
   @maydiscard 
@@ -278,7 +278,7 @@ fn sz? macroDef(
 <*
  Functional macro definition
 *>
-fn usz? funcMacroDef(
+fn sz? funcMacroDef(
   GlobalVisitData* vd,
   CXCursor cursor)
   @maydiscard => @pool()
@@ -336,7 +336,7 @@ fn usz? funcMacroDef(
 <*
  Constant macro definition
 *>
-fn usz? constMacroDef(
+fn sz? constMacroDef(
   GlobalVisitData* vd, 
   CXCursor cursor) 
   @maydiscard => @pool()
@@ -376,7 +376,7 @@ fn usz? constMacroDef(
 
 <*
  Typedef declaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_TYPEDEF_DECL
+ @require clang::getCursorKind(cursor) == CURSOR_TYPEDEF_DECL
 *>
 fn sz? typedefDecl(
   GlobalVisitData* vd, 

--- a/bindgen.c3l/src/translators.c3
+++ b/bindgen.c3l/src/translators.c3
@@ -30,6 +30,10 @@ fn usz? varDecl(
   => @pool() 
 {
   CXType type = clang::getCursorType(cursor);
+  String docs;
+  if (vd.use_docs) {
+    docs = misc::getCursorDoc(cursor, tmem);
+  }
 
   if (clang::isConstQualifiedType(type)) {
     return ttor::constDecl(vd, cursor);
@@ -65,16 +69,16 @@ fn usz? varDecl(
     valgen::moduleWrap(vd, cursor_str);
 
     WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.gen_fns);
-    return wter::varDecl(vd.out, &vd.write_state, trans_type_str, name, rhs_val, attrs);
+    return wter::varDecl(vd.out, &vd.write_state, trans_type_str, name, rhs_val, docs, attrs);
   }
 }
 
 
 <*
- Global constant declaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_VAR_DECL
+  Global constant declaration
+  @require clang::getCursorKind(cursor) == CURSOR_VAR_DECL
 *>
-fn usz? constDecl(
+fn sz? constDecl(
   GlobalVisitData* vd, 
   CXCursor cursor) 
   @maydiscard => @pool()
@@ -123,10 +127,10 @@ fn usz? constDecl(
 
 
 <*
- Enum declaration and all underlying constants
- @require clang::getCursorKind(cursor) == clang::CURSOR_ENUM_DECL
+  Enum declaration and all underlying constants
+  @require clang::getCursorKind(cursor) == CURSOR_ENUM_DECL
 *>
-fn usz? enumDecl(
+fn sz? enumDecl(
   GlobalVisitData* vd, 
   CXCursor cursor) 
   @maydiscard => @pool() 
@@ -135,6 +139,10 @@ fn usz? enumDecl(
   CXString enum_spell = clang::getTypeSpelling(enum_type);
   defer clang::disposeString(enum_spell);
   String orig_enum_name = misc::convStr(enum_spell);
+  String docs;
+  if (vd.use_docs) {
+    docs = misc::getCursorDoc(cursor, tmem);
+  }
 
   if (misc::isCursorForwardDeclared(cursor)) {
     err::warn(vd.no_verbose, "Enum '%s' has forward declaration, skipping this declaration...", orig_enum_name);
@@ -153,23 +161,24 @@ fn usz? enumDecl(
   }
 
   EnumVisitData vd_enum = {
-    .g = vd
+    .g = vd,
+    .allocator = mem,
   };
 
   switch (under_type.kind) {
-    case clang::TYPE_UCHAR:
-    case clang::TYPE_USHORT: 
-    case clang::TYPE_UINT:      
-    case clang::TYPE_ULONG:
-    case clang::TYPE_ULONGLONG: 
-      vd_enum.is_unsigned = true;
+    case TYPE_UCHAR:
+    case TYPE_USHORT: 
+    case TYPE_UINT:      
+    case TYPE_ULONG:
+    case TYPE_ULONGLONG: 
+    vd_enum.is_unsigned = true;
     default:
-      vd_enum.is_unsigned = false;
+    vd_enum.is_unsigned = false;
   }
 
   WriteAttrs attrs;
-  usz? acc;
-  if (clang::isAnonymous_Cursor(cursor)) {
+  sz? acc;
+  if (clang::cursor_isAnonymous(cursor)) {
     CXType base = misc::getBaseType(enum_type);
     vd.types_table[base] = under_type_str;
 
@@ -181,27 +190,27 @@ fn usz? enumDecl(
       return 0;
     }
 
+    if (clang::visitChildren(cursor, &vtor::enumField, (CXClientData)&vd_enum) != 0) return 0;
+
     valgen::moduleWrap(vd, orig_enum_name);
     attrs = valgen::getWriteAttrs(tmem, orig_enum_name, vd.gen_fns);
-    acc = wter::enumDecl(vd.out, &vd.write_state, tmp, under_type_str);
+    acc = wter::enumDecl(vd.out, &vd.write_state, vd_enum.fields.array_view(), tmp, under_type_str, docs);
     
     vd_enum.enum_name = tmp;
   }
 
-  clang::visitChildren(cursor, &vtor::enumDecl, (CXClientData) &vd_enum);
   return acc;
 }
 
 
 <*
- Function delcaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_FUNCTION_DECL
+	Function delcaration
+	@require clang::getCursorKind(cursor) == CURSOR_FUNCTION_DECL
 *>
-fn usz? func(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard 
-  => @pool()
+fn sz? func(
+	GlobalVisitData* vd, 
+	CXCursor cursor) 
+	@maydiscard => @pool()
 {
   FuncVisitData vd_func = {
     .g = vd,
@@ -209,6 +218,11 @@ fn usz? func(
   };
 
   vd_func.params.tinit(4);
+
+  String docs;
+  if (vd.use_docs) {
+    docs = misc::getCursorDoc(cursor, mem);
+  }
 
   // Translate function parameters and store them into vd_func.params
   if (clang::visitChildren(cursor, &vtor::func, (CXClientData) &vd_func) != 0) return 0;
@@ -242,22 +256,22 @@ fn usz? func(
   valgen::moduleWrap(vd, func_str);
 
   WriteAttrs attrs = valgen::getWriteAttrs(tmem, func_str, vd.gen_fns);
-  return wter::func(vd.out, &vd.write_state, vd_func.params.array_view(), trans_ret_type_str, func_str, trans_func_str, attrs);
+  return wter::func(vd.out, &vd.write_state, vd_func.params.array_view(), trans_ret_type_str, func_str, trans_func_str, docs, attrs);
 }
 
 
 <*
- Macro definition
- @require clang::getCursorKind(cursor) == clang::CURSOR_MACRO_DEFINITION
+	Macro definition
+	@require clang::getCursorKind(cursor) == CURSOR_MACRO_DEFINITION
 *>
-fn usz? macroDef(
-  GlobalVisitData* vd, 
-  CXCursor cursor) 
-  @maydiscard
+fn sz? macroDef(
+	GlobalVisitData* vd, 
+	CXCursor cursor) 
+	@maydiscard
 {
-  return clang::isMacroFunctionLike_Cursor(cursor) ? 
-    ttor::funcMacroDef(vd, cursor) :
-    ttor::constMacroDef(vd, cursor) @inline;
+	return clang::cursor_isMacroFunctionLike(cursor) ? 
+		ttor::funcMacroDef(vd, cursor) :
+		ttor::constMacroDef(vd, cursor) @inline;
 }
 
 
@@ -287,7 +301,7 @@ fn usz? funcMacroDef(
   List{String} params;
   params.tinit();
 
-  CXTranslationUnit tu = clang::getTranslationUnit_Cursor(cursor);
+  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursor);
   CXSourceRange sr = misc::getTrueCursorExtent(cursor); // We don't need to do getTrueCursorExtent as bug is not occured under macro declaration
   
   CXToken* tokens_ptr; uint tokens_len;
@@ -364,7 +378,7 @@ fn usz? constMacroDef(
  Typedef declaration
  @require clang::getCursorKind(cursor) == clang::CURSOR_TYPEDEF_DECL
 *>
-fn usz? typedefDecl(
+fn sz? typedefDecl(
   GlobalVisitData* vd, 
   CXCursor cursor) 
   @maydiscard => @pool()
@@ -412,10 +426,10 @@ fn usz? typedefDecl(
 
 
 <*
- Structure declaration
- @require clang::getCursorKind(cursor) == clang::CURSOR_STRUCT_DECL
+  Structure declaration
+  @require clang::getCursorKind(cursor) == CURSOR_STRUCT_DECL
 *>
-fn usz? structDecl(
+fn sz? structDecl(
   GlobalVisitData* vd, 
   CXCursor cursor) 
   @maydiscard
@@ -425,10 +439,10 @@ fn usz? structDecl(
 
 
 <*
- Union declaration
- @require  clang::getCursorKind(cursor) == clang::CURSOR_UNION_DECL 
+  Union declaration
+  @require  clang::getCursorKind(cursor) == CURSOR_UNION_DECL 
 *>
-fn usz? unionDecl(
+fn sz? unionDecl(
   GlobalVisitData* vd, 
   CXCursor cursor) 
   @maydiscard
@@ -440,7 +454,7 @@ fn usz? unionDecl(
 <*
  Both struct and union declaration helper macro
 *>
-macro usz? recordDecl(
+macro sz? recordDecl(
   GlobalVisitData* vd,
   CXCursor cursor, 
   bool $is_union)
@@ -450,6 +464,10 @@ macro usz? recordDecl(
   CXString rec_spell = clang::getTypeSpelling(rec_type);
   defer clang::disposeString(rec_spell);
   String orig_rec_name = misc::convStr(rec_spell);
+  String docs;
+  if (vd.use_docs) {
+    docs = misc::getCursorDoc(cursor, tmem);
+  }
 
   if (misc::isCursorForwardDeclared(cursor)) {
     $if $is_union:
@@ -470,8 +488,8 @@ macro usz? recordDecl(
     $endif
     return 0;
   }
- 
-  if (clang::isAnonymous_Cursor(cursor)) {
+
+  if (clang::cursor_isAnonymous(cursor)) {
     CXSourceLocation cursor_loc = clang::getCursorLocation(cursor);
     CUInt line, col;
     CXFile file;
@@ -493,7 +511,7 @@ macro usz? recordDecl(
   // If no fields are defined, rec_type is incomplete.
   // Then we write it as typedef to void and wrap into
   // module if needed
-  usz fields_len = misc::getTopChildrenNumber(cursor);
+  sz fields_len = misc::getTopChildrenNumber(cursor);
   if (fields_len == 0)  {
     valgen::moduleWrap(vd, orig_rec_name);
     return wter::typedefDistinct(vd.out, &vd.write_state, rec_name, "void", attrs);
@@ -532,7 +550,7 @@ macro usz? recordDecl(
   $if $is_union:
     return wter::unionDecl(vd.out, &vd.write_state, rec_name, &c3_fields, 0, attrs);
   $else
-    return wter::structDecl(vd.out, &vd.write_state, rec_name, &c3_fields, 0, attrs);
+    return wter::structDecl(vd.out, &vd.write_state, rec_name, &c3_fields, 0, docs, attrs);
   $endif
 }
 
@@ -540,7 +558,7 @@ macro usz? recordDecl(
 <*
  Pointer to function type (not top-level declaration)
 *>
-fn usz? pfnType(
+fn sz? pfnType(
   GlobalVisitData* vd, 
   String name,
   CXType type, 

--- a/bindgen.c3l/src/user.c3
+++ b/bindgen.c3l/src/user.c3
@@ -47,34 +47,45 @@ fn void? includeLibcToArgs(
   List{ZString}* res) 
   => @pool()
 {
-  SubProcess proc = process::create({ "clang", "-E", "-Wp,-v", "-xc", "-" })!;
-  proc.join()!; // join the process to close stdin of clang
+  Process proc = process::spawn({ "clang", "-E", "-Wp,-v", "-xc", "-" })!;
   defer proc.destroy();
   File in = proc.stderr();
 
-  bool found;
-  while (!found) {
-    if (in.read_byte()! == '\n') {
-      char[14] buffer;
-      in.read(buffer[..])!;
-      if (buffer[..] == "#include <...>") {
-        while(in.read_byte()! != '\n') {}; // read till '\n'
-        found = true;
-      }
+  bool inside_include_section = false;
+  DString current_line;
+  current_line.tinit();
+
+  while (try c = in.read_byte()) {
+    if (c != '\n') {
+      current_line.append(c);
+      continue;
+    }
+
+    if (!inside_include_section) {
+      if (current_line.str_view().contains("#include <...>")) {
+      inside_include_section = true;
+    }
+
+  } else {
+    // If we are inside the section, lines starting with ' ' are paths
+    if (current_line.str_view().starts_with(" ")) {
+    DString path_flag;
+    path_flag.tinit();
+    path_flag.append("-I");
+    // Append the path, stripping the leading space
+    path_flag.append(current_line.str_view()[1..]); 
+    
+    res.push(path_flag.copy_zstr(alloc));
+    } 
+    else 
+    {
+    break;
     }
   }
 
-  while (try first_c = in.read_byte() && first_c == ' ') {
-    DString path_dstr;
-    path_dstr.tinit();
-
-    path_dstr.append("-I");
-    while (try c = in.read_byte() && c != '\n') {
-      path_dstr.append(c);
-    }
-
-    // Append all possible headers
-    res.push(path_dstr.copy_zstr(alloc));
+  current_line.clear();
   }
+
+  proc.join()!;
 }
 

--- a/bindgen.c3l/src/valgen.c3
+++ b/bindgen.c3l/src/valgen.c3
@@ -8,14 +8,14 @@ import bindgen::bg,
  Applies fun to a name for value generation.
  If function is null, returns the default value
  of return type.
- @require $typeof(fun) == BGGenFn ||| $typeof(fun) == BGModuleWrapFn
+ @require $Typeof(fun) == BGGenFn ||| $Typeof(fun) == BGModuleWrapFn
 *>
 macro apply(
   Allocator alloc, 
   String name,  
   fun)
 {
-  var $RetType = $typefrom($typeof(fun).returns);
+  var $RetType = $Typefrom($Typeof(fun)::returns);
   if (fun == null) return ($RetType){};
 
   $RetType res = fun(name, alloc);

--- a/bindgen.c3l/src/visitors.c3
+++ b/bindgen.c3l/src/visitors.c3
@@ -33,28 +33,28 @@ fn CXChildVisitResult global(
   clang::getExpansionLocation(clang::getCursorLocation(cursor), &cursor_file, null, null, null);
 
   // Ignore null file as it might be a macro included by a compiler
-  if (cursor_file == null) return clang::CHILD_VISIT_CONTINUE;
+  if (cursor_file == null) return CHILD_VISIT_CONTINUE;
 
   // If file is not equal to ours and it's not permitted, skip it
-  if (!clang::isEqual_File(cursor_file, vd.cxfile)) {
+  if (!clang::file_isEqual(cursor_file, vd.cxfile)) {
     CXString file_spell = clang::getFileName(cursor_file);
     defer clang::disposeString(file_spell);
     String file_str = misc::convStr(file_spell);
 
-    if (!check::apply(file_str, vd.include_file)) return clang::CHILD_VISIT_CONTINUE; 
+    if (!check::apply(file_str, vd.include_file)) return CHILD_VISIT_CONTINUE; 
   }
 
   switch (cursor_kind) {
-    case clang::CURSOR_FUNCTION_DECL: ttor::func(vd, cursor);
-    case clang::CURSOR_STRUCT_DECL: ttor::structDecl(vd, cursor);
-    case clang::CURSOR_TYPEDEF_DECL: ttor::typedefDecl(vd, cursor);
-    case clang::CURSOR_VAR_DECL: ttor::varDecl(vd, cursor);
-    case clang::CURSOR_ENUM_DECL: ttor::enumDecl(vd, cursor);
-    case clang::CURSOR_MACRO_DEFINITION: ttor::macroDef(vd, cursor);
-    case clang::CURSOR_UNION_DECL: ttor::unionDecl(vd, cursor);
+    case CURSOR_FUNCTION_DECL: ttor::func(vd, cursor);
+    case CURSOR_STRUCT_DECL: ttor::structDecl(vd, cursor);
+    case CURSOR_TYPEDEF_DECL: ttor::typedefDecl(vd, cursor);
+    case CURSOR_VAR_DECL: ttor::varDecl(vd, cursor);
+    case CURSOR_ENUM_DECL: ttor::enumDecl(vd, cursor);
+    case CURSOR_MACRO_DEFINITION: ttor::macroDef(vd, cursor);
+    case CURSOR_UNION_DECL: ttor::unionDecl(vd, cursor);
   }
 
-  return clang::CHILD_VISIT_CONTINUE;
+  return CHILD_VISIT_CONTINUE;
 }
 
 
@@ -71,15 +71,54 @@ fn CXChildVisitResult constDecl(
 
   // When cursor type is a typedef of some other type, one more 
   // child is added to it so skip it
-  if (clang::getCursorKind(cursor) == clang::CURSOR_TYPE_REF) {
-    return clang::CHILD_VISIT_CONTINUE;
+  if (clang::getCursorKind(cursor) == CURSOR_TYPE_REF) {
+    return CHILD_VISIT_CONTINUE;
   }
 
   vd.val = trans::tokensUnderCursor(vd.allocator, cursor, &vd.g.trans_fns) ?? EMPTY_TOKENS;
 
-  return clang::CHILD_VISIT_CONTINUE;
+  if (clang::getCursorKind(cursor) != CURSOR_FIELD_DECL) {
+
+
+
+    return CHILD_VISIT_CONTINUE;
+  }
+
+  return CHILD_VISIT_CONTINUE;
 }
 
+<*
+	visit an enums fields/members
+*>
+fn CXChildVisitResult enumField(
+  CXCursor cursor, 
+  CXCursor parent, 
+  CXClientData client_data)
+{
+	if (clang::getCursorKind(cursor) != CURSOR_ENUM_CONSTANT_DECL) {
+		return CHILD_VISIT_CONTINUE;
+	}
+
+	EnumVisitData* vd = (EnumVisitData*)client_data;
+	
+	CXString name_spell = clang::getCursorSpelling(cursor);
+	defer clang::disposeString(name_spell);
+	String name_str = misc::convStr(name_spell); 
+
+  	String trans_name_str = trans::apply(name_str, vd.g.trans_fns.enum_field, vd.allocator) ?? "";
+
+	CLongLong enum_value = clang::getEnumConstantDeclValue(cursor);
+	String value_str = string::format(vd.allocator, "%d", enum_value);
+
+	String docs;
+	if (vd.g.use_docs) {
+		docs = misc::getCursorDoc(cursor, mem, 1);
+	}
+
+	vd.fields.push({ trans_name_str, value_str, docs });
+
+	return CHILD_VISIT_CONTINUE;
+}
 
 <*
  Enum constants
@@ -91,40 +130,28 @@ fn CXChildVisitResult enumDecl(
   CXCursor parent, 
   CXClientData client_data)
 {
-  EnumVisitData* vd = (EnumVisitData*) client_data;
+  if (clang::getCursorKind(cursor) != CURSOR_ENUM_DECL) {
+    return CHILD_VISIT_CONTINUE;
+  }
+
+  EnumVisitData* vd = (EnumVisitData*)client_data;
 
   CXString cursor_spell = clang::getCursorSpelling(cursor);
   defer clang::disposeString(cursor_spell);
   String cursor_str = misc::convStr(cursor_spell);
-  
+
   String? trans_cursor_str = trans::apply(cursor_str, vd.g.trans_fns.constant, tmem);
   if (catch trans_cursor_str) {
     err::warn(vd.g.no_verbose, "Enum constant '%s' is ignored", cursor_str);
-    return clang::CHILD_VISIT_CONTINUE;
+    return CHILD_VISIT_CONTINUE;
   }
-  
-  ConstVisitData vd_const = {
-    .g = vd.g,
-    .allocator = tmem,
-  };
 
-  clang::visitChildren(cursor, &vtor::constDecl, (CXClientData) &vd_const);
+  vd.fields.tinit();
 
-  // If we get empty rhs, evaluate value
-  if (vd_const.val == EMPTY_TOKENS) {
-    if (vd.is_unsigned) {
-      CULongLong ival = clang::getEnumConstantDeclUnsignedValue(cursor);
-      vd_const.val = string::tformat("%s", ival);
-    } else {
-      CLongLong ival = clang::getEnumConstantDeclValue(cursor);
-      vd_const.val = string::tformat("%s", ival);
-    }
-  }
+  clang::visitChildren(cursor, &enumField, (CXClientData)&vd);
 
   WriteAttrs attrs = valgen::getWriteAttrs(tmem, cursor_str, vd.g.gen_fns);
-  wter::constDecl(vd.g.out, &vd.g.write_state, vd.enum_name, trans_cursor_str, vd_const.val, attrs);
-
-  return clang::CHILD_VISIT_CONTINUE;
+  return CHILD_VISIT_CONTINUE;
 }
 
 
@@ -139,19 +166,24 @@ fn CXChildVisitResult typedefDecl(
 {
   // The visitor can also encounter non-types in a function.
   // For example, it may be attributes, declared structures, etc.
-  if (clang::getCursorKind(cursor) != clang::CURSOR_TYPE_REF) {
-    return clang::CHILD_VISIT_CONTINUE;
+  if (clang::getCursorKind(cursor) != CURSOR_TYPE_REF) {
+  return CHILD_VISIT_CONTINUE;
   }
 
   TypedefVisitData* vd = (TypedefVisitData*) client_data;
-  vd.is_incomplete = !clang::isCursorDefinition(cursor) && misc::isTypeIncomplete(vd.under_type);
+
+  CXCursor ref_cursor = clang::getCursorReferenced(cursor);
+  bool has_definition = clang::isCursorDefinition(ref_cursor) != 0;
+  bool is_layout_incomplete = clang::type_getSizeOf(vd.under_type) == -2;
+
+  vd.is_incomplete = !has_definition || is_layout_incomplete;
 
   if (vd.is_incomplete) {
     CXType key = misc::getBaseType(vd.under_type);
     vd.g.types_table[key] = "void";
   }
 
-  return clang::CHILD_VISIT_BREAK;
+  return CHILD_VISIT_BREAK;
 }
 
 
@@ -166,8 +198,8 @@ fn CXChildVisitResult func(
 {
   // The visitor can also encounter non-paremeters in a function.
   // For example, it may be attributes, etc.
-  if (clang::getCursorKind(cursor) != clang::CURSOR_PARM_DECL) {
-    return clang::CHILD_VISIT_CONTINUE;
+  if (clang::getCursorKind(cursor) != CURSOR_PARM_DECL) {
+    return CHILD_VISIT_CONTINUE;
   }
 
   FuncVisitData* vd = (FuncVisitData*) client_data;
@@ -192,12 +224,12 @@ fn CXChildVisitResult func(
     String parent_str = misc::convStr(parent_spell);
 
     err::warn(vd.g.no_verbose, "Can't translate function '%s' as it's parameter type '%s' is ignored", parent_str, type_str);
-    return clang::CHILD_VISIT_BREAK;
+    return CHILD_VISIT_BREAK;
   }
 
   vd.params.push({trans_type_str, trans_name_str});
 
-  return clang::CHILD_VISIT_CONTINUE;
+  return CHILD_VISIT_CONTINUE;
 }
 
 
@@ -222,13 +254,13 @@ fn CXChildVisitResult fields(
   String? trans_field_name = trans::apply(field_name, vd.g.trans_fns.variable, vd.allocator);
   if (catch trans_field_name) {
     err::warn(vd.g.no_verbose, "Field (variable) '%s' is ignored", field_name);
-    return clang::CHILD_VISIT_BREAK;
+    return CHILD_VISIT_BREAK;
   }
 
   CXType type = clang::getCanonicalType(clang::getCursorType(cursor));
   CXType prev_type = clang::getCursorType(vd.prev_inline);
 
-  if (!clang::isNull_Cursor(vd.prev_inline) && clang::equalTypes(type, prev_type)) {
+  if (!clang::cursor_isNull(vd.prev_inline) && clang::equalTypes(type, prev_type)) {
     switch (tparse::getCFieldKind(vd.prev_inline)) {
       case STRUCT:
         vd.fields.structs[^1].name = trans_field_name;
@@ -239,7 +271,7 @@ fn CXChildVisitResult fields(
     }
 
     vd.prev_inline = clang::getNullCursor();
-    return clang::CHILD_VISIT_CONTINUE;
+    return CHILD_VISIT_CONTINUE;
   }
 
   CFieldKind kind = tparse::getCFieldKind(cursor);
@@ -255,8 +287,8 @@ fn CXChildVisitResult fields(
       defer clang::disposeString(parent_spell);
       String parent_str = misc::convStr(parent_spell);
 
-      err::warn(vd.g.no_verbose, "Can't translate struct/union '%s' as it's field type '%s' is ignored", parent_str, type_str);
-      return clang::CHILD_VISIT_BREAK;
+    err::warn(vd.g.no_verbose, "Can't translate struct/union '%s' as it's field type '%s' is ignored", parent_str, type_str);
+    return CHILD_VISIT_BREAK;
     }
 
     switch (kind) {
@@ -277,40 +309,40 @@ fn CXChildVisitResult fields(
     // is anonymous or not. In first case, we create anonymous record 
     // as well; in second one, we regularly translate a record and 
     // write it globally
-    if (clang::isAnonymous_Cursor(cursor)) {
-      vd.prev_inline = cursor;
-      FieldsVisitData vd_inner = {
-        .g = vd.g,
-        .allocator = vd.allocator,
-        .prev_inline = clang::getNullCursor(),
-      };
+    if (clang::cursor_isAnonymous(cursor)) {
+    vd.prev_inline = cursor;
+    FieldsVisitData vd_inner = {
+      .g = vd.g,
+      .allocator = vd.allocator,
+      .prev_inline = clang::getNullCursor(),
+    };
 
-      vd_inner.fields.init(vd_inner.allocator);
-      if (clang::visitChildren(cursor, &vtor::fields, (CXClientData) &vd_inner) != 0) return clang::CHILD_VISIT_BREAK;
+    vd_inner.fields.init(vd_inner.allocator);
+    if (clang::visitChildren(cursor, &vtor::fields, (CXClientData) &vd_inner) != 0) return CHILD_VISIT_BREAK;
 
-      switch (kind) {
-        case STRUCT:
-          vd.fields.structs.push({"", vd_inner.fields});
-          vd.fields.kinds.push(STRUCT);
-        case UNION:
-          vd.fields.unions.push({"", vd_inner.fields});
-          vd.fields.kinds.push(UNION);
-        default: 
-          unreachable();
-      }
+    switch (kind) {
+    case STRUCT:
+      vd.fields.structs.push({"", vd_inner.fields});
+      vd.fields.kinds.push(STRUCT);
+    case UNION:
+      vd.fields.unions.push({"", vd_inner.fields});
+      vd.fields.kinds.push(UNION);
+    default: 
+      unreachable();
+    }
     } else {
-      switch (kind) {
-        case STRUCT:
-          ttor::structDecl(vd.g, cursor);
-        case UNION:
-          ttor::unionDecl(vd.g, cursor);
-        default:
-          unreachable();
-      }
+    switch (kind) {
+    case STRUCT:
+      ttor::structDecl(vd.g, cursor);
+    case UNION:
+      ttor::unionDecl(vd.g, cursor);
+    default:
+      unreachable();
+    }
     }
   }
 
-  return clang::CHILD_VISIT_CONTINUE;
+  return CHILD_VISIT_CONTINUE;
 }
 
 

--- a/bindgen.c3l/src/writers.c3
+++ b/bindgen.c3l/src/writers.c3
@@ -22,7 +22,7 @@ const INDENT = "  ";
  @require name            != ""
  @require underlying_name != ""
 *>
-fn usz? typedefAlias(
+fn sz? typedefAlias(
   OutStream out,
   WriteState* state,
   String name,
@@ -32,7 +32,7 @@ fn usz? typedefAlias(
 {
   state.kind = ALIAS;
 
-  usz? acc;
+  sz? acc;
   acc += io::fprintfn(out, "\nalias %s%s = %s;", name, attribs, underlying_name);
   return acc;
 }
@@ -45,7 +45,7 @@ fn usz? typedefAlias(
  @require name            != ""
  @require underlying_name != ""
 *>
-fn usz? typedefDistinct(
+fn sz? typedefDistinct(
   OutStream out,
   WriteState* state,
   String name,
@@ -55,7 +55,7 @@ fn usz? typedefDistinct(
 {
   state.kind = TYPEDEF;
 
-  usz? acc;
+  sz? acc;
   acc += io::fprintfn(out, "\ntypedef %s%s = %s;", name, attribs, underlying_name);
   return acc;
 }
@@ -69,7 +69,7 @@ fn usz? typedefDistinct(
  @require name        != ""
  @require return_type != ""
 *>
-fn usz? typedefFunc(
+fn sz? typedefFunc(
   OutStream out,
   WriteState* state,
   String name,
@@ -80,8 +80,8 @@ fn usz? typedefFunc(
 {
   state.kind = ALIAS;
 
-  usz? acc;
-  
+  sz? acc;
+
   acc += io::fprintf(out, "\nalias %s%s = fn %s(", name, attribs, return_type);
   
   if (params.len > 0) acc += io::fprintf(out, "\n");
@@ -110,7 +110,7 @@ fn usz? typedefFunc(
  @require name  != ""
  @require value != ""
 *>
-fn usz? constDecl(
+fn sz? constDecl(
   OutStream out,
   WriteState* state,
   String type,
@@ -122,7 +122,7 @@ fn usz? constDecl(
   WriteKind prev_kind = state.kind;
   state.kind = CONST;
 
-  usz? acc;
+  sz? acc;
 
   if (prev_kind != CONST && prev_kind != ENUM) acc += io::fprintf(out, "\n");
 
@@ -144,18 +144,24 @@ fn usz? constDecl(
  @require type != ""
  @require name != ""
 *>
-fn usz? varDecl(
+fn sz? varDecl(
   OutStream out,
   WriteState* state,
   String type,
   String name,
   String value,
+  String docs = "",
   WriteAttrs attribs = {})
   @maydiscard
 {
   state.kind = VAR;
 
-  usz? acc;
+  sz? acc;
+
+  if (docs)
+  {
+    acc += io::fprintf(out, "\n%s", docs);
+  }
 
   if (value == "") {
     acc += io::fprintfn(out, "\n%s %s%s;", type, name, attribs);
@@ -174,17 +180,38 @@ fn usz? varDecl(
  @require name != ""
  @require type != ""
 *>
-fn usz? enumDecl(
+fn sz? enumDecl(
   OutStream out,
   WriteState* state,
+  EnumField[] fields,
   String name,
   String type,
+  String docs = "",
   WriteAttrs attribs = {})
   @maydiscard
 {
   state.kind = ENUM;
 
-  return io::fprintfn(out, "\ntypedef %s%s = inline %s;", name, attribs, type);
+  sz? acc;
+  if (docs)
+  {
+    acc += io::fprintf(out, "\n%s", docs);
+  }
+  acc += io::fprintfn(out, "\nconstdef %s%s : %s {", name, attribs, type);
+
+  foreach (i, p : fields)  {
+    if (p.docs != "")
+    {
+      acc += io::fprintfn(out, "\n%s", p.docs);
+    }
+    acc += io::fprintf(out, INDENT+++"%s =", p.name);
+    acc += io::fprintf(out, " %s", p.init);
+    if (i < fields.len - 1) acc += io::fprintn(out, ",");
+    }
+
+  acc += io::fprintfn(out, "\n}");
+
+  return acc;
 }
 
 
@@ -197,21 +224,27 @@ fn usz? enumDecl(
  @require original_name != ""
  @require name          != ""
 *>
-fn usz? func(
+fn sz? func(
   OutStream out,
   WriteState* state,
   VarDecl[] params,
   String return_type,
   String original_name,
   String name,
+  String docs = "",
   WriteAttrs attribs = {}) 
   @maydiscard
 {
   state.kind = FUNC;
 
-  usz? acc;
+  sz? acc;
 
-  acc += io::fprintf(out, "\nfn %s %s(", return_type, name);
+  if (docs.len > 0)
+  {
+    acc += io::fprintf(out, "\n%s", docs);
+  }
+
+  acc += io::fprintf(out, "\nextern fn %s %s(", return_type, name);
   if (params.len > 0) acc += io::fprintf(out, "\n");
 
   foreach (i, p : params)  {
@@ -221,7 +254,7 @@ fn usz? func(
     }
     if (i < params.len - 1) acc += io::fprintn(out, ",");
   }
-  acc += io::fprintfn(out, ")\n@extern(\"%s\")%s;", original_name, attribs);
+  acc += io::fprintfn(out, ")\n@cname(\"%s\")%s;", original_name, attribs);
 
   return acc;
 }
@@ -235,7 +268,7 @@ fn usz? func(
  @require !array::has(params, fn bool(String val) => val == "") : "params can't contain empty entries"
  @require name != ""
 *>
-fn usz? funcMacro(
+fn sz? funcMacro(
   OutStream out,
   WriteState* state,
   String[] params,
@@ -246,7 +279,7 @@ fn usz? funcMacro(
 {
   state.kind = MACRO;
 
-  usz? acc;
+  sz? acc;
 
   acc += io::fprintf(out, "\nmacro @%s(", name);
   foreach (i, p : params) {
@@ -271,7 +304,7 @@ fn usz? funcMacro(
  @param [&out]   state : "Sets state.kind to WriteKind.MODULE"
  @require module_name != ""
 *>
-fn usz? moduleHead(
+fn sz? moduleHead(
   OutStream out,
   WriteState* state,
   String module_name,
@@ -290,7 +323,7 @@ fn usz? moduleHead(
  @param [&out]   state : "Sets state.kind to WriteKind.IMPORT"
  @require import_module != ""
 *>
-fn usz? importModule(
+fn sz? importModule(
   OutStream out,
   WriteState* state,
   String import_module)
@@ -308,22 +341,24 @@ fn usz? importModule(
  @param [&in]    fields
  @param [&out]   state  : "Sets state.kind to WriteKind.IMPORT"
 *>
-fn usz? structDecl(
+fn sz? structDecl(
   OutStream out,
   WriteState* state,
   String name,
   C3Fields* fields,
-  usz indent_level = 0,
+  sz indent_level = 0,
+  String docs = "",
   WriteAttrs attribs = {}) 
   @maydiscard
 {
   state.kind = STRUCT;
 
-  usz? acc;
+  sz? acc;
 
   acc += printIndent(out, indent_level);
-  
+
   if (indent_level == 0) acc += io::fprintf(out, "\n");
+  acc += io::fprintfn(out, docs);
 
   if (name == "") {
     acc += io::fprintfn(out, "struct {");
@@ -343,18 +378,18 @@ fn usz? structDecl(
 <*
  Union declaration
 *>
-fn usz? unionDecl(
+fn sz? unionDecl(
   OutStream out,
   WriteState* state,
   String name,
   C3Fields* fields,
-  usz indent_level = 0,
+  sz indent_level = 0,
   WriteAttrs attribs = {}) 
   @maydiscard
 {
   state.kind = UNION;
 
-  usz? acc;
+  sz? acc;
 
   acc += printIndent(out, indent_level);
 
@@ -379,15 +414,15 @@ fn usz? unionDecl(
  Helper function for wter::structDecl and wter::unionDecl,
  which writes record fields
 *>
-fn usz? fields(
+fn sz? fields(
   OutStream out,
   WriteState* state,
   C3Fields* fields,
-  usz indent_level)
+  sz indent_level)
 {
-  usz? acc;
+  sz? acc;
 
-  fields.@foreach(; C3FieldKind* kind, usz index)
+  fields.@foreach(; C3FieldKind* kind, sz index)
   {
     switch (*kind)
     {
@@ -427,12 +462,12 @@ fn usz? fields(
 <*
  Helper printer
 *>
-fn usz? printIndent( 
+fn sz? printIndent( 
   OutStream out, 
-  usz indent_level = 1)
+  sz indent_level = 1)
 {
-  usz? acc;
-  for (usz i; i < indent_level; ++i) acc += io::fprintf(out, INDENT);
+  sz? acc;
+  for (sz i; i < indent_level; ++i) acc += io::fprintf(out, INDENT);
   return acc;
 }
 

--- a/project.json
+++ b/project.json
@@ -10,6 +10,11 @@
       "sources" : [ "examples/sandbox.c3" ],
     },
 
+    "clang": {
+      "type": "executable",
+      "sources": ["examples/clang.c3"]
+    },
+
     "dummy" : {
       "type" : "executable",
       "sources" : [ "examples/dummy.c3" ],

--- a/tests/bgtest_lib.c3
+++ b/tests/bgtest_lib.c3
@@ -3,7 +3,7 @@ module bgtest;
 import bgimpl,
        clang,
        std::io,
-       std::collections::elastic_array,
+       std::collections::fixedlist,
        std::collections::list;
 
 
@@ -27,19 +27,19 @@ fn CXCursor[]? parse(
   Allocator alloc, 
   char[] code,
   ZString[] extra_args = {},
-  CXDiagnosticSeverity min_severity = clang::DIAGNOSTIC_ERROR,
+  CXDiagnosticSeverity min_severity = DIAGNOSTIC_ERROR,
   bool quiet = false)
   => @pool()
 {
   const PARSE_FLAGS = 
-    clang::TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD |
-    clang::TRANSLATION_UNIT_SKIP_FUNCTION_BODIES |
-    clang::TRANSLATION_UNIT_KEEP_GOING;
+    CXTranslationUnit_Flags.TRANSLATION_UNIT_DETAILED_PREPROCESSING_RECORD |
+    CXTranslationUnit_Flags.TRANSLATION_UNIT_SKIP_FUNCTION_BODIES |
+    CXTranslationUnit_Flags.TRANSLATION_UNIT_KEEP_GOING;
 
   // Create temp header
   Path tmp = path::temp_directory(tmem)!!;
   tmp = tmp.tappend(HEADER_NAME)!!;
-  file::save(tmp.str_view(), code)!!;
+  file::save(tmp, code)!!;
 
   // Get args
   List{ZString} args_list;
@@ -53,7 +53,7 @@ fn CXCursor[]? parse(
   // Parse file
   CXIndex index = clang::createIndex(0, 0);
   defer clang::disposeIndex(index);
-  CXTranslationUnit tu = clang::parseTranslationUnit(index, (ZString)tmp.str_view(), args.ptr, args.len, null, 0, PARSE_FLAGS);
+  CXTranslationUnit tu = clang::parseTranslationUnit(index, (ZString)tmp, args.ptr, args.len, null, 0, (CUInt)PARSE_FLAGS);
   
   // Check the parse result
   if (tu == null) return PARSE_FAILURE~;
@@ -99,14 +99,14 @@ fn CXCursor[]? parse(
     // If cursor_file is null, it might be a macro included by a compiler
     CXFile cursor_file;
     clang::getExpansionLocation(clang::getCursorLocation(cursor), &cursor_file, null, null, null);
-    if (cursor_file == null) return clang::CHILD_VISIT_CONTINUE;
+    if (cursor_file == null) return CHILD_VISIT_CONTINUE;
 
     // Skip macro expansions
-    if (clang::getCursorKind(cursor) == clang::CURSOR_MACRO_EXPANSION) return clang::CHILD_VISIT_CONTINUE;
+    if (clang::getCursorKind(cursor) == CURSOR_MACRO_EXPANSION) return CHILD_VISIT_CONTINUE;
 
     List{CXCursor}* cursors = (List{CXCursor}*) client;
     cursors.push(cursor);
-    return clang::CHILD_VISIT_CONTINUE;
+    return CHILD_VISIT_CONTINUE;
   }, (CXClientData) &cursors);
 
   return cursors.to_array(alloc);
@@ -121,10 +121,10 @@ fn CXType[] get_types(
   CXCursor[] cursors) 
   @inline
 {
-  CXType[] res = allocator::alloc_array(alloc, CXType, cursors.len);
+  CXType[] res = alloc::alloc_array(alloc, CXType, cursors.len);
   foreach (i, c : cursors) {
     switch (clang::getCursorKind(c)) {
-      case clang::CURSOR_TYPEDEF_DECL:
+      case CURSOR_TYPEDEF_DECL:
         res[i] = clang::getTypedefDeclUnderlyingType(c);
 
       default:
@@ -169,5 +169,5 @@ fn void cleanup() @local @finalizer
 }
 
 
-ElasticArray{CXTranslationUnit, TUS_CAPACITY} translation_units @local;
+FixedList{CXTranslationUnit, TUS_CAPACITY} translation_units @local;
 

--- a/tests/unit/data_methods.c3
+++ b/tests/unit/data_methods.c3
@@ -4,7 +4,7 @@ import std::io;
 
 
 <*
- @require WriteAttrs.membersof.len == 2 : "Test is out of date"
+ @require WriteAttrs::members.len == 2 : "Test is out of date"
 *>
 fn void test_WriteAttrs_to_format()
 {

--- a/tests/unit/misc.c3
+++ b/tests/unit/misc.c3
@@ -79,7 +79,7 @@ fn void test_is_type_incomplete()
   CXCursor[] cursors = bgtest::parse(tmem, SUITE_TRUE)!!;
   CXType[] types = bgtest::get_types(tmem, cursors);
   foreach (t : types) {
-    CXType base = t.kind == clang::TYPE_POINTER ? clang::getPointeeType(t) : t;
+    CXType base = t.kind == TYPE_POINTER ? clang::getPointeeType(t) : t;
     assert( isTypeIncomplete(base) );
   }
 
@@ -115,7 +115,7 @@ fn void test_get_true_cursor_extent()
 
   usz i;
   CXCursor[] cursors = bgtest::parse(tmem, SUITE)!!;
-  CXTranslationUnit tu = clang::getTranslationUnit_Cursor(cursors[0]);
+  CXTranslationUnit tu = clang::cursor_getTranslationUnit(cursors[0]);
   foreach (c : cursors) {
     CXToken* tokens_ptr; uint tokens_len;
     clang::tokenize(tu, getTrueCursorExtent(c), &tokens_ptr, &tokens_len);

--- a/tests/unit/writers.c3
+++ b/tests/unit/writers.c3
@@ -174,7 +174,7 @@ fn void test_enum_decl()
 
   {
     defer @reset(out, state);
-    const EXPECTED = "\ntypedef En = inline int;\n";
+    const EXPECTED = "\nconstdef En : int {\n\n}\n";
 
     enumDecl(&out, &state, {}, "En", "int");
 
@@ -184,7 +184,7 @@ fn void test_enum_decl()
 
   {
     defer @reset(out, state);
-    const EXPECTED = "\ntypedef En @private = inline int;\n";
+    const EXPECTED = "\nconstdef En @private : int {\n\n}\n";
 
     WriteAttrs attrs = { .private = true };
     enumDecl(&out, &state, {}, "En", "int", "", attrs);
@@ -201,7 +201,7 @@ fn void test_func()
 
   {
     defer @reset(out, state);
-    const EXPECTED = "\nfn char* f()\n@extern(\"F\");\n";
+    const EXPECTED = "\nextern fn char* f()\n@cname(\"F\");\n";
 
     func(&out, &state, {}, "char*", "F", "f");
 
@@ -211,7 +211,7 @@ fn void test_func()
 
   {
     defer @reset(out, state);
-    const EXPECTED = "\nfn char** some_func(\n  int b,\n  double)\n@extern(\"SomeFunc\") @private;\n";
+    const EXPECTED = "\nextern fn char** some_func(\n  int b,\n  double)\n@cname(\"SomeFunc\") @private;\n";
 
     VarDecl[] params = { {"int", "b"}, {"double", ""} };
     WriteAttrs attrs = { .private = true };

--- a/tests/unit/writers.c3
+++ b/tests/unit/writers.c3
@@ -159,7 +159,7 @@ fn void test_var_decl()
 
     state.kind = ENUM;
     WriteAttrs attrs = { .private = true };
-    varDecl(&out, &state, "int", "name", "", attrs);
+    varDecl(&out, &state, "int", "name", "", "", attrs);
 
     assert( out.str_view() == EXPECTED );
   }

--- a/tests/unit/writers.c3
+++ b/tests/unit/writers.c3
@@ -176,7 +176,7 @@ fn void test_enum_decl()
     defer @reset(out, state);
     const EXPECTED = "\ntypedef En = inline int;\n";
 
-    enumDecl(&out, &state, "En", "int");
+    enumDecl(&out, &state, {}, "En", "int");
 
     assert( state.kind == ENUM );
     assert( out.str_view() == EXPECTED );
@@ -187,7 +187,7 @@ fn void test_enum_decl()
     const EXPECTED = "\ntypedef En @private = inline int;\n";
 
     WriteAttrs attrs = { .private = true };
-    enumDecl(&out, &state, "En", "int", attrs);
+    enumDecl(&out, &state, {}, "En", "int", "", attrs);
 
     assert( out.str_view() == EXPECTED );
   }
@@ -215,7 +215,7 @@ fn void test_func()
 
     VarDecl[] params = { {"int", "b"}, {"double", ""} };
     WriteAttrs attrs = { .private = true };
-    func(&out, &state, params, "char**", "SomeFunc", "some_func", attrs);
+    func(&out, &state, params, "char**", "SomeFunc", "some_func", "", attrs);
 
     io::printfn("<%s>", out);
     assert( out.str_view() == EXPECTED );


### PR DESCRIPTION
might be a bit many lines changed since a new clang.c3i [bc89386](https://github.com/vssukharev/bindgen.c3l/pull/8/commits/bc89386891464daa2e2e3aad465e5f6b200e1b85)  was needed

- usz -> sz
- Comments support
- enums outputted as constdef